### PR TITLE
Tags system

### DIFF
--- a/src/components/TagChips.jsx
+++ b/src/components/TagChips.jsx
@@ -1,0 +1,43 @@
+// TagChips: renders a tag array as small inline chips.
+// onRemove: optional — if provided, renders an × button on each chip.
+// onFilter: optional — if provided, clicking the tag label triggers a filter action.
+export default function TagChips({ tags = [], onRemove, onFilter }) {
+  if (!tags.length) return null
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+      {tags.map(tag => (
+        <span
+          key={tag}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 2,
+            padding: '2px 7px',
+            background: 'var(--color-background-tertiary)',
+            border: '0.5px solid var(--color-border-tertiary)',
+            borderRadius: 99,
+            fontSize: 11,
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          <span
+            onClick={onFilter ? () => onFilter(tag) : undefined}
+            style={{ cursor: onFilter ? 'pointer' : 'default' }}
+          >
+            {tag}
+          </span>
+          {onRemove && (
+            <button
+              onClick={() => onRemove(tag)}
+              style={{
+                background: 'none', border: 'none', padding: '0 0 0 3px',
+                cursor: 'pointer', color: 'var(--color-text-tertiary)',
+                fontSize: 12, lineHeight: 1, display: 'flex', alignItems: 'center',
+              }}
+            >
+              ×
+            </button>
+          )}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/TagInput.jsx
+++ b/src/components/TagInput.jsx
@@ -1,0 +1,98 @@
+import { useState, useEffect, useRef } from 'react'
+import { inp } from '../styles.js'
+import { getTagSuggestions } from '../supabase.js'
+import TagChips from './TagChips.jsx'
+
+// Lowercase, no special characters, spaces allowed.
+function normalizeTag(raw) {
+  return raw.toLowerCase().replace(/[^a-z0-9 ]/g, '').trim()
+}
+
+// TagInput: editable tag list with autocomplete.
+// value:    string[] of current tags
+// onChange: (newTags: string[]) => void
+export default function TagInput({ value = [], onChange }) {
+  const [text,        setText]        = useState('')
+  const [suggestions, setSuggestions] = useState([])
+  const [open,        setOpen]        = useState(false)
+  const debounceRef = useRef(null)
+
+  useEffect(() => {
+    clearTimeout(debounceRef.current)
+    if (!text.trim()) { setSuggestions([]); return }
+    debounceRef.current = setTimeout(() => {
+      getTagSuggestions(text.trim()).then(tags => {
+        setSuggestions(tags.filter(t => !value.includes(t)))
+      })
+    }, 200)
+  }, [text, value])
+
+  function addTag(raw) {
+    const tag = normalizeTag(raw)
+    if (!tag || value.includes(tag)) { setText(''); setOpen(false); return }
+    onChange([...value, tag])
+    setText(''); setOpen(false); setSuggestions([])
+  }
+
+  function removeTag(tag) {
+    onChange(value.filter(t => t !== tag))
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      if (text.trim()) addTag(text)
+    } else if (e.key === 'Backspace' && !text && value.length) {
+      onChange(value.slice(0, -1))
+    }
+  }
+
+  return (
+    <div>
+      {value.length > 0 && (
+        <div style={{ marginBottom: 6 }}>
+          <TagChips tags={value} onRemove={removeTag} />
+        </div>
+      )}
+      <div style={{ position: 'relative' }}>
+        <input
+          style={{ ...inp(), margin: 0 }}
+          placeholder={value.length ? 'Add another tag…' : 'Add a tag (Enter to confirm)…'}
+          value={text}
+          onChange={e => { setText(e.target.value); setOpen(true) }}
+          onKeyDown={handleKeyDown}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 160)}
+        />
+        {open && suggestions.length > 0 && (
+          <div style={{
+            position: 'absolute', top: 'calc(100% + 2px)', left: 0, right: 0,
+            background: 'var(--color-background-primary)',
+            border: '0.5px solid var(--color-border-secondary)',
+            borderRadius: 'var(--border-radius-md)',
+            zIndex: 200, overflow: 'hidden',
+            boxShadow: '0 6px 18px rgba(0,0,0,0.18)',
+          }}>
+            {suggestions.map((tag, i) => (
+              <button
+                key={tag}
+                onMouseDown={() => addTag(tag)}
+                style={{
+                  display: 'block', width: '100%', textAlign: 'left',
+                  padding: '8px 12px', background: 'transparent', border: 'none',
+                  borderTop: i > 0 ? '0.5px solid var(--color-border-tertiary)' : 'none',
+                  cursor: 'pointer', fontSize: 13, color: 'var(--color-text-primary)',
+                }}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '4px 0 0' }}>
+        Lowercase, spaces allowed. Press Enter or comma to add.
+      </p>
+    </div>
+  )
+}

--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
+import TagChips from '../components/TagChips.jsx'
 import { btn, tab, inp } from '../styles.js'
 import { listCombatants, searchCast } from '../supabase.js'
 
@@ -14,12 +15,13 @@ const CAST_SORTS = [
 const PAGE_SIZE = 20
 
 export default function ArchiveScreen({ onBack, onViewCombatant }) {
-  const [items, setItems] = useState([])
-  const [total, setTotal] = useState(0)
-  const [page, setPage] = useState(0)
-  const [sort, setSort] = useState('wins')
-  const [loading, setLoading] = useState(true)
-  const [query, setQuery] = useState('')
+  const [items, setItems]       = useState([])
+  const [total, setTotal]       = useState(0)
+  const [page, setPage]         = useState(0)
+  const [sort, setSort]         = useState('wins')
+  const [loading, setLoading]   = useState(true)
+  const [query, setQuery]       = useState('')
+  const [activeTag, setActiveTag] = useState(null)
   const debounceRef = useRef(null)
   // "characters" hides variants (combatants with lineage set) so each character
   // appears once — story-first, not form-first. "all" shows every published form.
@@ -29,12 +31,12 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
     setLoading(true)
     const sortDef = CAST_SORTS.find(s => s.key === sort)
     // baseOnly filters variants server-side so pagination counts are accurate
-    const opts = { sort, ascending: sortDef?.asc ?? false, page, pageSize: PAGE_SIZE, baseOnly: view === 'characters' }
+    const opts = { sort, ascending: sortDef?.asc ?? false, page, pageSize: PAGE_SIZE, baseOnly: view === 'characters', tag: activeTag }
     const fn = query.trim()
       ? searchCast(query.trim(), opts)
       : listCombatants(opts)
     fn.then(({ items, total }) => { setItems(items); setTotal(total); setLoading(false) })
-  }, [sort, page, query, view])
+  }, [sort, page, query, view, activeTag])
 
   function changeSort(key) {
     if (sort === key) return
@@ -44,6 +46,14 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
   function handleSearch(val) {
     clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => { setQuery(val); setPage(0) }, 280)
+  }
+
+  function filterByTag(tag) {
+    setActiveTag(tag); setPage(0)
+  }
+
+  function clearTagFilter() {
+    setActiveTag(null); setPage(0)
   }
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
@@ -57,6 +67,26 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
         placeholder="Search by name, bio, or player…"
         onChange={e => handleSearch(e.target.value)}
       />
+
+      {/* Active tag filter pill */}
+      {activeTag && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: '0.75rem' }}>
+          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Tag:</span>
+          <span style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            padding: '3px 9px',
+            background: 'var(--color-background-info)',
+            border: '0.5px solid var(--color-border-info)',
+            borderRadius: 99, fontSize: 12, color: 'var(--color-text-info)',
+          }}>
+            {activeTag}
+            <button
+              onClick={clearTagFilter}
+              style={{ background: 'none', border: 'none', padding: '0 0 0 2px', cursor: 'pointer', color: 'var(--color-text-info)', fontSize: 13, lineHeight: 1 }}
+            >×</button>
+          </span>
+        </div>
+      )}
 
       {/* View toggle */}
       <div style={{ display: 'flex', gap: 6, marginBottom: '1rem' }}>
