### PR TITLE
Terminology refactor: retire 'Bestiary', 'Battle History', 'The Forge'

### DIFF
--- a/docs/user-guide.txt
+++ b/docs/user-guide.txt
@@ -124,7 +124,7 @@ next round hasn't started.
 --- End Game Early ---
 
 The host can end the game before all rounds are played. The game is marked as
-ended early. Combatants from that game won't be published to the Bestiary
+ended early. Combatants from that game won't be published to The Cast
 (since the game was incomplete).
 
 --- Game Complete ---
@@ -151,13 +151,13 @@ HOW IT WORKS:
 3. The writer sees a form with the combatant's current name pre-filled. They
    give the evolved form a new name. The bio field starts with the original
    bio as a baseline — they can rewrite it entirely or extend it.
-4. On submit, the name is checked for uniqueness across the entire Bestiary.
+4. On submit, the name is checked for uniqueness across The Cast.
    Evolution names must be novel — you can't evolve into something that
    already exists.
 
 WHAT EVOLUTION CREATES:
 
-  · A new entry in the global Bestiary — the evolved variant is a distinct
+  · A new entry in The Cast — the evolved variant is a distinct
     combatant with its own win/loss record, reactions, and bio.
   · A permanent evolution record on the round — storing who evolved from whom,
     what opponent caused it, and the game it happened in.
@@ -187,10 +187,10 @@ READING THE EVOLUTION IN HISTORY:
 
 
 ================================================================================
-BATTLE HISTORY
+THE CHRONICLES
 ================================================================================
 
-Tap "Battle history" from the home screen to see all recorded games.
+Tap "The Chronicles" from the home screen to see all recorded games.
 
 Games in a series are grouped together. Each group shows the total rounds
 played across the series and the date range.
@@ -222,10 +222,10 @@ history and the series can be resumed later.
 
 
 ================================================================================
-THE BESTIARY
+THE CAST
 ================================================================================
 
-The Bestiary is the permanent public record of every combatant ever entered
+The Cast is the permanent public record of every combatant ever entered
 across all games — once a game completes, its combatants are published here.
 
 Each entry shows:
@@ -376,7 +376,7 @@ Priority key: [P1] = fix or ship soon  [P2] = important, next wave  [P3] = nice-
   currently-running game could contain an unpublished combatant that shares a
   name with an evolution target — both would pass validation and get published
   simultaneously. Low probability but a real integrity gap: two distinct
-  Bestiary entries with the same name corrupt the lineage record.
+  Cast entries with the same name corrupt the lineage record.
 
 [P2] TICKET 6 — Series standings missing Draws column
   computeSeriesStandings tracks wins/losses/games but the standings table

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,13 +11,13 @@ import LobbyScreen from './screens/LobbyScreen.jsx'
 import DraftScreen from './screens/DraftScreen.jsx'
 import BattleScreen from './screens/BattleScreen.jsx'
 import VoteScreen from './screens/VoteScreen.jsx'
-import HistoryScreen from './screens/HistoryScreen.jsx'
+import ChroniclesScreen from './screens/ChroniclesScreen.jsx'
 import CombatantScreen from './screens/CombatantScreen.jsx'
 import AuthScreen from './screens/AuthScreen.jsx'
 import AdminScreen from './screens/AdminScreen.jsx'
 import PlayersScreen from './screens/PlayersScreen.jsx'
 import PlayerProfile from './screens/PlayerProfile.jsx'
-import BestiaryScreen from './screens/BestiaryScreen.jsx'
+import ArchiveScreen from './screens/ArchiveScreen.jsx'
 import GlobalCombatantDetail from './screens/GlobalCombatantDetail.jsx'
 import SpectateScreen from './screens/SpectateScreen.jsx'
 import GameSummaryScreen from './screens/GameSummaryScreen.jsx'
