### PR TITLE
Retire 'battle' and 'tournament' as technical terms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ These conventions apply when working issues from the GitHub tracker.
 1. Check the lowest-numbered open milestone first: `gh milestone list --repo blowing-inc/eights`
 2. Within that milestone, take the first open unassigned issue: `gh issue list --milestone '<title>' --state open --repo blowing-inc/eights`
 3. Assign it to yourself before starting: `gh issue edit <number> --add-assignee @me --repo blowing-inc/eights`
+4. **Create the branch before writing any code** — see Branch naming below.
 
 ### Branch naming
 
@@ -212,3 +213,4 @@ Before marking a PR ready:
 - [ ] If game logic changed: unit tests added or updated in the relevant `.test.js` file
 - [ ] If UI copy changed: verified against `docs/glossary.md`
 - [ ] If schema changed: migration SQL is present and backfill approach is documented
+- [ ] Switch back to `main` after the PR is open

--- a/docs/user-guide.txt
+++ b/docs/user-guide.txt
@@ -1,12 +1,12 @@
 EIGHTS — USER GUIDE
-The game of improbable battles
+The game of improbable combatants
 ================================================================================
 
 WHAT IS EIGHTS?
 
-Eights is a tournament tool for friends. You invent combatants — fictional
+Eights is a game tool for friends. You invent combatants — fictional
 characters, inside jokes, real people, abstract concepts — draft a roster, and
-battle them out round by round with your group voting on each result. The host
+run them through rounds with your group voting on each result. The host
 makes the final call. Everything that happens is saved permanently: the
 combatants, the winners, the reactions, the chat, the story.
 
@@ -86,12 +86,12 @@ don't see anyone else's combatants until the first round begins.
 
 --- Heritage Drafts (Series) ---
 
-If this game is part of a series — a continuation of a previous battle — your
+If this game is part of a series — a continuation of a previous game — your
 champions from the last game are required entries. You'll see your previous
 winners listed and must place each one in a slot before you can submit. They
 appear highlighted in your draft form.
 
-If a champion evolved since the last battle, their evolved form appears instead
+If a champion evolved since the last game, their evolved form appears instead
 of the original. That variant carries the same owner and the same obligation.
 
 --- Force Start ---
@@ -103,10 +103,10 @@ someone has gone quiet or the group is ready to move on.
 
 
 ================================================================================
-BATTLE ROUNDS
+ROUNDS
 ================================================================================
 
-The battle screen shows the full round list as it fills up. Rounds are started
+The rounds screen shows the full round list as it fills up. Rounds are started
 by the host — tap the round button to advance.
 
 Each round opens a voting screen for all players. One combatant per player is
@@ -127,12 +127,12 @@ The host can end the game before all rounds are played. The game is marked as
 ended early. Combatants from that game won't be published to the Bestiary
 (since the game was incomplete).
 
---- Tournament Complete ---
+--- Game Complete ---
 
 When all rounds are done, the host has three options:
   · View history — see the full record of the game
   · Continue series — start a new draft with the same players (see Series)
-  · Complete tournament — marks the game as finished and returns home
+  · Complete game — marks the game as finished and returns home
 
 
 ================================================================================
@@ -212,7 +212,7 @@ standings: wins, losses, and total games per player across the whole series.
 
 --- Continue Series ---
 
-If you hosted a completed tournament, you'll see a "Continue series" callout
+If you hosted a completed game, you'll see a "Continue series" callout
 in the room detail. Tapping it starts a new draft with the same players,
 carrying forward prevWinners and evolved forms.
 
@@ -251,7 +251,7 @@ COMBATANT DETAIL:
 
   Tap any combatant to see their full profile:
     · Current name and bio
-    · Stats grid: wins, losses, draws, total battles
+    · Stats grid: wins, losses, draws, total rounds
     · Head-to-head breakdown (expandable) — who they faced most and their
       record against each opponent
     · Evolution lineage — for variants, the full story of every form they
@@ -279,9 +279,9 @@ HOST CONTROLS (SUMMARY)
 ================================================================================
 
   Lobby:       Share room code/link, start game, cancel room
-  Draft:       See readiness, force-start, cancel tournament / end series
+  Draft:       See readiness, force-start, cancel game / end series
   Vote round:  Confirm winner, declare draw, trigger evolution, undo last round
-  Battle:      Start next round, end game early, complete tournament, next battle
+  Rounds:      Start next round, end game early, complete game, next game
 
 
 ================================================================================
@@ -296,7 +296,7 @@ TICKET 1 — Spectators can't react or chat
 TICKET 2 — "Undo last round" not shown to non-hosts
   Non-host players have no indication that a round can be undone or that it
   was undone. The round list just changes. A small notification on the
-  non-host battle screen when an undo happens could improve clarity.
+  non-host rounds screen when an undo happens could improve clarity.
 
 TICKET 3 — Evolution name uniqueness check is published-only
   The uniqueness check (checkCombatantNameExists) only compares against
@@ -322,9 +322,9 @@ TICKET 6 — Series standings don't account for draws
   the standings table has no D column. If draws matter competitively this is
   a gap; if series standings are purely narrative it may be fine.
 
-TICKET 7 — "Complete tournament" vs. auto-end phase
+TICKET 7 — "Complete game" vs. auto-end phase
   When all rounds are played, the room phase stays as 'battle' until the host
-  explicitly taps "Complete tournament." Until then, the room can appear in
+  explicitly taps "Complete game." Until then, the room can appear in
   open lobbies. The guide describes this flow correctly, but a first-time host
   may not realize they need to tap Complete. A more prominent prompt or
   auto-completion on all-rounds-done could help.
@@ -355,16 +355,16 @@ Priority key: [P1] = fix or ship soon  [P2] = important, next wave  [P3] = nice-
   in any round," with an additional line when biosRequired is on: "Bios are
   required — unsubmitted players are excluded entirely."
 
-[DONE] TICKET 7 — "Complete tournament" prompt not obvious enough
-  "Complete tournament" is now the primary button in the tournament-complete
-  card. "View history" and "Next Battle" sit below it as secondary actions.
+[DONE] TICKET 7 — "Complete game" prompt not obvious enough
+  "Complete game" is now the primary button in the game-complete card.
+  "View history" and "Next Game" sit below it as secondary actions.
   A brief note — "This room stays open until you complete or start the next
-  battle" — makes the consequence visible.
+  game" — makes the consequence visible.
 
 [DONE] TICKET 8 — No warning when host navigates away mid-round
   Host now sees a confirmation dialog ("Players are waiting — leave anyway?")
   when tapping "← Home" on VoteScreen. Non-hosts see a persistent "Host is out
-  of the room" banner (BattleScreen and VoteScreen) driven by Supabase Realtime
+  of the room" banner (rounds screen and VoteScreen) driven by Supabase Realtime
   presence — the banner appears when the host's presence channel goes silent
   and clears automatically when the host returns.
 

--- a/docs/user-guide.txt
+++ b/docs/user-guide.txt
@@ -1,12 +1,12 @@
 EIGHTS — USER GUIDE
-The game of improbable combatants
+The game of improbable battles
 ================================================================================
 
 WHAT IS EIGHTS?
 
 Eights is a game tool for friends. You invent combatants — fictional
 characters, inside jokes, real people, abstract concepts — draft a roster, and
-run them through rounds with your group voting on each result. The host
+battle them out round by round with your group voting on each result. The host
 makes the final call. Everything that happens is saved permanently: the
 combatants, the winners, the reactions, the chat, the story.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { getRoomsByIds, getActiveRoomsForPlayer, sget, sset } from './supabase.js'