@@ -75,14 +105,17 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
       {loading && <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>}
       {!loading && items.length === 0 && (
         <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
-          {query.trim()
-            ? `No results for "${query.trim()}".`
-            : 'No combatants yet — play some games first!'}
+          {activeTag
+            ? `No combatants tagged "${activeTag}".`
+            : query.trim()
+              ? `No results for "${query.trim()}".`
+              : 'No combatants yet — play some games first!'}
         </p>
       )}
 
       {!loading && items.map((c, idx) => {
         const isVariant = !!c.lineage
+        const tags = c.tags || []
         return (
           <button key={c.id} onClick={() => onViewCombatant(c)}
             style={{ display: 'block', width: '100%', textAlign: 'left', padding: '12px 14px', background: 'var(--color-background-secondary)', border: `0.5px solid ${isVariant ? 'var(--color-border-info)' : 'var(--color-border-tertiary)'}`, borderRadius: 'var(--border-radius-md)', marginBottom: 8, cursor: 'pointer' }}>
@@ -115,6 +148,11 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
               </div>
             </div>
             {c.bio && <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '4px 0 0 32px', lineHeight: 1.4 }}>{c.bio.length > 90 ? c.bio.slice(0, 90) + '…' : c.bio}</p>}
+            {tags.length > 0 && (
+              <div style={{ marginTop: 6, paddingLeft: 32 }} onClick={e => e.stopPropagation()}>
+                <TagChips tags={tags} onFilter={filterByTag} />
+              </div>
+            )}
           </button>
         )
       })}

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
+import TagChips from '../components/TagChips.jsx'
+import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
 import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget } from '../supabase.js'
 import { buildStoryFromLineageTree } from '../gameLogic.js'