@@ -129,8 +129,8 @@ export default function App() {
   const [afterAuth, setAfterAuth] = useState(null)
   const [room, setRoom] = useState(null)
   const [viewCombatant, setViewCombatant] = useState(null)
-  const [viewHistory, setViewHistory] = useState(false)
-  const [viewBestiary, setViewBestiary] = useState(false)
+  const [viewChronicles, setViewChronicles] = useState(false)
+  const [viewArchive, setViewArchive] = useState(false)
   const [viewGlobalCombatant, setViewGlobalCombatant] = useState(null)
   const [viewPlayers, setViewPlayers] = useState(false)
   const [viewPlayerProfile, setViewPlayerProfile] = useState(null)
@@ -252,10 +252,10 @@ export default function App() {
     content = <PlayersScreen playerId={playerId} onBack={() => setViewPlayers(false)} onViewPlayer={id => setViewPlayerProfile(id)} />
   else if (viewGlobalCombatant)
     content = <GlobalCombatantDetail key={viewGlobalCombatant?.id} combatant={viewGlobalCombatant} playerId={playerId} playerName={effectiveName} onBack={() => setViewGlobalCombatant(null)} onViewCombatant={setViewGlobalCombatant} />
-  else if (viewBestiary)
-    content = <BestiaryScreen playerId={playerId} onBack={() => setViewBestiary(false)} onViewCombatant={c => setViewGlobalCombatant(c)} />
-  else if (viewHistory)
-    content = <HistoryScreen onBack={() => setViewHistory(false)} setViewCombatant={c => { setViewCombatant(c); setViewHistory(false) }} playerId={playerId} onNextGame={r => { setViewHistory(false); handleHostNextGame(r) }} />
+  else if (viewArchive)
+    content = <ArchiveScreen playerId={playerId} onBack={() => setViewArchive(false)} onViewCombatant={c => setViewGlobalCombatant(c)} />
+  else if (viewChronicles)
+    content = <ChroniclesScreen onBack={() => setViewChronicles(false)} setViewCombatant={c => { setViewCombatant(c); setViewChronicles(false) }} playerId={playerId} onNextGame={r => { setViewChronicles(false); handleHostNextGame(r) }} />
   else if (viewCombatant)
     content = <CombatantScreen room={room} combatant={viewCombatant} playerId={playerId} onBack={() => setViewCombatant(null)} onViewCombatant={setViewCombatant} />
   else if (screen === 'auth')
@@ -263,7 +263,7 @@ export default function App() {
   else if (screen === 'admin')
     content = <AdminScreen onBack={() => nav('home')} />
   else if (screen === 'home')
-    content = <HomeScreen onCreate={() => nav('create')} onJoin={() => nav('join')} onHistory={() => setViewHistory(true)} onBestiary={() => setViewBestiary(true)} onPlayers={() => setViewPlayers(true)} onDev={startDevMode} currentUser={currentUser} onLogin={() => nav('auth')} onLogout={logout} onAdmin={() => nav('admin')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} onHelp={() => setViewHelp(true)} />
+    content = <HomeScreen onCreate={() => nav('create')} onJoin={() => nav('join')} onChronicles={() => setViewChronicles(true)} onArchive={() => setViewArchive(true)} onPlayers={() => setViewPlayers(true)} onDev={startDevMode} currentUser={currentUser} onLogin={() => nav('auth')} onLogout={logout} onAdmin={() => nav('admin')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} onHelp={() => setViewHelp(true)} />
   else if (screen === 'create')
     content = <CreateRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} onLogin={() => goAuth('create')} onCreated={r => { addLobbyCode(r.id); setRoom(r); nav('lobby') }} onBack={() => nav('home')} />
   else if (screen === 'join')
@@ -275,7 +275,7 @@ export default function App() {
   else if (screen === 'draft')
     content = <DraftScreen room={room} playerId={playerId} setRoom={setRoom} onDone={() => { removeLobbyCode(room?.id); nav('round') }} isGuest={isGuest} onLogin={() => goAuth('draft')} onBack={goHome} onEndSeries={handleEndSeries} />
   else if (screen === 'round')
-    content = <BattleScreen room={room} playerId={playerId} setRoom={setRoom} onVote={() => nav('vote')} onHistory={() => setViewHistory(true)} onHome={goHome} onNextGame={handleHostNextGame} onRejoinNextGame={r => { addLobbyCode(r.id); setRoom(r); nav('draft') }} />
+    content = <BattleScreen room={room} playerId={playerId} setRoom={setRoom} onVote={() => nav('vote')} onChronicles={() => setViewChronicles(true)} onHome={goHome} onNextGame={handleHostNextGame} onRejoinNextGame={r => { addLobbyCode(r.id); setRoom(r); nav('draft') }} />
   else if (screen === 'vote')
     content = <VoteScreen room={room} playerId={playerId} setRoom={setRoom} onResult={() => nav('round')} onViewPlayer={setViewPlayerProfile} onHome={goHome} isGuest={isGuest} onLogin={() => goAuth('vote')} />
 

--- a/src/components/CombatantSheet.jsx
+++ b/src/components/CombatantSheet.jsx
@@ -4,7 +4,7 @@ import { getCombatant, updateGlobalCombatant, getLineageTree, getCombatantRoundH
 import { buildStoryFromLineageTree } from '../gameLogic.js'
 
 /**
- * Slide-up sheet showing a combatant's global Bestiary record.
+ * Slide-up sheet showing a combatant's global Cast record.
  *
  * Props:
  *   combatantId  — global combatant id to load (preferred)
@@ -95,7 +95,7 @@ function InRoomView({ combatant: c }) {
   return (
     <div style={{ padding: '16px' }}>
       <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px', fontStyle: 'italic' }}>
-        This combatant hasn't been published yet — full Bestiary stats are available after the game ends.
+        This combatant hasn't been published yet — full Cast stats are available after the game ends.
       </p>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: '1rem' }}>
         {[['Wins', c.wins || 0, 'var(--color-text-success)'], ['Losses', c.losses || 0, 'var(--color-text-danger)'], ['Draws', c.draws || 0, 'var(--color-text-secondary)'], ['Rounds', totalRounds, 'var(--color-text-tertiary)']].map(([label, val, color]) => (

--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -40,19 +40,19 @@ After confirming, the host can choose to evolve the winner: give them a new name
 
 The host can write the evolution themselves, or hand it to the combatant's owner. Either way, you pick a new name and write (or update) the bio for the evolved form.
 
-The original combatant's stats and bio are preserved. The evolved variant is a new entry in the Bestiary with its own record. In a series, the evolved form appears as a required pick in the next draft.`
+The original combatant's stats and bio are preserved. The evolved variant is a new entry in The Cast with its own record. In a series, the evolved form appears as a required pick in the next draft.`
   },
   {
-    title: 'Battle history & series',
-    content: `Every game is saved in Battle History. Tap a room to see round-by-round results, combatant rosters, reactions, and chat.
+    title: 'The Chronicles',
+    content: `Every game is saved in The Chronicles. Tap a room to see round-by-round results, combatant rosters, reactions, and chat.
 
 If you hosted a completed game, you'll see a "Continue series" option — this starts a new draft with the same players, carrying forward champions and evolved forms.
 
 A series groups all connected games together and shows standings across every game played.`
   },
   {
-    title: 'The Bestiary',
-    content: `The Bestiary is the permanent record of every combatant ever entered across all games. Search by name, bio text, or player name.
+    title: 'The Cast',
+    content: `The Cast is the permanent record of every combatant ever entered across all games. Search by name, bio text, or player name.
 
 Each combatant page shows their win/loss record, bio history, reactions, and — if they evolved — the full lineage of what they became and why.`
   },

--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -661,8 +661,8 @@ export function buildActiveFormMap(rooms) {
  *
  * Produces the same { combatantId, name, generation, bornFrom } shape as
  * buildChainEvolutionStory so display code is interchangeable between the two.
- * Use this when you have combatant data (Bestiary, detail pages). Use
- * buildChainEvolutionStory when you have room history (HistoryScreen).
+ * Use this when you have combatant data (The Cast, detail pages). Use
+ * buildChainEvolutionStory when you have room history (ChroniclesScreen).
  *
  * Requires that each variant's lineage.bornFrom was populated at creation time
  * (VoteScreen handleEvolution, Tier 4+).
@@ -943,7 +943,7 @@ export function computeSeriesStandings(rooms) {
 // ─── History grouping ─────────────────────────────────────────────────────────
 
 /**
- * Groups a flat list of rooms into display items for HistoryScreen.
+ * Groups a flat list of rooms into display items for ChroniclesScreen.
  *
  * Returns an array sorted newest-first, each item either:
  *   { type: 'series',     seriesId, rooms: Room[], latestAt: number }

--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import { btn, tab, inp } from '../styles.js'
-import { listCombatants, searchBestiary } from '../supabase.js'
+import { listCombatants, searchCast } from '../supabase.js'
 
-const BESTIARY_SORTS = [
+const CAST_SORTS = [
   { key: 'wins',            label: 'Wins',   asc: false },
   { key: 'losses',          label: 'Losses', asc: false },
   { key: 'reactions_heart', label: '❤️',     asc: false },
@@ -13,7 +13,7 @@ const BESTIARY_SORTS = [
 ]
 const PAGE_SIZE = 20
 
-export default function BestiaryScreen({ onBack, onViewCombatant }) {
+export default function ArchiveScreen({ onBack, onViewCombatant }) {
   const [items, setItems] = useState([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(0)
@@ -27,11 +27,11 @@ export default function BestiaryScreen({ onBack, onViewCombatant }) {
 
   useEffect(() => {
     setLoading(true)
-    const sortDef = BESTIARY_SORTS.find(s => s.key === sort)
+    const sortDef = CAST_SORTS.find(s => s.key === sort)
     // baseOnly filters variants server-side so pagination counts are accurate
     const opts = { sort, ascending: sortDef?.asc ?? false, page, pageSize: PAGE_SIZE, baseOnly: view === 'characters' }
     const fn = query.trim()
-      ? searchBestiary(query.trim(), opts)
+      ? searchCast(query.trim(), opts)
       : listCombatants(opts)
     fn.then(({ items, total }) => { setItems(items); setTotal(total); setLoading(false) })
   }, [sort, page, query, view])
@@ -49,7 +49,7 @@ export default function BestiaryScreen({ onBack, onViewCombatant }) {
   const totalPages = Math.ceil(total / PAGE_SIZE)
 
   return (
-    <Screen title="Bestiary" onBack={onBack}>
+    <Screen title="The Cast" onBack={onBack}>
       <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '-0.75rem 0 1rem' }}>Every fighter ever entered, across all games.</p>
 
       <input
@@ -67,7 +67,7 @@ export default function BestiaryScreen({ onBack, onViewCombatant }) {
 
       {/* Sort bar */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: '1.25rem' }}>
-        {BESTIARY_SORTS.map(s => (
+        {CAST_SORTS.map(s => (
           <button key={s.key} onClick={() => changeSort(s.key)} style={tab(sort === s.key)}>{s.label}</button>
         ))}
       </div>

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -6,7 +6,7 @@ import { btn } from '../styles.js'
 import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence } from '../supabase.js'
 import { uid, canUndoLastRound, undoRound, tallyReactions } from '../gameLogic.js'
 
-export default function BattleScreen({ room: init, playerId, setRoom, onVote, onHistory, onHome, onNextGame, onRejoinNextGame }) {
+export default function BattleScreen({ room: init, playerId, setRoom, onVote, onChronicles, onHome, onNextGame, onRejoinNextGame }) {
   const [room, setLocal] = useState(init)
   const [confirmUndo, setConfirmUndo] = useState(false)
   const [confirmEnd, setConfirmEnd] = useState(false)
@@ -108,7 +108,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
         <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>Battle arena</h2>
         <div style={{ display: 'flex', gap: 6 }}>
-          <button onClick={onHistory} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13 }}>History</button>
+          <button onClick={onChronicles} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13 }}>The Chronicles</button>
           <button onClick={onHome} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13 }}>← Home</button>
         </div>
       </div>
