### PR TITLE
Schema migration: combatants table v2 — source, status, tags, mvp_record

### DIFF
--- a/src/screens/admin/CombatantsTab.jsx
+++ b/src/screens/admin/CombatantsTab.jsx
@@ -79,7 +79,7 @@ export default function CombatantsTab() {
                     <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 3, display: 'flex', gap: 10 }}>
                       <span>by {c.owner_name || '—'}</span>
                       <span>{c.wins}W / {c.losses}L</span>
-                      {!c.published && <span style={{ color: 'var(--color-text-warning)' }}>unpublished</span>}
+                      {c.status !== 'published' && <span style={{ color: 'var(--color-text-warning)' }}>stashed</span>}
                     </div>
                   </div>
                   {!isEditing && !isConfirm && (

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -241,7 +241,7 @@ export async function getPlayerCombatants({ ownerId, query = '', sort = 'wins', 
     const to   = from + pageSize - 1
     let q = supabase.from('combatants')
       .select('id, name, bio, wins, losses, reactions_heart, reactions_angry, reactions_cry', { count: 'exact' })
-      .eq('owner_id', ownerId).eq('published', true)
+      .eq('owner_id', ownerId).eq('status', 'published')
     if (query.trim()) q = q.ilike('name', `%${query.trim()}%`)
     const { data, error, count } = await q.order(sort, { ascending }).range(from, to)
     if (error) { console.error('getPlayerCombatants error', error); return { items: [], total: 0 } }
@@ -352,7 +352,7 @@ export async function searchCombatants(query, limit = 8) {
     const { data, error } = await supabase
       .from('combatants').select('id, name, bio, wins, losses, owner_name')
       .ilike('name', `%${query}%`)
-      .eq('published', true)
+      .eq('status', 'published')
       .order('wins', { ascending: false })
       .limit(limit)
     if (error) { console.error('searchCombatants error', error); return [] }
@@ -366,7 +366,7 @@ export async function getPlayerRecentCombatants(ownerId, limit = 8) {
     const { data, error } = await supabase
       .from('combatants').select('id, name, bio, wins, losses, owner_name')
       .eq('owner_id', ownerId)
-      .eq('published', true)
+      .eq('status', 'published')
       .order('updated_at', { ascending: false })
       .limit(limit)
     if (error) { console.error('getPlayerRecentCombatants error', error); return [] }
@@ -378,24 +378,24 @@ export async function getPlayerRecentCombatants(ownerId, limit = 8) {
 
 // Insert a new variant combatant. lineage = { rootId, parentId, generation, bornFrom }.
 // bornFrom is required — it's the lineage link that powers buildChainEvolutionStory.
-// Published starts false — same lifecycle as any new combatant.
+// Status starts 'stashed' — same lifecycle as any new combatant.
 export async function createVariantCombatant({ id, name, bio, ownerId, ownerName, lineage }) {
   try {
     const { error } = await supabase.from('combatants').insert({
       id, name, bio: bio || '', owner_id: ownerId, owner_name: ownerName,
-      lineage, published: false, updated_at: new Date().toISOString(),
+      lineage, status: 'stashed', updated_at: new Date().toISOString(),
     })
     if (error) console.error('createVariantCombatant error', error)
   } catch (e) { console.error('createVariantCombatant exception', e) }
 }
 
 // Returns the full lineage tree for a character: root + all variants, oldest first.
-// Includes unpublished — lineage display shouldn't hide in-progress forms.
+// Includes stashed — lineage display shouldn't hide in-progress forms.
 export async function getLineageTree(rootId) {
   try {
     const { data, error } = await supabase
       .from('combatants')
-      .select('id, name, bio, wins, losses, reactions_heart, reactions_angry, reactions_cry, lineage, owner_id, owner_name, published')
+      .select('id, name, bio, wins, losses, reactions_heart, reactions_angry, reactions_cry, lineage, owner_id, owner_name, status')
       .or(`id.eq.${rootId},lineage->>rootId.eq.${rootId}`)
       .order('created_at', { ascending: true })
     if (error) { console.error('getLineageTree error', error); return [] }
@@ -411,7 +411,7 @@ export async function getEligibleCombatants(ownerId) {
       .from('combatants')
       .select('id, name, bio, wins, losses, lineage, owner_name')
       .eq('owner_id', ownerId)
-      .eq('published', true)
+      .eq('status', 'published')
       .order('updated_at', { ascending: false })
     if (error) { console.error('getEligibleCombatants error', error); return [] }
     return data || []
@@ -506,11 +506,11 @@ async function callAdminAction(action, params) {
 
 // ─── Admin combatant operations ──────────────────────────────────────────────
 
-// Search all combatants including unpublished — admin only
+// Search all combatants including stashed — admin only
 export async function adminSearchAllCombatants(query = '') {
   try {
     let q = supabase.from('combatants')
-      .select('id, name, bio, wins, losses, reactions_heart, reactions_angry, reactions_cry, owner_id, owner_name, published')
+      .select('id, name, bio, wins, losses, reactions_heart, reactions_angry, reactions_cry, owner_id, owner_name, status')
       .order('updated_at', { ascending: false })
       .limit(50)
     if (query.trim()) q = q.ilike('name', `%${query.trim()}%`)
@@ -547,12 +547,12 @@ export async function adminMergeUsers(keepId, dropId, rooms, applyMergeToRoomFn)
   await callAdminAction('merge-users', { roomUpdates, dropUserId: dropId, keepId })
 }
 
-// Fetch all combatants (published or not) belonging to a specific owner_id.
+// Fetch all combatants (stashed or published) belonging to a specific owner_id.
 // Used by the admin guest re-attribution tool to preview what will be moved.
 export async function getCombatantsByOwnerId(ownerId) {
   try {
     const { data, error } = await supabase
-      .from('combatants').select('id, name, published').eq('owner_id', ownerId)
+      .from('combatants').select('id, name, status').eq('owner_id', ownerId)
     if (error) { console.error('getCombatantsByOwnerId error', error); return [] }
     return data || []
   } catch (e) { console.error('getCombatantsByOwnerId exception', e); return [] }
@@ -588,7 +588,7 @@ export async function listCombatants({ sort = 'wins', ascending = false, page = 
   try {
     const from = page * pageSize
     const to   = from + pageSize - 1
-    let q = supabase.from('combatants').select('*', { count: 'exact' }).eq('published', true)
+    let q = supabase.from('combatants').select('*', { count: 'exact' }).eq('status', 'published')
     if (baseOnly) q = q.is('lineage', null)
     const { data, error, count } = await q.order(sort, { ascending }).range(from, to)
     if (error) { console.error('listCombatants error', error); return { items: [], total: 0 } }
@@ -603,7 +603,7 @@ export async function searchCast(query, { sort = 'wins', ascending = false, page
     const from = page * pageSize
     const to   = from + pageSize - 1
     let q = supabase.from('combatants').select('*', { count: 'exact' })
-      .eq('published', true)
+      .eq('status', 'published')
       .or(`name.ilike.%${query}%,bio.ilike.%${query}%,owner_name.ilike.%${query}%`)
     if (baseOnly) q = q.is('lineage', null)
     const { data, error, count } = await q.order(sort, { ascending }).range(from, to)
@@ -646,7 +646,7 @@ export async function publishCombatants(ids) {
   if (!ids.length) return
   try {
     const { error } = await supabase
-      .from('combatants').update({ published: true, updated_at: new Date().toISOString() })
+      .from('combatants').update({ status: 'published', updated_at: new Date().toISOString() })
       .in('id', ids)
     if (error) console.error('publishCombatants error', error)
   } catch (e) { console.error('publishCombatants exception', e) }

--- a/supabase/migrations/20260414_combatants_status_source_tags_mvp.sql
+++ b/supabase/migrations/20260414_combatants_status_source_tags_mvp.sql
@@ -1,0 +1,47 @@
+-- Migration: combatants table v2 (issue #3)
+--
+-- Changes:
+--   source text      — 'game' | 'created', default 'game' for all existing rows
+--   status text      — replaces boolean published column ('stashed' | 'published')
+--   tags text[]      — free-form labels, default empty array
+--   mvp_record jsonb — array of { gameCode, voteShare, coMvp }, default empty array
+--
+-- Run order matters: add status nullable → populate → set not null → drop published.
+-- Safe to re-run (all statements are idempotent).
+
+-- 1. source — 'game' for all existing rows
+alter table combatants
+  add column if not exists source text not null default 'game';
+
+-- 2. status — add nullable first so we can populate before enforcing not null
+alter table combatants
+  add column if not exists status text;
+
+-- 3. Migrate: true → 'published', false → 'stashed'
+--    Only touches rows where status is still null (idempotency safe).
+update combatants
+  set status = case when published = true then 'published' else 'stashed' end
+  where status is null;
+
+-- 4. Lock down the column
+alter table combatants
+  alter column status set not null,
+  alter column status set default 'stashed';
+
+-- 5. Drop the old boolean column
+alter table combatants
+  drop column if exists published;
+
+-- 6. tags — free-form labels
+alter table combatants
+  add column if not exists tags text[] not null default '{}';
+
+-- 7. mvp_record — permanent MVP vote log
+alter table combatants
+  add column if not exists mvp_record jsonb not null default '[]';
+
+-- 8. Swap the index: published boolean → status text
+drop index if exists combatants_published_idx;
+create index if not exists combatants_status_idx
+  on combatants (status)
+  where status = 'published';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -67,8 +67,10 @@ create policy "public update users" on users for update using (true);
 grant select, insert, update on table users to anon, authenticated;
 
 -- ─── Combatants ──────────────────────────────────────────────────────────────
--- Global bestiary. One row per combatant form (base + evolved variants).
--- published = false while the game is in progress; set to true on room end.
+-- Global cast. One row per combatant form (base + evolved variants).
+--
+-- source: 'game' = entered at draft time | 'created' = built in The Workshop
+-- status: 'stashed' = private to owner | 'published' = permanent public record
 --
 -- lineage is null for generation-0 combatants.
 -- For variants (evolved forms):
@@ -87,6 +89,9 @@ grant select, insert, update on table users to anon, authenticated;
 --
 -- round.evolution (stored in rooms.data JSON — no separate table):
 --   { fromId, fromName, toId, toName, toBio, ownerId, ownerName, authorId }
+--
+-- mvp_record: array of { gameCode, voteShare, coMvp } — one entry per MVP win.
+-- tags: free-form labels, lowercase, applied at creation or edit time.
 
 create table if not exists combatants (
   id               text        primary key,
@@ -101,16 +106,19 @@ create table if not exists combatants (
   reactions_heart  int         not null default 0,
   reactions_angry  int         not null default 0,
   reactions_cry    int         not null default 0,
-  published        boolean     not null default false,
-  lineage          jsonb       null,                   -- null for gen-0; see structure above
+  source           text        not null default 'game',   -- 'game' | 'created'
+  status           text        not null default 'stashed', -- 'stashed' | 'published'
+  tags             text[]      not null default '{}',
+  mvp_record       jsonb       not null default '[]',
+  lineage          jsonb       null,                      -- null for gen-0; see structure above
   created_at       timestamptz not null default now(),
   updated_at       timestamptz not null default now()
 );
 
-create index if not exists combatants_wins_idx        on combatants (wins desc);
-create index if not exists combatants_owner_idx       on combatants (owner_id);
-create index if not exists combatants_name_idx        on combatants (name);
-create index if not exists combatants_published_idx   on combatants (published) where published = true;
+create index if not exists combatants_wins_idx    on combatants (wins desc);
+create index if not exists combatants_owner_idx   on combatants (owner_id);
+create index if not exists combatants_name_idx    on combatants (name);
+create index if not exists combatants_status_idx  on combatants (status) where status = 'published';
 
 -- Fast lookup: all variants whose root is X → used by getLineageTree
 create index if not exists combatants_lineage_root_idx


### PR DESCRIPTION
Closes #3

## What changed

**New migration:** `supabase/migrations/20260414_combatants_status_source_tags_mvp.sql`
- Adds `source text` (`'game' | 'created'`) — default `'game'` for all existing rows
- Adds `status text` (`'stashed' | 'published'`) — migrated from the boolean `published` column (`true → 'published'`, `false → 'stashed'`), then drops `published`
- Adds `tags text[]` — default empty array
- Adds `mvp_record jsonb` — default empty array; shape: `{ gameCode, voteShare, coMvp }[]`
- Replaces `combatants_published_idx` with `combatants_status_idx` (same filter, new column)

**schema.sql** updated to match — now the canonical reference for fresh deploys.

**supabase.js:** all `.eq('published', ...)` and `published:` writes updated to use `status`. `createVariantCombatant` inserts `status: 'stashed'` instead of `published: false`. `publishCombatants` sets `status: 'published'`.

**admin/CombatantsTab.jsx:** `!c.published` badge updated to `c.status !== 'published'` with label "stashed" (matches glossary).

**bio_history note:** `bio_history` writes were already wired in `CombatantSheet.jsx` and `GlobalCombatantDetail.jsx` (each `saveEdit()` call appends the previous bio before updating). No new code needed for this item.

## Test notes
- Run the migration SQL against a Supabase project and confirm: `source`, `status`, `tags`, `mvp_record` columns present; `published` column absent
- Load The Cast (ArchiveScreen) — published combatants should still appear
- Draft autocomplete — only published combatants should surface
- Admin Combatants tab — stashed combatants should show the "stashed" badge
- Confirm winner on last round — `publishCombatants` call should flip status to `'published'`