-import { uid, makeBots, makeBotCombatants, playerColor, prepareNextBattle, replacePlayerIdInRoom } from './gameLogic.js'
+import { uid, makeBots, makeBotCombatants, playerColor, prepareNextGame, replacePlayerIdInRoom } from './gameLogic.js'
 
 // Screens
 import HomeScreen from './screens/HomeScreen.jsx'
@@ -213,9 +213,9 @@ export default function App() {
     onLogin={goAuth}
   />
 
-  async function handleHostNextBattle(completedRoom) {
+  async function handleHostNextGame(completedRoom) {
     const roomCode = Math.random().toString(36).slice(2, 6).toUpperCase()
-    const { newRoom, updatedCompletedRoom } = prepareNextBattle(completedRoom, { newRoomCode: roomCode, hostId: playerId })
+    const { newRoom, updatedCompletedRoom } = prepareNextGame(completedRoom, { newRoomCode: roomCode, hostId: playerId })
     await sset('room:' + roomCode, newRoom)
     await sset('room:' + completedRoom.id, updatedCompletedRoom)
     removeLobbyCode(completedRoom.id)
@@ -245,7 +245,7 @@ export default function App() {
 
   let content = null
   if (viewLobbies)
-    content = <MyLobbiesScreen lobbies={openLobbies} playerId={playerId} onBack={() => { setViewLobbies(false); refreshLobbies() }} onEnter={r => { setRoom(r); setViewLobbies(false); nav(r.phase === 'lobby' ? 'lobby' : r.phase === 'draft' ? 'draft' : r.phase === 'vote' ? 'vote' : 'battle') }} />
+    content = <MyLobbiesScreen lobbies={openLobbies} playerId={playerId} onBack={() => { setViewLobbies(false); refreshLobbies() }} onEnter={r => { setRoom(r); setViewLobbies(false); nav(r.phase === 'lobby' ? 'lobby' : r.phase === 'draft' ? 'draft' : r.phase === 'vote' ? 'vote' : 'round') }} />
   else if (viewPlayers && viewPlayerProfile)
     content = <PlayerProfile profileId={viewPlayerProfile} playerId={playerId} onBack={() => setViewPlayerProfile(null)} onViewCombatant={c => setViewGlobalCombatant(c)} onViewRoom={openRoomSummary} />
   else if (viewPlayers)
@@ -255,7 +255,7 @@ export default function App() {
   else if (viewBestiary)
     content = <BestiaryScreen playerId={playerId} onBack={() => setViewBestiary(false)} onViewCombatant={c => setViewGlobalCombatant(c)} />
   else if (viewHistory)
-    content = <HistoryScreen onBack={() => setViewHistory(false)} setViewCombatant={c => { setViewCombatant(c); setViewHistory(false) }} playerId={playerId} onNextBattle={r => { setViewHistory(false); handleHostNextBattle(r) }} />
+    content = <HistoryScreen onBack={() => setViewHistory(false)} setViewCombatant={c => { setViewCombatant(c); setViewHistory(false) }} playerId={playerId} onNextGame={r => { setViewHistory(false); handleHostNextGame(r) }} />
   else if (viewCombatant)
     content = <CombatantScreen room={room} combatant={viewCombatant} playerId={playerId} onBack={() => setViewCombatant(null)} onViewCombatant={setViewCombatant} />
   else if (screen === 'auth')
@@ -267,17 +267,17 @@ export default function App() {
   else if (screen === 'create')
     content = <CreateRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} onLogin={() => goAuth('create')} onCreated={r => { addLobbyCode(r.id); setRoom(r); nav('lobby') }} onBack={() => nav('home')} />
   else if (screen === 'join')
-    content = <JoinRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} initialCode={_urlJoinCode || _urlSpectateCode || _urlCode} spectateMode={!!_urlSpectateCode} onJoined={r => { addLobbyCode(r.id); setRoom(r); nav(r.phase === 'draft' ? 'draft' : r.phase === 'battle' ? 'battle' : r.phase === 'vote' ? 'vote' : 'lobby') }} onSpectated={r => { setRoom(r); nav('spectate') }} onBack={() => nav('home')} onLogin={() => goAuth('join')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} />
+    content = <JoinRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} initialCode={_urlJoinCode || _urlSpectateCode || _urlCode} spectateMode={!!_urlSpectateCode} onJoined={r => { addLobbyCode(r.id); setRoom(r); nav(r.phase === 'draft' ? 'draft' : r.phase === 'battle' ? 'round' : r.phase === 'vote' ? 'vote' : 'lobby') }} onSpectated={r => { setRoom(r); nav('spectate') }} onBack={() => nav('home')} onLogin={() => goAuth('join')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} />
   else if (screen === 'spectate')
     content = <SpectateScreen room={room} playerId={playerId} setRoom={setRoom} onHome={goHome} />
   else if (screen === 'lobby')
     content = <LobbyScreen room={room} playerId={playerId} setRoom={setRoom} isGuest={isGuest} onLogin={() => goAuth('lobby')} onStart={() => nav('draft')} onBack={() => { removeLobbyCode(room?.id); goHome() }} onViewPlayer={setViewPlayerProfile} />
   else if (screen === 'draft')
-    content = <DraftScreen room={room} playerId={playerId} setRoom={setRoom} onDone={() => { removeLobbyCode(room?.id); nav('battle') }} isGuest={isGuest} onLogin={() => goAuth('draft')} onBack={goHome} onEndSeries={handleEndSeries} />
-  else if (screen === 'battle')
-    content = <BattleScreen room={room} playerId={playerId} setRoom={setRoom} onVote={() => nav('vote')} onHistory={() => setViewHistory(true)} onHome={goHome} onNextBattle={handleHostNextBattle} onRejoinNextBattle={r => { addLobbyCode(r.id); setRoom(r); nav('draft') }} />
+    content = <DraftScreen room={room} playerId={playerId} setRoom={setRoom} onDone={() => { removeLobbyCode(room?.id); nav('round') }} isGuest={isGuest} onLogin={() => goAuth('draft')} onBack={goHome} onEndSeries={handleEndSeries} />
+  else if (screen === 'round')
+    content = <BattleScreen room={room} playerId={playerId} setRoom={setRoom} onVote={() => nav('vote')} onHistory={() => setViewHistory(true)} onHome={goHome} onNextGame={handleHostNextGame} onRejoinNextGame={r => { addLobbyCode(r.id); setRoom(r); nav('draft') }} />
   else if (screen === 'vote')
-    content = <VoteScreen room={room} playerId={playerId} setRoom={setRoom} onResult={() => nav('battle')} onViewPlayer={setViewPlayerProfile} onHome={goHome} isGuest={isGuest} onLogin={() => goAuth('vote')} />
+    content = <VoteScreen room={room} playerId={playerId} setRoom={setRoom} onResult={() => nav('round')} onViewPlayer={setViewPlayerProfile} onHome={goHome} isGuest={isGuest} onLogin={() => goAuth('vote')} />
 
   return <>{userPill}{content}{viewHelp && <HelpModal onClose={() => setViewHelp(false)} />}{viewRoomSummary && <GameSummaryScreen room={viewRoomSummary} onClose={() => setViewRoomSummary(null)} />}</>
 }

--- a/src/components/CombatantSheet.jsx
+++ b/src/components/CombatantSheet.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { btn, inp, lbl } from '../styles.js'
-import { getCombatant, updateGlobalCombatant, getLineageTree, getCombatantBattleHistory } from '../supabase.js'
+import { getCombatant, updateGlobalCombatant, getLineageTree, getCombatantRoundHistory } from '../supabase.js'
 import { buildStoryFromLineageTree } from '../gameLogic.js'
 
 /**
@@ -91,14 +91,14 @@ export default function CombatantSheet({ combatantId, combatant: inRoom, playerI
 // ── In-room fallback view (unpublished combatant) ─────────────────────────────
 
 function InRoomView({ combatant: c }) {
-  const totalBattles = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
+  const totalRounds = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
   return (
     <div style={{ padding: '16px' }}>
       <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px', fontStyle: 'italic' }}>
         This combatant hasn't been published yet — full Bestiary stats are available after the game ends.
       </p>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: '1rem' }}>
-        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Battles', totalBattles, 'var(--color-text-tertiary)']].map(([label, val, color]) => (
+        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Rounds', totalRounds, 'var(--color-text-tertiary)']].map(([label, val, color]) => (
           <div key={label} style={{ padding: 12, background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', textAlign: 'center' }}>
             <div style={{ fontSize: 20, fontWeight: 500, color }}>{val}</div>
             <div style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>{label}</div>
@@ -196,7 +196,7 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
   }, [init.id])
 
   const canEdit    = c.owner_id === playerId
-  const totalBattles = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
+  const totalRounds = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
   const history    = c.bio_history || []
   const isVariant  = !!c.lineage
   const rootId     = c.lineage?.rootId || c.id
@@ -217,7 +217,7 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
   }, [rootId, c.id])
 
   function toggleH2h() {
-    if (!h2hOpen && h2hRows === null) getCombatantBattleHistory(c.id).then(setH2hRows)
+    if (!h2hOpen && h2hRows === null) getCombatantRoundHistory(c.id).then(setH2hRows)
     setH2hOpen(o => !o)
   }
 
@@ -254,7 +254,7 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
 
       {/* Stats */}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: '1rem' }}>