@@ -214,7 +214,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
                 <>
                   <button style={btn('primary')} onClick={completeGame}>Complete game ✓</button>
                   <div style={{ display: 'flex', gap: 8 }}>
-                    <button style={btn()} onClick={onHistory}>View history</button>
+                    <button style={btn()} onClick={onChronicles}>The Chronicles</button>
                     <button style={btn()} onClick={() => onNextGame(room)}>Next Game ⚔️</button>
                   </div>
                   <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: 0 }}>
@@ -226,7 +226,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
                 <>
                   <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Waiting for host to start next game…</p>
                   <div style={{ display: 'flex', gap: 8 }}>
-                    <button style={btn()} onClick={onHistory}>View history</button>
+                    <button style={btn()} onClick={onChronicles}>The Chronicles</button>
                     <button style={btn()} onClick={onHome}>Back to home</button>
                   </div>
                 </>

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -6,9 +6,9 @@ import { tallyReactions, groupRoomsForHistory, computeSeriesStandings } from '..
 import { slist } from '../supabase.js'
 import { downloadFile, formatRoomAsText, formatSeriesAsText } from '../export.js'
 
-// NOTE: The round display logic in HistoryRoomDetail is partially duplicated with RoundCard
+// NOTE: The round display logic in ChroniclesRoomDetail is partially duplicated with RoundCard
 // in GameSummaryScreen.jsx. If you're updating either, consider extracting a shared component.