@@ -168,6 +170,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   const [editMode, setEditMode] = useState(false)
   const [editName, setEditName] = useState(init.name)
   const [editBio,  setEditBio]  = useState(init.bio || '')
+  const [editTags, setEditTags] = useState(init.tags || [])
   const [saving, setSaving] = useState(false)
   const [historyOpen,   setHistoryOpen]   = useState(false)
   const [lineageStory,  setLineageStory]  = useState([])  // heritage chain (where this combatant sits)
@@ -233,8 +236,8 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
     const newBio  = editBio.trim()
     const entry = { name: c.name, bio: c.bio || '', updatedAt: new Date().toISOString(), updatedBy: playerName || 'unknown' }
     const newHistory = [...history, entry].slice(-20)
-    await updateGlobalCombatant(c.id, { name: newName, bio: newBio, bio_history: newHistory })
-    setC({ ...c, name: newName, bio: newBio, bio_history: newHistory })
+    await updateGlobalCombatant(c.id, { name: newName, bio: newBio, bio_history: newHistory, tags: editTags })
+    setC({ ...c, name: newName, bio: newBio, bio_history: newHistory, tags: editTags })
     setSaving(false); setEditMode(false)
   }
 
@@ -320,13 +323,22 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
             <input style={inp()} value={editName} onChange={e => setEditName(e.target.value)} placeholder="Name" />
             <label style={lbl}>Bio</label>
             <textarea style={{ ...inp(), width: '100%', resize: 'none', height: 80 }} value={editBio} onChange={e => setEditBio(e.target.value)} placeholder="Bio (optional)" />
-            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+            <label style={{ ...lbl, marginTop: 4 }}>Tags</label>
+            <TagInput value={editTags} onChange={setEditTags} />
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
               <button style={btn('primary')} onClick={saveEdit} disabled={saving || !editName.trim()}>{saving ? 'Saving…' : 'Save'}</button>
