### PR TITLE
Schema migration: new tables — groups, combatant_groups, arenas

### DIFF
--- a/supabase/migrations/20260415_groups_combatant_groups_arenas.sql
+++ b/supabase/migrations/20260415_groups_combatant_groups_arenas.sql
@@ -1,0 +1,117 @@
+-- Migration: new tables — groups, combatant_groups, arenas (issue #4)
+--
+-- Creates three tables for future 1.1.x features.
+-- Schema only — no app-level feature work in this release.
+--
+-- groups:           named collectives combatants can belong to
+-- combatant_groups: join table for combatant ↔ group membership
+-- arenas:           optional fight contexts (schema only; feature work deferred)
+--
+-- Safe to re-run (all statements are idempotent).
+
+-- ─── groups ──────────────────────────────────────────────────────────────────
+-- Named collectives. Combatants belong to zero or multiple groups.
+-- Follows the same stash/publish lifecycle as combatants.
+-- A group's win/loss record is derived from its members — not stored here.
+--
+-- owner_name is snapshotted at creation time. If the user later changes their
+-- username, the group's record still shows who created it.
+
+create table if not exists groups (
+  id          text        primary key,
+  name        text        not null,
+  description text        not null default '',
+  owner_id    text        not null,
+  owner_name  text        not null,
+  status      text        not null default 'stashed', -- 'stashed' | 'published'
+  tags        text[]      not null default '{}',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists groups_owner_idx
+  on groups (owner_id);
+
+create index if not exists groups_status_idx
+  on groups (status)
+  where status = 'published';
+
+alter table groups enable row level security;
+
+create policy "public read groups"   on groups for select using (true);
+create policy "public insert groups" on groups for insert with check (true);
+create policy "public update groups" on groups for update using (true);
+
+grant select, insert, update on table groups to anon, authenticated;
+
+-- ─── combatant_groups ────────────────────────────────────────────────────────
+-- Join table for combatant ↔ group membership.
+-- Either the combatant owner or the group owner may create the link.
+--
+-- added_by: user id of whoever created the membership link.
+-- No FK to users — users are stored with text ids and the table may not exist
+-- in all deployments; enforce at app level.
+--
+-- On combatant delete (stashed only): app removes all combatant_groups rows
+-- for that combatant before deleting. Published combatants are not deletable.
+
+create table if not exists combatant_groups (
+  combatant_id  text        not null,
+  group_id      text        not null,
+  added_at      timestamptz not null default now(),
+  added_by      text        not null,
+  primary key (combatant_id, group_id)
+);
+
+-- Fast lookup of all combatants in a group
+create index if not exists combatant_groups_group_idx
+  on combatant_groups (group_id);
+
+alter table combatant_groups enable row level security;
+
+create policy "public read combatant_groups"   on combatant_groups for select using (true);
+create policy "public insert combatant_groups" on combatant_groups for insert with check (true);
+create policy "public update combatant_groups" on combatant_groups for update using (true);
+create policy "public delete combatant_groups" on combatant_groups for delete using (true);
+
+grant select, insert, update, delete on table combatant_groups to anon, authenticated;
+
+-- ─── arenas ──────────────────────────────────────────────────────────────────
+-- Optional fight contexts: name, bio (setting/vibe), and house rules.
+-- Schema only — no arena feature work in 1.1.x.
+-- Scope decision (game-level vs round-level) must be resolved before app work.
+--
+-- Follows the same stash/publish lifecycle as combatants and groups.
+-- Publish-on-game-completion applies: stashed arenas used in a completed game
+-- auto-publish on room close (app-level logic, not enforced here).
+--
+-- Arena data is denormalized into the round/room at selection time.
+-- Later edits to the arena row do not alter the fight record.
+
+create table if not exists arenas (
+  id          text        primary key,
+  name        text        not null,
+  bio         text        not null default '',   -- the setting, the vibe, the absurdity
+  rules       text        not null default '',   -- optional house rules (free text)
+  owner_id    text        not null,
+  owner_name  text        not null,
+  status      text        not null default 'stashed', -- 'stashed' | 'published'
+  tags        text[]      not null default '{}',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists arenas_owner_idx
+  on arenas (owner_id);
+
+create index if not exists arenas_status_idx
+  on arenas (status)
+  where status = 'published';
+
+alter table arenas enable row level security;
+
+create policy "public read arenas"   on arenas for select using (true);
+create policy "public insert arenas" on arenas for insert with check (true);
+create policy "public update arenas" on arenas for update using (true);
+
+grant select, insert, update on table arenas to anon, authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -172,3 +172,110 @@ grant execute on function increment_combatant_stats(text, int, int, int, int, in
 -- create or replace function delete_old_rooms() returns void language sql as $$
 --   delete from rooms where updated_at < now() - interval '7 days';
 -- $$;
+
+-- ─── Groups ──────────────────────────────────────────────────────────────────
+-- Named collectives combatants can belong to.
+-- Follows the same stash/publish lifecycle as combatants.
+-- A group's win/loss record is derived from its members — not stored here.
+--
+-- owner_name is snapshotted at creation time. If the user later changes their
+-- username, the group's record still shows who created it.
+
+create table if not exists groups (
+  id          text        primary key,
+  name        text        not null,
+  description text        not null default '',
+  owner_id    text        not null,
+  owner_name  text        not null,
+  status      text        not null default 'stashed', -- 'stashed' | 'published'
+  tags        text[]      not null default '{}',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists groups_owner_idx
+  on groups (owner_id);
+
+create index if not exists groups_status_idx
+  on groups (status)
+  where status = 'published';
+
+alter table groups enable row level security;
+
+create policy "public read groups"   on groups for select using (true);
+create policy "public insert groups" on groups for insert with check (true);
+create policy "public update groups" on groups for update using (true);
+
+grant select, insert, update on table groups to anon, authenticated;
+
+-- ─── Combatant Groups ────────────────────────────────────────────────────────
+-- Join table for combatant ↔ group membership.
+-- Either the combatant owner or the group owner may create the link.
+--
+-- added_by: user id of whoever created the membership link.
+-- No FK to users — users are stored with text ids; enforce membership integrity
+-- at the app level.
+--
+-- On combatant delete (stashed only): app removes all combatant_groups rows
+-- for that combatant before deleting. Published combatants are not deletable.
+
+create table if not exists combatant_groups (
+  combatant_id  text        not null,
+  group_id      text        not null,
+  added_at      timestamptz not null default now(),
+  added_by      text        not null,
+  primary key (combatant_id, group_id)
+);
+
+-- Fast lookup of all combatants in a group
+create index if not exists combatant_groups_group_idx
+  on combatant_groups (group_id);
+
+alter table combatant_groups enable row level security;
+
+create policy "public read combatant_groups"   on combatant_groups for select using (true);
+create policy "public insert combatant_groups" on combatant_groups for insert with check (true);
+create policy "public update combatant_groups" on combatant_groups for update using (true);
+create policy "public delete combatant_groups" on combatant_groups for delete using (true);
+
+grant select, insert, update, delete on table combatant_groups to anon, authenticated;
+
+-- ─── Arenas ──────────────────────────────────────────────────────────────────
+-- Optional fight contexts: name, bio (the setting/vibe), and house rules.
+-- Schema only in 1.1.x — no arena feature work until scope decision is resolved
+-- (game-level vs round-level assignment; see docs/glossary.md → Arenas).
+--
+-- Follows the same stash/publish lifecycle as combatants and groups.
+-- Publish-on-game-completion applies: stashed arenas used in a completed game
+-- auto-publish on room close (app-level logic, not enforced here).
+--
+-- Arena data is denormalized into the round/room at selection time.
+-- Later edits to the arena row do not alter the fight record.
+
+create table if not exists arenas (
+  id          text        primary key,
+  name        text        not null,
+  bio         text        not null default '',   -- the setting, the vibe, the absurdity
+  rules       text        not null default '',   -- optional house rules (free text)
+  owner_id    text        not null,
+  owner_name  text        not null,
+  status      text        not null default 'stashed', -- 'stashed' | 'published'
+  tags        text[]      not null default '{}',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists arenas_owner_idx
+  on arenas (owner_id);
+
+create index if not exists arenas_status_idx
+  on arenas (status)
+  where status = 'published';
+
+alter table arenas enable row level security;
+
+create policy "public read arenas"   on arenas for select using (true);
+create policy "public insert arenas" on arenas for insert with check (true);
+create policy "public update arenas" on arenas for update using (true);
+
+grant select, insert, update on table arenas to anon, authenticated;


### PR DESCRIPTION
Closes #4

## What changed

- **Migration** `20260415_groups_combatant_groups_arenas.sql` — idempotent SQL to create the three new tables on an existing deployment
- **`schema.sql`** updated so a fresh deployment gets all three tables

### Tables added

**`groups`** — named collectives combatants belong to. Same stash/published lifecycle as combatants. `owner_name` snapshotted at creation. Derived win/loss record (not stored).

**`combatant_groups`** — join table with composite PK `(combatant_id, group_id)`. `added_by` records who created the link (either combatant owner or group owner per glossary). Includes DELETE policy so stashed combatant cleanup works cleanly. Index on `group_id` for group-member lookups.

**`arenas`** — schema only; no feature work. `bio` + `rules` fields per issue body. Same lifecycle as combatants/groups. Comment in SQL calls out the scope decision (game-level vs round-level) that must be resolved before app work starts.

## Test notes

- Run the migration SQL against a Supabase project and verify all three tables appear with correct columns, indexes, and RLS policies
- Re-run the migration to confirm idempotency (all `create … if not exists`)
- Run `schema.sql` from scratch to verify a clean deployment includes the new tables