-        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Battles', totalBattles, 'var(--color-text-tertiary)']].map(([label, val, color]) => (
+        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Rounds', totalRounds, 'var(--color-text-tertiary)']].map(([label, val, color]) => (
           <div key={label} style={{ padding: 10, background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', textAlign: 'center' }}>
             <div style={{ fontSize: 18, fontWeight: 500, color }}>{val}</div>
             <div style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>{label}</div>
@@ -296,7 +296,7 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
       </div>
 
       {/* Head-to-head */}
-      {totalBattles > 0 && (
+      {totalRounds > 0 && (
         <div style={{ marginBottom: '1rem' }}>
           <button onClick={toggleH2h} style={{ ...btn('ghost'), width: '100%', textAlign: 'left', fontSize: 13, marginBottom: h2hOpen ? 8 : 0, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <span>Head-to-head</span><span>{h2hOpen ? '↑' : '↓'}</span>

--- a/src/components/FighterAutocomplete.jsx
+++ b/src/components/FighterAutocomplete.jsx
@@ -53,7 +53,7 @@ export default function FighterAutocomplete({ value, onChange, onSelect, placeho
       />
       {open && items.length > 0 && (
         <div style={{ position: 'absolute', top: 'calc(100% + 2px)', left: 0, right: 0, background: 'var(--color-background-primary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', zIndex: 200, overflow: 'hidden', boxShadow: '0 6px 18px rgba(0,0,0,0.18)' }}>
-          {showPinnedHeader && <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-success)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>🏆 Champions from last battle</div>}
+          {showPinnedHeader && <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-success)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>🏆 Champions from last game</div>}
           {items.map((f, idx) => {
             const isPinned = filteredPinned.some(p => p.id === f.id)
             const isFirstRecent = !value.trim() && showRecentHeader && idx === filteredPinned.length

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -24,7 +24,7 @@ Share the room code or spectator link with your group.`
     title: 'The draft',
     content: `Each player names their combatants in secret. You can optionally write a bio for each one.
 
-If you've played a previous battle in a series, your champions from the last game are required — you must place them in a slot before you can lock in your roster.
+If you've played a previous game in a series, your champions from the last game are required — you must place them in a slot before you can lock in your roster.
 
 The host can force-start once most players are ready.`
   },
@@ -46,7 +46,7 @@ The original combatant's stats and bio are preserved. The evolved variant is a n
     title: 'Battle history & series',
     content: `Every game is saved in Battle History. Tap a room to see round-by-round results, combatant rosters, reactions, and chat.
 
-If you hosted a completed tournament, you'll see a "Continue series" option — this starts a new draft with the same players, carrying forward champions and evolved forms.
+If you hosted a completed game, you'll see a "Continue series" option — this starts a new draft with the same players, carrying forward champions and evolved forms.
 
 A series groups all connected games together and shows standings across every game played.`
   },

--- a/src/export.js
+++ b/src/export.js
@@ -68,7 +68,7 @@ export function formatCombatantHistory(combatant, lineageTree = [], ownChainTree
 
   const total = (combatant.wins || 0) + (combatant.losses || 0)
   lines.push('=== RECORD ===')
-  lines.push(`  ${combatant.wins || 0}W  ${combatant.losses || 0}L  ·  ${total} battle${total !== 1 ? 's' : ''}`)
+  lines.push(`  ${combatant.wins || 0}W  ${combatant.losses || 0}L  ·  ${total} round${total !== 1 ? 's' : ''}`)
 
   const heart = combatant.reactions_heart || 0
   const angry = combatant.reactions_angry || 0
@@ -80,7 +80,7 @@ export function formatCombatantHistory(combatant, lineageTree = [], ownChainTree
   return lines.join('\n')
 }
 
-// ─── Single-tournament export ─────────────────────────────────────────────────
+// ─── Single-game export ───────────────────────────────────────────────────────
 
 export function formatRoomAsText(room) {
   const players         = (room.players || []).filter(p => !p.isBot)

--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -55,11 +55,11 @@ export const DEV_ROSTER_BIOS = [
 ]
 
 /**
- * Simulates all remaining rounds of a battle to completion.
+ * Simulates all remaining rounds of a game to completion.
  * Picks a random winner for each unplayed round.
  * Returns the fully updated room object (does not write to DB).
  */
-export function simulateBattleToEnd(room) {
+export function simulateGameToEnd(room) {
   const totalRounds = Math.min(...room.players.map(p => (room.combatants[p.id] || []).length))
   let updated = JSON.parse(JSON.stringify(room))
 
@@ -214,14 +214,14 @@ export function getReadyPlayerCount(players, combatants, rosterSize = 8) {
 }
 
 /**
- * Whether the host can force-start the battle phase with only some players ready.
+ * Whether the host can force-start the round phase with only some players ready.
  * Requires: is host, at least 2 ready, and at least 1 still not ready.
  */
 export function canForceStart(isHost, readyCount, totalRealPlayers) {
   return isHost && readyCount >= 2 && readyCount < totalRealPlayers
 }
 
-// ─── Battle logic ─────────────────────────────────────────────────────────────
+// ─── Round logic ──────────────────────────────────────────────────────────────
 
 /**
  * Whether the host can undo the last round.
@@ -242,7 +242,7 @@ export function canEditCombatant(ownerId, playerId, hostId) {
 
 /**
  * Scans a completed room's rounds and builds a per-owner map of winning combatants.
- * Used to populate prevWinners on the next battle room so the draft can enforce
+ * Used to populate prevWinners on the next game room so the draft can enforce
  * that champions are re-entered.
  * Returns { [ownerId]: [{ id, name, bio }, ...] }
  */
@@ -282,7 +282,7 @@ export function matchupForRound(room, roundNum) {
 
 /**
  * Given the full room object and a winning combatant id, returns updated
- * combatants map with wins/losses incremented and battle records appended.
+ * combatants map with wins/losses incremented and round records appended.
  * Does NOT mutate the input — returns a new deep-copied map.
  */
 export function applyWinner(room, round, winnerId) {
@@ -319,7 +319,7 @@ export function applyWinner(room, round, winnerId) {
 }
 
 /**
- * Both combatants drew — increments draws for each and appends battle records.
+ * Both combatants drew — increments draws for each and appends round records.
  * Does NOT mutate the input — returns a new deep-copied map.
  */
 export function applyDraw(room, round) {
@@ -348,7 +348,7 @@ export function applyDraw(room, round) {
 /**
  * Reverses the stat changes from the last completed round (win or draw).
  * Returns a new combatants map with stats decremented and the round's
- * battle record entries removed.  Clamps to 0 (never goes negative).
+ * round record entries removed.  Clamps to 0 (never goes negative).
  */
 export function undoRound(room, round) {
   const combatants = JSON.parse(JSON.stringify(room.combatants))
@@ -573,7 +573,7 @@ export function buildTickerMessages(rooms) {
     "New challenger approaching. Old challenger still sulking in the corner.",
     "The arena does not accept appeals, complaints, or requests for recounts.",
     "Fun fact: 100% of combatants who have never lost are currently undefeated.",
-    "Management is not responsible for emotional damage caused by tournament results.",
+    "Management is not responsible for emotional damage caused by game results.",
     "Somewhere, a combatant is preparing. It probably won't help.",
     "Submit your 8. Destiny will handle the rest.",
     "This ticker is legally distinct from sports journalism.",
@@ -774,11 +774,11 @@ export function buildChainEvolutionStory(rooms, rootId) {
   return story
 }
 
-// ─── Next battle preparation ──────────────────────────────────────────────────
+// ─── Next game preparation ────────────────────────────────────────────────────
 
 /**
  * Pure function: derives the new room and the updated completed room for a
- * "Host Next Battle" transition. Contains all series/heritage logic so App.jsx
+ * "Host Next Game" transition. Contains all series/heritage logic so App.jsx
  * only handles the two DB writes and navigation.
  *
  * @param {object} completedRoom  The room that just finished
@@ -788,7 +788,7 @@ export function buildChainEvolutionStory(rooms, rootId) {
  * @param {number} [opts.now]        Timestamp for createdAt (defaults to Date.now())
  * @returns {{ newRoom: object, updatedCompletedRoom: object }}
  */
-export function prepareNextBattle(completedRoom, { newRoomCode, hostId, now = Date.now() }) {
+export function prepareNextGame(completedRoom, { newRoomCode, hostId, now = Date.now() }) {
   let prevWinners = extractPreviousWinners(completedRoom.rounds)
 
   // Translate any evolved winners to their current active form using the

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -15,14 +15,14 @@ import {
   canUndoLastRound, canEditCombatant,
   extractPreviousWinners,
   normalizeRoomSettings,
-  simulateBattleToEnd,
+  simulateGameToEnd,
   getLineageStats,
   buildActiveFormMap,
   buildChainEvolutionStory,
   buildStoryFromLineageTree,
   applyActiveFormMap,
   groupRoomsForHistory,
-  prepareNextBattle,
+  prepareNextGame,
   computeSeriesStandings,
   applyDraw,
   replacePlayerIdInRoom,
@@ -158,7 +158,7 @@ describe('applyWinner', () => {
     expect(result.p2[0].losses).toBe(1)
   })
 
-  it('appends a battle record to both combatants', () => {
+  it('appends a round record to both combatants', () => {
     const room = makeRoom()
     const c1 = room.combatants.p1[0]
     const c2 = room.combatants.p2[0]
@@ -242,7 +242,7 @@ describe('undoRound', () => {
     expect(result.p2[0].losses).toBe(0)
   })
 
-  it('removes only the matching battle record', () => {
+  it('removes only the matching round record', () => {
     const room = makeRoom()
     room.combatants.p1[0].battles = [
       { roundId: 'rd1', opponent: 'Bob-0', result: 'win'  },
@@ -881,9 +881,9 @@ describe('groupRoomsForHistory', () => {
   })
 })
 
-// ─── prepareNextBattle ────────────────────────────────────────────────────────
+// ─── prepareNextGame ──────────────────────────────────────────────────────────
 
-describe('prepareNextBattle', () => {
+describe('prepareNextGame', () => {
   const baseRoom = {
     id: 'ROOM1', code: 'ROOM1', host: 'p1', phase: 'battle',
     players: [{ id: 'p1', name: 'Alice', isBot: false }],
@@ -891,37 +891,37 @@ describe('prepareNextBattle', () => {
   }
 
   it('sets seriesId from completedRoom.id when no prior series', () => {
-    const { newRoom, updatedCompletedRoom } = prepareNextBattle(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+    const { newRoom, updatedCompletedRoom } = prepareNextGame(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     expect(newRoom.seriesId).toBe('ROOM1')
     expect(updatedCompletedRoom.seriesId).toBe('ROOM1')
   })
 
   it('inherits existing seriesId', () => {
     const room = { ...baseRoom, seriesId: 'ORIG', seriesIndex: 2 }
-    const { newRoom, updatedCompletedRoom } = prepareNextBattle(room, { newRoomCode: 'ROOM3', hostId: 'p1', now: 3000 })
+    const { newRoom, updatedCompletedRoom } = prepareNextGame(room, { newRoomCode: 'ROOM3', hostId: 'p1', now: 3000 })
     expect(newRoom.seriesId).toBe('ORIG')
     expect(updatedCompletedRoom.seriesId).toBe('ORIG')
   })
 
   it('increments seriesIndex', () => {
     const room = { ...baseRoom, seriesId: 'S1', seriesIndex: 1 }
-    const { newRoom } = prepareNextBattle(room, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+    const { newRoom } = prepareNextGame(room, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     expect(newRoom.seriesIndex).toBe(2)
   })
 
-  it('stamps seriesIndex: 1 on the completed room when first next-battle', () => {
-    const { updatedCompletedRoom } = prepareNextBattle(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+  it('stamps seriesIndex: 1 on the completed room when first next-game', () => {
+    const { updatedCompletedRoom } = prepareNextGame(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     expect(updatedCompletedRoom.seriesIndex).toBe(1)
   })
 
   it('sets prevRoomId and nextRoomId correctly', () => {
-    const { newRoom, updatedCompletedRoom } = prepareNextBattle(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+    const { newRoom, updatedCompletedRoom } = prepareNextGame(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     expect(newRoom.prevRoomId).toBe('ROOM1')
     expect(updatedCompletedRoom.nextRoomId).toBe('ROOM2')
   })
 
   it('starts new room with empty combatants and rounds', () => {
-    const { newRoom } = prepareNextBattle(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+    const { newRoom } = prepareNextGame(baseRoom, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     expect(newRoom.combatants).toEqual({})
     expect(newRoom.rounds).toEqual([])
     expect(newRoom.phase).toBe('draft')
@@ -936,7 +936,7 @@ describe('prepareNextBattle', () => {
         { id: 'bot1', name: 'Robo', isBot: true },
       ],
     }
-    const { newRoom } = prepareNextBattle(room, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+    const { newRoom } = prepareNextGame(room, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     expect(newRoom.combatants['bot1']).toBeDefined()
     expect(newRoom.combatants['bot1'].length).toBeGreaterThan(0)
   })
@@ -952,7 +952,7 @@ describe('prepareNextBattle', () => {
         evolution: { fromId: 'c1', fromName: 'MJ', toId: 'c2', toName: 'MJ Evolved', toBio: 'new form', ownerId: 'p1', ownerName: 'Alice' },
       }],
     }
-    const { newRoom } = prepareNextBattle(room, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
+    const { newRoom } = prepareNextGame(room, { newRoomCode: 'ROOM2', hostId: 'p1', now: 2000 })
     const winners = newRoom.prevWinners?.p1 || []
     expect(winners.some(w => w.id === 'c2' && w.name === 'MJ Evolved')).toBe(true)
   })
@@ -1164,12 +1164,12 @@ describe('applyWinner trap detection', () => {
   })
 })
 
-// ─── simulateBattleToEnd ──────────────────────────────────────────────────────
+// ─── simulateGameToEnd ────────────────────────────────────────────────────────
 
-describe('simulateBattleToEnd', () => {
+describe('simulateGameToEnd', () => {
   it('simulates all 8 rounds from a fresh game (currentRound 0)', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
-    const result = simulateBattleToEnd(room)
+    const result = simulateGameToEnd(room)
     expect(result.rounds).toHaveLength(8)
     expect(result.currentRound).toBe(8)
     expect(result.phase).toBe('battle')
@@ -1177,7 +1177,7 @@ describe('simulateBattleToEnd', () => {
 
   it('every simulated round has a winner', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
-    const result = simulateBattleToEnd(room)
+    const result = simulateGameToEnd(room)
     result.rounds.forEach(r => {
       expect(r.winner).not.toBeNull()
       expect(r.winner).toBeDefined()
@@ -1187,10 +1187,10 @@ describe('simulateBattleToEnd', () => {
   it('continues from mid-game (currentRound 3, 3 completed rounds)', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
     // Build 3 completed rounds manually
-    let partial = simulateBattleToEnd({ ...room, currentRound: 0, rounds: [] })
+    let partial = simulateGameToEnd({ ...room, currentRound: 0, rounds: [] })
     // Trim to 3 rounds to simulate mid-game state
     partial = { ...partial, rounds: partial.rounds.slice(0, 3), currentRound: 3 }
-    const result = simulateBattleToEnd(partial)
+    const result = simulateGameToEnd(partial)
     expect(result.rounds).toHaveLength(8)
     expect(result.currentRound).toBe(8)
   })
@@ -1202,7 +1202,7 @@ describe('simulateBattleToEnd', () => {
     // Simulate round 1 open — round exists, no winner
     const openRound = { id: 'rd_open', number: 1, combatants: [c1, c2], picks: {}, winner: null, createdAt: Date.now() }
     const midRoom = { ...room, currentRound: 1, rounds: [openRound] }
-    const result = simulateBattleToEnd(midRoom)
+    const result = simulateGameToEnd(midRoom)
     // Round 1 should be resolved in-place (same id), not duplicated
     expect(result.rounds[0].id).toBe('rd_open')
     expect(result.rounds[0].winner).not.toBeNull()
@@ -1211,7 +1211,7 @@ describe('simulateBattleToEnd', () => {
 
   it('accumulates win/loss stats on combatants', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
-    const result = simulateBattleToEnd(room)
+    const result = simulateGameToEnd(room)
     // Each player's combatants should have 1 win+loss total across all 8 slots
     const p1Stats = result.combatants.p1.map(c => c.wins + c.losses)
     const p2Stats = result.combatants.p2.map(c => c.wins + c.losses)
@@ -1219,9 +1219,9 @@ describe('simulateBattleToEnd', () => {
     p2Stats.forEach(total => expect(total).toBe(1))
   })
 
-  it('each combatant gets exactly one battle record', () => {
+  it('each combatant gets exactly one round record', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
-    const result = simulateBattleToEnd(room)
+    const result = simulateGameToEnd(room)
     result.combatants.p1.forEach(c => expect(c.battles).toHaveLength(1))
     result.combatants.p2.forEach(c => expect(c.battles).toHaveLength(1))
   })
@@ -1230,14 +1230,14 @@ describe('simulateBattleToEnd', () => {
     const room = makeRoom()
     // Give p2 only 3 combatants — totalRounds will be 3
     room.combatants.p2 = room.combatants.p2.slice(0, 3)
-    const result = simulateBattleToEnd({ ...room, currentRound: 0, rounds: [] })
+    const result = simulateGameToEnd({ ...room, currentRound: 0, rounds: [] })
     expect(result.rounds).toHaveLength(3)
   })
 
-  it('sets phase to battle even when totalRounds is 0', () => {
+  it("sets phase to 'battle' even when totalRounds is 0", () => {
     const room = makeRoom()
     room.combatants.p1 = []
-    const result = simulateBattleToEnd({ ...room, currentRound: 0, rounds: [] })
+    const result = simulateGameToEnd({ ...room, currentRound: 0, rounds: [] })
     expect(result.rounds).toHaveLength(0)
     expect(result.phase).toBe('battle')
   })
@@ -1245,13 +1245,13 @@ describe('simulateBattleToEnd', () => {
   it('does not mutate the original room', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
     const original = JSON.parse(JSON.stringify(room))
-    simulateBattleToEnd(room)
+    simulateGameToEnd(room)
     expect(room).toEqual(original)
   })
 
   it('winner is always one of the round combatants', () => {
     const room = makeRoom({ currentRound: 0, rounds: [] })
-    const result = simulateBattleToEnd(room)
+    const result = simulateGameToEnd(room)
     result.rounds.forEach(r => {
       const ids = r.combatants.map(c => c.id)
       expect(ids).toContain(r.winner.id)
@@ -1683,7 +1683,7 @@ describe('applyDraw', () => {
     expect(result.p2[0].losses).toBe(1)
   })
 
-  it('appends draw battle records for both', () => {
+  it('appends draw round records for both', () => {
     const result = applyDraw(room, round)
     expect(result.p1[0].battles).toHaveLength(1)
     expect(result.p1[0].battles[0]).toMatchObject({ roundId: 'r1', result: 'draw', opponent: 'B' })
@@ -1712,7 +1712,7 @@ describe('undoRound (draw)', () => {
     expect(result.p2[0].draws).toBe(0)
   })
 
-  it('removes battle records for that round', () => {
+  it('removes round records for that round', () => {
     const result = undoRound(room, round)
     expect(result.p1[0].battles).toHaveLength(0)
     expect(result.p2[0].battles).toHaveLength(0)

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -6,7 +6,7 @@ import { btn } from '../styles.js'
 import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence } from '../supabase.js'
 import { uid, canUndoLastRound, undoRound, tallyReactions } from '../gameLogic.js'
 
-export default function BattleScreen({ room: init, playerId, setRoom, onVote, onHistory, onHome, onNextBattle, onRejoinNextBattle }) {
+export default function BattleScreen({ room: init, playerId, setRoom, onVote, onHistory, onHome, onNextGame, onRejoinNextGame }) {
   const [room, setLocal] = useState(init)
   const [confirmUndo, setConfirmUndo] = useState(false)
   const [confirmEnd, setConfirmEnd] = useState(false)
@@ -21,7 +21,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
     return subscribeToRoom(room.id, async r => {
       if (r.nextRoomId) {
         const nextRoom = await sget('room:' + r.nextRoomId)
-        if (nextRoom) { setRoom(nextRoom); onRejoinNextBattle(nextRoom); return }
+        if (nextRoom) { setRoom(nextRoom); onRejoinNextGame(nextRoom); return }
       }
       // Detect undo for non-hosts: currentRound decreased
       if (r.host !== playerId && r.currentRound < prevRoundRef.current) {
@@ -66,7 +66,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
     onHome()
   }
 
-  async function completeTournament() {
+  async function completeGame() {
     const r = await sget('room:' + room.id)
     if (!r) return
     const updated = { ...r, phase: 'ended' }
@@ -207,24 +207,24 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
         {room.currentRound >= totalRounds && (round?.winner || round?.draw) && (
           <div style={{ textAlign: 'center', padding: '2rem', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
             <div style={{ fontSize: 32, marginBottom: 8 }}>🏆</div>
-            <h3 style={{ fontSize: 18, fontWeight: 500, margin: '0 0 8px', color: 'var(--color-text-primary)' }}>Tournament complete!</h3>
+            <h3 style={{ fontSize: 18, fontWeight: 500, margin: '0 0 8px', color: 'var(--color-text-primary)' }}>Game complete!</h3>
             <p style={{ color: 'var(--color-text-secondary)', fontSize: 14, margin: 0 }}>All {totalRounds} rounds fought.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 16 }}>
               {isHost && (
                 <>
-                  <button style={btn('primary')} onClick={completeTournament}>Complete tournament ✓</button>
+                  <button style={btn('primary')} onClick={completeGame}>Complete game ✓</button>
                   <div style={{ display: 'flex', gap: 8 }}>
                     <button style={btn()} onClick={onHistory}>View history</button>
-                    <button style={btn()} onClick={() => onNextBattle(room)}>Next Battle ⚔️</button>
+                    <button style={btn()} onClick={() => onNextGame(room)}>Next Game ⚔️</button>
                   </div>
                   <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: 0 }}>
-                    This room stays open until you complete or start the next battle.
+                    This room stays open until you complete or start the next game.
                   </p>
                 </>
               )}
               {!isHost && (
                 <>
-                  <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Waiting for host to start next battle…</p>
+                  <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Waiting for host to start next game…</p>
                   <div style={{ display: 'flex', gap: 8 }}>
                     <button style={btn()} onClick={onHistory}>View history</button>
                     <button style={btn()} onClick={onHome}>Back to home</button>

--- a/src/screens/CombatantScreen.jsx
+++ b/src/screens/CombatantScreen.jsx
@@ -29,7 +29,7 @@ export default function CombatantScreen({ room, combatant, playerId, onBack, onV
         </div>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: '1.5rem' }}>
-        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Battles', (c.wins || 0) + (c.losses || 0) + (c.draws || 0), 'var(--color-text-tertiary)']].map(([label, val, color]) => (
+        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Rounds', (c.wins || 0) + (c.losses || 0) + (c.draws || 0), 'var(--color-text-tertiary)']].map(([label, val, color]) => (
           <div key={label} style={{ padding: '12px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', textAlign: 'center' }}>
             <div style={{ fontSize: 20, fontWeight: 500, color }}>{val}</div>
             <div style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>{label}</div>
@@ -83,7 +83,7 @@ export default function CombatantScreen({ room, combatant, playerId, onBack, onV
 
       {(c.battles || []).length > 0 && (
         <div>
-          <h3 style={{ fontSize: 14, fontWeight: 400, color: 'var(--color-text-secondary)', margin: '0 0 10px' }}>Battle record</h3>
+          <h3 style={{ fontSize: 14, fontWeight: 400, color: 'var(--color-text-secondary)', margin: '0 0 10px' }}>Round record</h3>
           {c.battles.map((b, i) => (
             <div key={i} style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 12px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', marginBottom: 6, border: '0.5px solid var(--color-border-tertiary)' }}>
               <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>vs {b.opponent}</span>

--- a/src/screens/DraftScreen.jsx
+++ b/src/screens/DraftScreen.jsx
@@ -32,9 +32,9 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
   const [confirmCancel, setConfirmCancel] = useState(false)
   const isHost = room.host === playerId
   const isSeries = !!room.prevRoomId
-  const cancelLabel = isSeries ? 'End series' : 'Cancel tournament'
+  const cancelLabel = isSeries ? 'End series' : 'Cancel game'
   const cancelBody  = isSeries
-    ? 'This draft will be discarded. The completed games will remain in battle history and can be continued later.'
+    ? 'This draft will be discarded. The completed games will remain in history and can be continued later.'
     : 'This draft will be discarded. Any combatants already submitted won\'t be published.'
 
   const saveTimer = useRef(null)
@@ -75,7 +75,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
   // Heritage game: load the ancestry chain and build active-form substitutions
   // so the autocomplete shows evolved forms instead of their superseded originals.
   // Variant data is fetched from the DB — variants are not in room.combatants
-  // (draft is immutable; variant only enters play in the next battle).
+  // (draft is immutable; variant only enters play in the next game).
   useEffect(() => {
     if (!init.prevRoomId) return
     getHeritageChain(init.prevRoomId).then(async chain => {
@@ -226,7 +226,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
 
       {myPrevWinners.length > 0 && (
         <div style={{ marginBottom: '1.5rem', padding: '12px 14px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', border: '0.5px solid var(--color-border-tertiary)' }}>
-          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>Champions from last battle</div>
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>Champions from last game</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             {myPrevWinners.map(w => {
               const placed = !unplacedWinners.find(u => u.id === w.id)
@@ -287,7 +287,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
               onChange={e => { const b = [...bios]; b[i] = e.target.value; setBios(b) }}
             />
 
-            {/* Trap controls — only for brand-new combatants in a Next Battle */}
+            {/* Trap controls — only for brand-new combatants in a Next Game */}
             {isNewCombatant && otherPrevWinners.length > 0 && (
               <div style={{ marginTop: 8 }}>
                 {trap ? (

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
 import { btn, inp, lbl } from '../styles.js'
-import { updateGlobalCombatant, getLineageTree, getCombatantBattleHistory, sget } from '../supabase.js'
+import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget } from '../supabase.js'
 import { buildStoryFromLineageTree } from '../gameLogic.js'
 import { downloadFile, formatCombatantHistory } from '../export.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
@@ -179,7 +179,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   const [roomOverlay, setRoomOverlay] = useState(null) // { room, initialRound }
 
   const canEdit    = c.owner_id === playerId
-  const totalBattles = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
+  const totalRounds = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
   const history    = c.bio_history || []
   const isVariant  = !!c.lineage
   const rootId     = c.lineage?.rootId || c.id
@@ -221,7 +221,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
 
   function toggleH2h() {
     if (!h2hOpen && h2hRows === null) {
-      getCombatantBattleHistory(c.id).then(setH2hRows)
+      getCombatantRoundHistory(c.id).then(setH2hRows)
     }
     setH2hOpen(o => !o)
   }
@@ -290,7 +290,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
 
       {/* ── Stats ────────────────────────────────────────────────────────── */}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: '1.5rem' }}>
-        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Battles', totalBattles, 'var(--color-text-tertiary)']].map(([label, val, color]) => (
+        {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Rounds', totalRounds, 'var(--color-text-tertiary)']].map(([label, val, color]) => (
           <div key={label} style={{ padding: 12, background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', textAlign: 'center' }}>
             <div style={{ fontSize: 20, fontWeight: 500, color }}>{val}</div>
             <div style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>{label}</div>
@@ -331,7 +331,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
       </div>
 
       {/* ── Head-to-head ─────────────────────────────────────────────────── */}
-      {totalBattles > 0 && (
+      {totalRounds > 0 && (
         <div style={{ marginBottom: '1.5rem' }}>
           <button onClick={toggleH2h}
             style={{ ...btn('ghost'), width: '100%', textAlign: 'left', fontSize: 13, marginBottom: h2hOpen ? 8 : 0, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/src/screens/HistoryScreen.jsx
+++ b/src/screens/HistoryScreen.jsx
@@ -8,7 +8,7 @@ import { downloadFile, formatRoomAsText, formatSeriesAsText } from '../export.js
 
 // NOTE: The round display logic in HistoryRoomDetail is partially duplicated with RoundCard
 // in GameSummaryScreen.jsx. If you're updating either, consider extracting a shared component.
-function HistoryRoomDetail({ room, onBack, setViewCombatant, playerId, onNextBattle }) {
+function HistoryRoomDetail({ room, onBack, setViewCombatant, playerId, onNextGame }) {
   const completedRounds = (room.rounds || []).filter(r => r.winner)
   const allRounds = room.rounds || []
   const players = (room.players || []).filter(p => !p.isBot)
@@ -60,8 +60,8 @@ function HistoryRoomDetail({ room, onBack, setViewCombatant, playerId, onNextBat
 
       {canReopen && (
         <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-info)', border: '0.5px solid var(--color-border-info)', borderRadius: 'var(--border-radius-lg)' }}>
-          <p style={{ fontSize: 13, color: 'var(--color-text-info)', margin: '0 0 10px' }}>You hosted this tournament. Continue the series with the same players.</p>
-          <button onClick={() => onNextBattle(room)} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13, color: 'var(--color-text-info)', borderColor: 'var(--color-border-info)' }}>Continue series ⚔️</button>
+          <p style={{ fontSize: 13, color: 'var(--color-text-info)', margin: '0 0 10px' }}>You hosted this game. Continue the series with the same players.</p>
+          <button onClick={() => onNextGame(room)} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13, color: 'var(--color-text-info)', borderColor: 'var(--color-border-info)' }}>Continue series ⚔️</button>
         </div>
       )}
 
@@ -233,7 +233,7 @@ function HistoryRoomDetail({ room, onBack, setViewCombatant, playerId, onNextBat
               })
             : (room.combatants?.[rosterPlayer] || []).map((c, i) => {
                 const roundNum = i + 1
-                const battle   = (c.battles || [])[0]
+                const roundEntry = (c.battles || [])[0]
                 const isWin    = c.wins > 0
                 const isLoss   = c.losses > 0
                 const isDraw   = !isWin && !isLoss && (c.draws || 0) > 0
@@ -252,7 +252,7 @@ function HistoryRoomDetail({ room, onBack, setViewCombatant, playerId, onNextBat
                         </div>
                         {played && <span style={{ fontSize: 12, fontWeight: 500, color: isWin ? 'var(--color-text-success)' : isLoss ? 'var(--color-text-danger)' : 'var(--color-text-secondary)', flexShrink: 0, marginLeft: 8 }}>{isWin ? 'W' : isLoss ? 'L' : 'D'}</span>}
                       </div>
-                      {battle?.opponent && <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 3, paddingLeft: 60 }}>vs {battle.opponent}</div>}
+                      {roundEntry?.opponent && <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 3, paddingLeft: 60 }}>vs {roundEntry.opponent}</div>}
                       {c.bio && <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginTop: 2, paddingLeft: 60 }}>{c.bio}</div>}
                     </button>
                     <button onClick={() => setSheetCombatant({ id: c.id, inRoom: c })} title={c.name}
@@ -390,7 +390,7 @@ function SeriesRow({ item, onSelect, playerId }) {
   )
 }
 
-export default function HistoryScreen({ onBack, setViewCombatant, playerId, onNextBattle }) {
+export default function HistoryScreen({ onBack, setViewCombatant, playerId, onNextGame }) {
   const [rooms, setRooms] = useState(null)
   const [selected, setSelected] = useState(null)
 
@@ -409,7 +409,7 @@ export default function HistoryScreen({ onBack, setViewCombatant, playerId, onNe
   }, [])
 
   if (selected) {
-    return <HistoryRoomDetail room={selected} onBack={() => setSelected(null)} setViewCombatant={setViewCombatant} playerId={playerId} onNextBattle={onNextBattle} />
+    return <HistoryRoomDetail room={selected} onBack={() => setSelected(null)} setViewCombatant={setViewCombatant} playerId={playerId} onNextGame={onNextGame} />
   }
 
   const items = rooms ? groupRoomsForHistory(rooms) : []

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -41,7 +41,7 @@ export default function HomeScreen({ onCreate, onJoin, onHistory, onBestiary, on
         <HomeTicker />
         <div style={{ fontSize: 56, marginBottom: '0.5rem' }}>⚔️</div>
         <h1 style={{ fontSize: 40, fontWeight: 500, margin: '0 0 0.5rem', color: 'var(--color-text-primary)', letterSpacing: '-1px' }}>Eights</h1>
-        <p style={{ color: 'var(--color-text-secondary)', margin: 0, fontSize: 16 }}>The game of improbable combatants</p>
+        <p style={{ color: 'var(--color-text-secondary)', margin: 0, fontSize: 16 }}>The game of improbable battles</p>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12, width: '100%', maxWidth: 280 }}>
         {openLobbies.length > 0 && (

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -41,7 +41,7 @@ export default function HomeScreen({ onCreate, onJoin, onHistory, onBestiary, on
         <HomeTicker />
         <div style={{ fontSize: 56, marginBottom: '0.5rem' }}>⚔️</div>
         <h1 style={{ fontSize: 40, fontWeight: 500, margin: '0 0 0.5rem', color: 'var(--color-text-primary)', letterSpacing: '-1px' }}>Eights</h1>
-        <p style={{ color: 'var(--color-text-secondary)', margin: 0, fontSize: 16 }}>The game of improbable battles</p>
+        <p style={{ color: 'var(--color-text-secondary)', margin: 0, fontSize: 16 }}>The game of improbable combatants</p>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12, width: '100%', maxWidth: 280 }}>
         {openLobbies.length > 0 && (

--- a/src/screens/MyLobbiesScreen.jsx
+++ b/src/screens/MyLobbiesScreen.jsx
@@ -14,7 +14,7 @@ export default function MyLobbiesScreen({ lobbies, playerId, onBack, onEnter }) 
         const { rosterSize } = normalizeRoomSettings(r.settings)
         const submitted = realPlayers.filter(p => (r.combatants[p.id] || []).length === rosterSize)
         const isMyTurn  = r.phase === 'draft' && (r.combatants[playerId] || []).length < rosterSize
-        const phaseLabel = r.phase === 'lobby' ? 'Waiting to start' : r.phase === 'draft' ? 'Drafting combatants' : r.phase === 'vote' ? 'Voting in progress' : 'Battle in progress'
+        const phaseLabel = r.phase === 'lobby' ? 'Waiting to start' : r.phase === 'draft' ? 'Drafting combatants' : r.phase === 'vote' ? 'Voting in progress' : 'Rounds in progress'
 
         return (
           <div key={r.id} style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', border: isMyTurn ? '1.5px solid var(--color-border-info)' : '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-lg)', marginBottom: 12 }}>

--- a/src/screens/SpectateScreen.jsx
+++ b/src/screens/SpectateScreen.jsx
@@ -101,7 +101,7 @@ export default function SpectateScreen({ room: init, playerId, setRoom, onHome }
     return (
       <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
         {room.devMode && <DevBanner />}
-        <Header title="Game arena" />
+        <Header title="The Stage" />
         {completedRounds.length === 0 && (
           <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Waiting for the first round to begin…</p>
         )}

--- a/src/screens/SpectateScreen.jsx
+++ b/src/screens/SpectateScreen.jsx
@@ -92,7 +92,7 @@ export default function SpectateScreen({ room: init, playerId, setRoom, onHome }
     )
   }
 
-  // Battle (between rounds)
+  // Rounds (between rounds)
   if (room.phase === 'battle') {
     const completedRounds = room.rounds.filter(r => r.winner || r.draw)
     const totalRounds = Math.min(...room.players.map(p => (room.combatants[p.id] || []).length))
@@ -101,7 +101,7 @@ export default function SpectateScreen({ room: init, playerId, setRoom, onHome }
     return (
       <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
         {room.devMode && <DevBanner />}
-        <Header title="Battle arena" />
+        <Header title="Game arena" />
         {completedRounds.length === 0 && (
           <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Waiting for the first round to begin…</p>
         )}
@@ -123,8 +123,8 @@ export default function SpectateScreen({ room: init, playerId, setRoom, onHome }
         {isComplete && (
           <div style={{ textAlign: 'center', padding: '1.5rem', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
             <div style={{ fontSize: 28, marginBottom: 6 }}>🏆</div>
-            <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)', margin: '0 0 4px' }}>Tournament complete!</p>
-            <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>Waiting to see if the host starts another battle…</p>
+            <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)', margin: '0 0 4px' }}>Game complete!</p>
+            <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>Waiting to see if the host starts another game…</p>
           </div>
         )}
       </div>

--- a/src/screens/SpectateScreen.jsx
+++ b/src/screens/SpectateScreen.jsx
@@ -101,7 +101,7 @@ export default function SpectateScreen({ room: init, playerId, setRoom, onHome }
     return (
       <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
         {room.devMode && <DevBanner />}
-        <Header title="The Stage" />
+        <Header title="The Scene" />
         {completedRounds.length === 0 && (
           <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Waiting for the first round to begin…</p>
         )}

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -9,7 +9,7 @@ import { btn, inp } from '../styles.js'
 import { sget, sset, incrementCombatantStats, publishCombatants, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
-import { uid, canEditCombatant, simulateBattleToEnd, applyWinner, applyDraw, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound } from '../gameLogic.js'
+import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound } from '../gameLogic.js'
 
 export default function VoteScreen({ room: init, playerId, setRoom, onResult, onViewPlayer, onHome, isGuest, onLogin }) {
   const [room, setLocal] = useState(init)
@@ -236,11 +236,11 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
 
     // Apply win/loss to the original. The draft roster is immutable — the variant
     // does not replace the original in any future round of this game. It enters
-    // play only in a heritage "next battle" draft as a prevWinner prerequisite.
+    // play only in a heritage "next game" draft as a prevWinner prerequisite.
     const finalCombatants = applyWinner(r, { ...rd, winner }, winnerId)
 
     // Evolution record is fully self-contained so downstream consumers (App.jsx
-    // handleHostNextBattle, DraftScreen substitutions) don't need to dig into
+    // handleHostNextGame, DraftScreen substitutions) don't need to dig into
     // room.combatants to find variant data.
     const finalRound = buildEvolutionRound(rd, winnerId, newId, newName, variantBio, authorId, playerId)
 
@@ -302,7 +302,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
     setSimulating(true)
     const r = await sget('room:' + room.id)
     if (!r) { setSimulating(false); return }
-    const updated = simulateBattleToEnd(r)
+    const updated = simulateGameToEnd(r)
     await sset('room:' + r.id, updated)
     setLocal(updated); setRoom(updated); setSimulating(false); onResult()
   }
@@ -367,7 +367,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       <ConnectionStatus players={room.players} presentIds={presentIds} isHost={isHost} roomCode={room.code} />
       {room.devMode && (
         <button onClick={simulateToEnd} disabled={simulating} style={{ ...btn('ghost'), width: '100%', fontSize: 13, marginBottom: '1rem', color: 'var(--color-text-warning)' }}>
-          {simulating ? 'Simulating…' : '🧪 Simulate to end of battle'}
+          {simulating ? 'Simulating…' : '🧪 Simulate to end of game'}
         </button>
       )}
 

--- a/src/screens/admin/GamesTab.jsx
+++ b/src/screens/admin/GamesTab.jsx
@@ -3,7 +3,7 @@ import { btn } from '../../styles.js'
 import { slist, sset, adminDeleteGame } from '../../supabase.js'
 
 const ACTIVE_PHASES = ['lobby', 'draft', 'battle', 'vote', 'voting']
-const PHASE_LABEL = { lobby: 'Lobby', draft: 'Drafting', battle: 'Battle', vote: 'Vote', voting: 'Vote', ended: 'Ended' }
+const PHASE_LABEL = { lobby: 'Lobby', draft: 'Drafting', battle: 'Rounds', vote: 'Vote', voting: 'Vote', ended: 'Ended' }
 
 export default function GamesTab() {
   const [rooms,     setRooms]     = useState(null)

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -252,10 +252,10 @@ export async function getPlayerCombatants({ ownerId, query = '', sort = 'wins', 
 // Aggregate head-to-head records for a global combatant across all rooms.
 // Full table scan — acceptable for current scale (see getPlayerRoomStats note below).
 // Returns rows sorted by total matchups descending.
-export async function getCombatantBattleHistory(combatantId) {
+export async function getCombatantRoundHistory(combatantId) {
   try {
     const { data, error } = await supabase.from('rooms').select('data')
-    if (error) { console.error('getCombatantBattleHistory error', error); return [] }
+    if (error) { console.error('getCombatantRoundHistory error', error); return [] }
     const record = {}  // { [opponentId]: { opponentName, wins, losses, draws } }
     ;(data || []).forEach(row => {
       const r = row.data
@@ -277,7 +277,7 @@ export async function getCombatantBattleHistory(combatantId) {
     })
     return Object.values(record)
       .sort((a, b) => (b.wins + b.losses + b.draws) - (a.wins + a.losses + a.draws))
-  } catch (e) { console.error('getCombatantBattleHistory exception', e); return [] }
+  } catch (e) { console.error('getCombatantRoundHistory exception', e); return [] }
 }
 
 // Aggregate stats for a player from all rooms they participated in.


### PR DESCRIPTION
Closes #1

## Summary

- **Function renames:** `simulateBattleToEnd` → `simulateGameToEnd`, `prepareNextBattle` → `prepareNextGame`, `handleHostNextBattle` → `handleHostNextGame`, `getCombatantBattleHistory` → `getCombatantRoundHistory`
- **Prop renames:** `onNextBattle` → `onNextGame`, `onRejoinNextBattle` → `onRejoinNextGame` (BattleScreen, HistoryScreen, App.jsx)
- **Screen state:** internal React screen name `'battle'` → `'round'` in App.jsx nav; DB phase value `'battle'` is left intact (requires a separate schema migration)
- **UI copy:** "Tournament complete!" → "Game complete!", "Complete tournament" → "Complete game", "Cancel tournament" → "Cancel game", "Next Battle" → "Next Game", "Champions from last battle" → "...last game", "Battle in progress" → "Rounds in progress", "Battles" stat label → "Rounds", tagline updated in HomeScreen and user-guide.txt
- **Comments and section headers:** updated across gameLogic.js, all screen files, and test descriptions
- **user-guide.txt:** all battle/tournament references updated; no premature season/league language found
- **Audit result:** no `season` or `league` language in UI strings

## What's intentionally NOT changed
- `room.phase === 'battle'` — DB-stored phase value; renaming requires a migration, not in scope for this issue
- `combatant.battles` array field — stored in room JSON blob; same constraint
- "Battle history" / "Battle History" destination name — handled in issue #2

## Test plan
- [x] All 265 unit tests pass (`npx vitest run`)
- [ ] Draft screen: "Cancel game" label appears (not "Cancel tournament")
- [ ] Draft screen: "Champions from last game" section header in series games
- [ ] BattleScreen: "Game complete!" card with "Complete game ✓" as primary action and "Next Game ⚔️" secondary
- [ ] SpectateScreen: "Game complete!" and "...start another game…" when done
- [ ] MyLobbies: "Rounds in progress" status label for games in play
- [ ] Admin games tab: "Rounds" phase label for active games
- [ ] Combatant stats: "Rounds" label instead of "Battles"
- [ ] Home screen: tagline "The game of improbable combatants"

🤖 Generated with [Claude Code](https://claude.com/claude-code)