-function HistoryRoomDetail({ room, onBack, setViewCombatant, playerId, onNextGame }) {
+function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNextGame }) {
   const completedRounds = (room.rounds || []).filter(r => r.winner)
   const allRounds = room.rounds || []
   const players = (room.players || []).filter(p => !p.isBot)
@@ -390,7 +390,7 @@ function SeriesRow({ item, onSelect, playerId }) {
   )
 }
 
-export default function HistoryScreen({ onBack, setViewCombatant, playerId, onNextGame }) {
+export default function ChroniclesScreen({ onBack, setViewCombatant, playerId, onNextGame }) {
   const [rooms, setRooms] = useState(null)
   const [selected, setSelected] = useState(null)
 
@@ -409,7 +409,7 @@ export default function HistoryScreen({ onBack, setViewCombatant, playerId, onNe
   }, [])
 
   if (selected) {
-    return <HistoryRoomDetail room={selected} onBack={() => setSelected(null)} setViewCombatant={setViewCombatant} playerId={playerId} onNextGame={onNextGame} />
+    return <ChroniclesRoomDetail room={selected} onBack={() => setSelected(null)} setViewCombatant={setViewCombatant} playerId={playerId} onNextGame={onNextGame} />
   }
 
   const items = rooms ? groupRoomsForHistory(rooms) : []
@@ -418,7 +418,7 @@ export default function HistoryScreen({ onBack, setViewCombatant, playerId, onNe
     <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: '1.5rem' }}>
         <button onClick={onBack} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13 }}>← Back</button>