-              <button style={btn()} onClick={() => { setEditName(c.name); setEditBio(c.bio || ''); setEditMode(false) }}>Cancel</button>
+              <button style={btn()} onClick={() => { setEditName(c.name); setEditBio(c.bio || ''); setEditTags(c.tags || []); setEditMode(false) }}>Cancel</button>
             </div>
           </>
         ) : (
-          <p style={{ color: c.bio ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)', fontSize: 14, margin: 0 }}>{c.bio || 'No bio yet.'}</p>
+          <>
+            <p style={{ color: c.bio ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)', fontSize: 14, margin: 0 }}>{c.bio || 'No bio yet.'}</p>
+            {(c.tags || []).length > 0 && (
+              <div style={{ marginTop: 8 }}>
+                <TagChips tags={c.tags} />
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/src/screens/admin/CombatantsTab.jsx
+++ b/src/screens/admin/CombatantsTab.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { btn, inp } from '../../styles.js'
-import { adminSearchAllCombatants, adminDeleteCombatant, updateGlobalCombatant } from '../../supabase.js'
+import { adminSearchAllCombatants, adminDeleteCombatant, updateGlobalCombatant, mergeTagsGlobal } from '../../supabase.js'
 
 export default function CombatantsTab() {
   const [query,      setQuery]      = useState('')
@@ -44,6 +44,8 @@ export default function CombatantsTab() {
   return (
     <>
       {msg && <Notice msg={msg} />}
+      <TagMerge />
+      <hr style={{ border: 'none', borderTop: '0.5px solid var(--color-border-tertiary)', margin: '1.5rem 0' }} />
       <div style={{ display: 'flex', gap: 8, marginBottom: '1rem' }}>
         <input
           style={{ ...inp(), margin: 0, flex: 1, fontSize: 14 }}
@@ -131,6 +133,67 @@ function Notice({ msg }) {
   return (
     <div style={{ padding: '8px 12px', background: 'var(--color-background-success)', border: '0.5px solid var(--color-border-success)', borderRadius: 'var(--border-radius-md)', marginBottom: '1rem', fontSize: 13, color: 'var(--color-text-success)' }}>
       {msg}
+    </div>
+  )
+}
+
+// Tag merge — Super Host capability, temporarily admin-only until 1.2.x Super Host role ships.
+// Replaces old_tag with new_tag on every combatant that carries it.
+function TagMerge() {
+  const [oldTag,  setOldTag]  = useState('')
+  const [newTag,  setNewTag]  = useState('')
+  const [merging, setMerging] = useState(false)
+  const [result,  setResult]  = useState(null) // { count } | { error }
+
+  async function doMerge() {
+    const from = oldTag.trim().toLowerCase()
+    const into = newTag.trim().toLowerCase()
+    if (!from || !into || from === into) return
+    setMerging(true); setResult(null)
+    const count = await mergeTagsGlobal(from, into)
+    setResult({ count })
+    setMerging(false)
+    if (count > 0) { setOldTag(''); setNewTag('') }
+  }
+
+  return (
+    <div>
+      <h3 style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        Merge Tags
+      </h3>
+      <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 10px' }}>
+        Replaces a tag with another across all combatants — use this to consolidate typos or duplicates.
+        Will become a Super Host power in 1.2.x.
+      </p>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+        <input
+          style={{ ...inp(), margin: 0, flex: 1, minWidth: 120, fontSize: 14 }}
+          placeholder="Old tag (e.g. spoooky)"
+          value={oldTag}
+          onChange={e => setOldTag(e.target.value)}
+        />
+        <span style={{ fontSize: 14, color: 'var(--color-text-tertiary)', paddingTop: 10 }}>→</span>
+        <input
+          style={{ ...inp(), margin: 0, flex: 1, minWidth: 120, fontSize: 14 }}
+          placeholder="New tag (e.g. spooky)"
+          value={newTag}
+          onChange={e => setNewTag(e.target.value)}
+        />
+        <button
+          onClick={doMerge}
+          disabled={merging || !oldTag.trim() || !newTag.trim() || oldTag.trim() === newTag.trim()}
+          style={{ ...btn('primary'), width: 'auto', padding: '0 16px', fontSize: 13, flex: 'none' }}
+        >
+          {merging ? '…' : 'Merge'}
+        </button>
+      </div>
+      {result && (
+        <p style={{ fontSize: 12, margin: '6px 0 0', color: result.count > 0 ? 'var(--color-text-success)' : 'var(--color-text-tertiary)' }}>
+          {result.count > 0
+            ? `Done — updated ${result.count} combatant${result.count === 1 ? '' : 's'}.`
+            : 'No combatants found with that tag.'}
+        </p>
+      )}
     </div>
   )
 }

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -584,12 +584,14 @@ export async function getAllCombatantsForExport() {
 // Paginated Cast list — published only.
 // baseOnly: when true, excludes variants (lineage IS NULL) so pagination is accurate
 // for the "characters" view in ArchiveScreen.
-export async function listCombatants({ sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false } = {}) {
+// tag: when set, filters to combatants whose tags array contains this exact tag.
+export async function listCombatants({ sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false, tag = null } = {}) {
   try {
     const from = page * pageSize
     const to   = from + pageSize - 1
     let q = supabase.from('combatants').select('*', { count: 'exact' }).eq('status', 'published')
     if (baseOnly) q = q.is('lineage', null)
+    if (tag)      q = q.contains('tags', [tag])
     const { data, error, count } = await q.order(sort, { ascending }).range(from, to)
     if (error) { console.error('listCombatants error', error); return { items: [], total: 0 } }
     return { items: data || [], total: count || 0 }
@@ -598,7 +600,8 @@ export async function listCombatants({ sort = 'wins', ascending = false, page = 
 
 // Full-field name/bio search across published combatants — used by ArchiveScreen.
 // baseOnly: same as listCombatants — filters variants server-side for accurate pagination.
-export async function searchCast(query, { sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false } = {}) {
+// tag: when set, additionally filters to combatants carrying this tag.
+export async function searchCast(query, { sort = 'wins', ascending = false, page = 0, pageSize = 20, baseOnly = false, tag = null } = {}) {
   try {
     const from = page * pageSize
     const to   = from + pageSize - 1
@@ -606,10 +609,34 @@ export async function searchCast(query, { sort = 'wins', ascending = false, page
       .eq('status', 'published')
       .or(`name.ilike.%${query}%,bio.ilike.%${query}%,owner_name.ilike.%${query}%`)
     if (baseOnly) q = q.is('lineage', null)
+    if (tag)      q = q.contains('tags', [tag])
     const { data, error, count } = await q.order(sort, { ascending }).range(from, to)
     if (error) { console.error('searchCast error', error); return { items: [], total: 0 } }
     return { items: data || [], total: count || 0 }
   } catch (e) { console.error('searchCast exception', e); return { items: [], total: 0 } }
+}
+
+// Tag autocomplete — returns distinct tags from published combatants matching the prefix.
+// Backed by the get_tag_suggestions SQL function (migration 20260416).
+export async function getTagSuggestions(prefix = '') {
+  try {
+    const { data, error } = await supabase.rpc('get_tag_suggestions', { prefix, limit_n: 10 })
+    if (error) { console.error('getTagSuggestions error', error); return [] }
+    return data || []
+  } catch (e) { console.error('getTagSuggestions exception', e); return [] }
+}
+
+// Merge one tag into another across all combatants.
+// Replaces old_tag with new_tag on every row that carries it.
+// If a row already has new_tag, old_tag is simply removed to avoid duplicates.
+// Returns the count of affected rows (0 on error).
+// Backed by the merge_tags SQL function (migration 20260416).
+export async function mergeTagsGlobal(oldTag, newTag) {
+  try {
+    const { data, error } = await supabase.rpc('merge_tags', { old_tag: oldTag, new_tag: newTag })
+    if (error) { console.error('mergeTagsGlobal error', error); return 0 }
+    return data || 0
+  } catch (e) { console.error('mergeTagsGlobal exception', e); return 0 }
 }
 
 // Past games for a player — used on the profile screen to show game history.

--- a/supabase/migrations/20260416_tag_suggestions_fn.sql
+++ b/supabase/migrations/20260416_tag_suggestions_fn.sql
@@ -1,0 +1,37 @@
+-- Migration: tag support functions (issue #5)
+--
+-- get_tag_suggestions: autocomplete endpoint — returns distinct tags from published
+--   combatants that start with the given prefix, up to limit_n results.
+--
+-- merge_tags: Super Host capability (role defined in 1.2.x) — replaces old_tag with
+--   new_tag on every combatant that carries old_tag. If the combatant already has
+--   new_tag, old_tag is simply removed to avoid duplicates.
+--   Returns the count of affected rows.
+
+create or replace function get_tag_suggestions(prefix text, limit_n int default 10)
+returns setof text
+language sql stable
+as $$
+  select distinct t
+  from combatants, unnest(tags) as t
+  where status = 'published'
+    and (prefix = '' or t ilike prefix || '%')
+  order by t
+  limit limit_n;
+$$;
+
+create or replace function merge_tags(old_tag text, new_tag text)
+returns int
+language sql
+as $$
+  with updated as (
+    update combatants
+    set tags = case
+      when new_tag = any(tags) then array_remove(tags, old_tag)
+      else array_append(array_remove(tags, old_tag), new_tag)
+    end
+    where old_tag = any(tags)
+    returning 1
+  )
+  select count(*)::int from updated;
+$$;


### PR DESCRIPTION
Closes #5

## What changed

**New components**
- `TagChips.jsx` — renders tag arrays as small inline chips; optionally clickable (for filtering) or removable (in edit mode)
- `TagInput.jsx` — tag editor with autocomplete (backed by `get_tag_suggestions` RPC) and free-form fallback; normalizes to lowercase, strips special characters, spaces allowed; Enter or comma confirms

**New migration** (`20260416_tag_suggestions_fn.sql`)
- `get_tag_suggestions(prefix, limit_n)` — returns distinct tags from published combatants matching a prefix; powers autocomplete
- `merge_tags(old_tag, new_tag)` — replaces one tag with another across all combatants; deduplicates if new_tag already present; returns affected row count

**`supabase.js`**
- `getTagSuggestions(prefix)` — wraps the RPC for use in TagInput
- `mergeTagsGlobal(oldTag, newTag)` — wraps the RPC for use in admin
- `listCombatants` and `searchCast` — accept new `tag` option; filters via `.contains('tags', [tag])` when set

**`ArchiveScreen.jsx`**
- Tags rendered as chips on each cast card; clicking a tag sets it as the active filter
- Active tag filter shown as a dismissable info pill above the list
- Empty state message adjusted for tag-filtered views

**`GlobalCombatantDetail.jsx`**
- Tags displayed as chips below the bio (view mode)
- Tags editable via TagInput in edit mode; saved alongside name/bio

**`admin/CombatantsTab.jsx`**
- Tag Merge section at the top — old tag → new tag, runs `mergeTagsGlobal`, reports affected count. Noted as temporary admin-only until Super Host role ships in 1.2.x.

## Test notes
- Apply tags to a combatant via GlobalCombatantDetail edit — verify they persist and appear as chips
- Verify autocomplete suggests existing tags; free-form entry still works (press Enter)
- In The Cast, click a tag chip on a card — confirm the filter activates and results narrow
- Dismiss the filter pill — confirm full list returns
- In admin Combatants tab, run a tag merge (e.g. create "spoooky" on one combatant, merge into "spooky") — verify count reported and the old tag is gone
- Run the migration SQL (`20260416_tag_suggestions_fn.sql`) against the Supabase project before testing