-        <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>Battle history</h2>
+        <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>The Chronicles</h2>
       </div>
 
       {rooms === null && <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>}

--- a/src/screens/DraftScreen.jsx
+++ b/src/screens/DraftScreen.jsx
@@ -172,7 +172,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
             </p>
             {biosRequired && (
               <p style={{ fontSize: 12, color: 'var(--color-text-warning)', margin: '0 0 10px', opacity: 0.85 }}>
-                Bios are required in this game. Unsubmitted players are excluded entirely — their combatants won't enter the Bestiary from this game.
+                Bios are required in this game. Unsubmitted players are excluded entirely — their combatants won't enter The Cast from this game.
               </p>
             )}
             {!biosRequired && <div style={{ marginBottom: 10 }} />}
@@ -204,6 +204,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
     <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
       {room.devMode && <DevBanner />}
       <button onClick={onBack} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13, marginBottom: '1rem' }}>← Back</button>
+      <p style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.08em', margin: '0 0 4px' }}>The Fight Card</p>
       <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: '0.25rem' }}>
         <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>Your {rosterSize} combatants</h2>
         {saveStatus === 'saving'   && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>Saving…</span>}

--- a/src/screens/GameSummaryScreen.jsx
+++ b/src/screens/GameSummaryScreen.jsx
@@ -7,8 +7,8 @@ import { btn } from '../styles.js'
 //   initialRound — 1-based round number to open to (e.g. the round where an evolution happened)
 //   onClose      — called when the user dismisses the screen
 //
-// NOTE: The round display logic here (RoundCard) is partially duplicated with HistoryRoomDetail
-// in HistoryScreen.jsx. If you're updating either, consider extracting a shared component.
+// NOTE: The round display logic here (RoundCard) is partially duplicated with ChroniclesRoomDetail
+// in ChroniclesScreen.jsx. If you're updating either, consider extracting a shared component.
 export default function GameSummaryScreen({ room, initialRound = 1, onClose }) {
   const rounds     = room.rounds || []
   const players    = (room.players || []).filter(p => !p.isBot)

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -33,7 +33,7 @@ function HomeTicker() {
   )
 }
 
-export default function HomeScreen({ onCreate, onJoin, onHistory, onBestiary, onPlayers, onDev, currentUser, onLogin, onLogout, onAdmin, openLobbies, onLobbies, onHelp }) {
+export default function HomeScreen({ onCreate, onJoin, onChronicles, onArchive, onPlayers, onDev, currentUser, onLogin, onLogout, onAdmin, openLobbies, onLobbies, onHelp }) {
   return (
     <div style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '2rem', position: 'relative' }}>
       <button onClick={onHelp} title="How to play" style={{ position: 'absolute', top: '1rem', left: '1rem', background: 'transparent', border: '0.5px solid var(--color-border-tertiary)', borderRadius: '50%', width: 28, height: 28, fontSize: 13, color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1 }}>?</button>
@@ -52,8 +52,8 @@ export default function HomeScreen({ onCreate, onJoin, onHistory, onBestiary, on
         )}
         <button onClick={onCreate} style={btn('primary')}>Create a room</button>
         <button onClick={onJoin}   style={btn()}>Join a room</button>
-        <button onClick={onHistory} style={btn('ghost')}>Battle history ↗</button>
-        <button onClick={onBestiary} style={btn('ghost')}>Bestiary ↗</button>
+        <button onClick={onChronicles} style={btn('ghost')}>The Chronicles ↗</button>
+        <button onClick={onArchive} style={btn('ghost')}>The Archive ↗</button>
         <button onClick={onPlayers} style={btn('ghost')}>Players ↗</button>
         <div style={{ borderTop: '0.5px solid var(--color-border-tertiary)', paddingTop: 12, marginTop: 4, display: 'flex', flexDirection: 'column', gap: 8 }}>
           {currentUser ? (

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -581,9 +581,9 @@ export async function getAllCombatantsForExport() {
   } catch (e) { console.error('getAllCombatantsForExport exception', e); return [] }
 }
 
-// Paginated bestiary list — published only.
+// Paginated Cast list — published only.
 // baseOnly: when true, excludes variants (lineage IS NULL) so pagination is accurate
-// for the "characters" view in BestiaryScreen.
+// for the "characters" view in ArchiveScreen.
 export async function listCombatants({ sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false } = {}) {
   try {
     const from = page * pageSize
@@ -596,9 +596,9 @@ export async function listCombatants({ sort = 'wins', ascending = false, page = 
   } catch (e) { console.error('listCombatants exception', e); return { items: [], total: 0 } }
 }
 
-// Full-field name/bio search across published combatants — used by BestiaryScreen.
+// Full-field name/bio search across published combatants — used by ArchiveScreen.
 // baseOnly: same as listCombatants — filters variants server-side for accurate pagination.
-export async function searchBestiary(query, { sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false } = {}) {
+export async function searchCast(query, { sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false } = {}) {
   try {
     const from = page * pageSize
     const to   = from + pageSize - 1
@@ -607,9 +607,9 @@ export async function searchBestiary(query, { sort = 'wins', ascending = false, 
       .or(`name.ilike.%${query}%,bio.ilike.%${query}%,owner_name.ilike.%${query}%`)
     if (baseOnly) q = q.is('lineage', null)
     const { data, error, count } = await q.order(sort, { ascending }).range(from, to)
-    if (error) { console.error('searchBestiary error', error); return { items: [], total: 0 } }
+    if (error) { console.error('searchCast error', error); return { items: [], total: 0 } }
     return { items: data || [], total: count || 0 }
-  } catch (e) { console.error('searchBestiary exception', e); return { items: [], total: 0 } }
+  } catch (e) { console.error('searchCast exception', e); return { items: [], total: 0 } }
 }
 
 // Past games for a player — used on the profile screen to show game history.


### PR DESCRIPTION
Closes #2

## What changed

- **File renames:** `BestiaryScreen.jsx` → `ArchiveScreen.jsx`, `HistoryScreen.jsx` → `ChroniclesScreen.jsx`
- **Component/state renames in `App.jsx`:** `BestiaryScreen` → `ArchiveScreen`, `HistoryScreen` → `ChroniclesScreen`, `viewBestiary` → `viewArchive`, `viewHistory` → `viewChronicles`, props updated accordingly
- **`HomeScreen.jsx`:** nav buttons now read "The Chronicles ↗" and "The Archive ↗"
- **`BattleScreen.jsx`:** prop `onHistory` → `onChronicles`; buttons "History" and "View history" → "The Chronicles"
- **`HelpModal.jsx`:** section titles and copy updated — "Battle history & series" → "The Chronicles", "The Bestiary" → "The Cast", inline Bestiary references updated
- **`DraftScreen.jsx`:** "The Fight Card" label added above draft header; "won't enter the Bestiary" → "won't enter The Cast"
- **`supabase.js`:** `searchBestiary` → `searchCast`, comments updated
- **`CombatantSheet.jsx`, `gameLogic.js`, `GameSummaryScreen.jsx`:** Bestiary/HistoryScreen references in comments updated
- **`docs/user-guide.txt`:** BATTLE HISTORY → THE CHRONICLES, THE BESTIARY → THE CAST, inline references updated

File rename decision: `BestiaryScreen` → `ArchiveScreen` (not `CastScreen`) because The Archive is the canonical home screen nav destination per the glossary. The Cast is the content inside it — reflected in the screen title.

## Test notes

- Home screen nav should show "The Chronicles ↗" and "The Archive ↗"
- Tapping "The Chronicles" opens the game history view with heading "The Chronicles"
- Tapping "The Archive" opens the combatant listing with title "The Cast"
- Draft screen shows "THE FIGHT CARD" label above the combatants heading
- BattleScreen "The Chronicles" button opens the same history view
- HelpModal tabs should read "The Chronicles" and "The Cast"