### PR TITLE
[1.1.x] Combatants 2.0: bio history

### DIFF
--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -172,6 +172,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   const [editBio,  setEditBio]  = useState(init.bio || '')
   const [editTags, setEditTags] = useState(init.tags || [])
   const [saving, setSaving] = useState(false)
+  const [confirmPending, setConfirmPending] = useState(false)
   const [historyOpen,   setHistoryOpen]   = useState(false)
   const [lineageStory,  setLineageStory]  = useState([])  // heritage chain (where this combatant sits)
   const [lineageTree,   setLineageTree]   = useState([])  // raw tree data for heritage — needed for branching child map + navigation
@@ -231,6 +232,11 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
 
   async function saveEdit() {
     if (!editName.trim()) return
+    // Published combatants require a one-step confirm before writing.
+    if (c.status === 'published' && !confirmPending) {
+      setConfirmPending(true)
+      return
+    }
     setSaving(true)
     const newName = editName.trim()
     const newBio  = editBio.trim()
@@ -238,7 +244,12 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
     const newHistory = [...history, entry].slice(-20)
     await updateGlobalCombatant(c.id, { name: newName, bio: newBio, bio_history: newHistory, tags: editTags })
     setC({ ...c, name: newName, bio: newBio, bio_history: newHistory, tags: editTags })
-    setSaving(false); setEditMode(false)
+    setSaving(false); setConfirmPending(false); setEditMode(false)
+  }
+
+  function cancelEdit() {
+    setEditName(c.name); setEditBio(c.bio || ''); setEditTags(c.tags || [])
+    setConfirmPending(false); setEditMode(false)
   }
 
   return (
@@ -325,9 +336,18 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
             <textarea style={{ ...inp(), width: '100%', resize: 'none', height: 80 }} value={editBio} onChange={e => setEditBio(e.target.value)} placeholder="Bio (optional)" />
             <label style={{ ...lbl, marginTop: 4 }}>Tags</label>
             <TagInput value={editTags} onChange={setEditTags} />
+            {confirmPending && (
+              <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '8px 0 0', padding: '8px 10px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', border: '0.5px solid var(--color-border-secondary)' }}>
+                This combatant is published — edits become part of the permanent record.
+              </p>
+            )}
             <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-              <button style={btn('primary')} onClick={saveEdit} disabled={saving || !editName.trim()}>{saving ? 'Saving…' : 'Save'}</button>
-              <button style={btn()} onClick={() => { setEditName(c.name); setEditBio(c.bio || ''); setEditTags(c.tags || []); setEditMode(false) }}>Cancel</button>
+              <button style={btn('primary')} onClick={saveEdit} disabled={saving || !editName.trim()}>
+                {saving ? 'Saving…' : confirmPending ? 'Confirm save' : 'Save'}
+              </button>
+              <button style={btn()} onClick={confirmPending ? () => setConfirmPending(false) : cancelEdit}>
+                {confirmPending ? 'Go back' : 'Cancel'}
+              </button>
             </div>
           </>
         ) : (

--- a/supabase/migrations/20260416_combatants_bio_history.sql
+++ b/supabase/migrations/20260416_combatants_bio_history.sql
@@ -1,0 +1,9 @@
+-- Migration: combatants bio_history (issue #6)
+--
+-- Adds bio_history column to track every bio edit as a historical record.
+-- Format: [{name, bio, updatedAt, updatedBy}] — last 20 entries kept (enforced at app layer).
+--
+-- Safe to re-run (idempotent).
+
+alter table combatants
+  add column if not exists bio_history jsonb not null default '[]';


### PR DESCRIPTION
Closes #6

## What changed

- **Migration** (`20260416_combatants_bio_history.sql`): adds `bio_history jsonb not null default '[]'` to the `combatants` table for existing databases. Column and app-layer logic were already present; this migration closes the gap for databases created before the column was in the schema.
- **Confirm step for published combatants** (`GlobalCombatantDetail.jsx`): the first click of Save on a published combatant now sets `confirmPending`, swaps the buttons to "Confirm save" / "Go back", and shows a note ("This combatant is published — edits become part of the permanent record."). Clicking "Confirm save" proceeds; "Go back" returns to the edit form unchanged. Cancelling from either state resets cleanly. Stashed combatants save immediately (no confirm).

Bio history logging itself (`saveEdit` appending to `bio_history` before write) and the collapsible bio log section were already in place from prior work.

## Test notes

- Edit a **published** combatant's bio → first Save shows the confirm note and button swap → Confirm save writes the change and appends the previous bio to the bio log → bio log shows the entry in reverse-chronological order.
- Click "Go back" during confirm → returns to edit form with fields intact, no save happens.
- Cancel from confirm state → exits edit mode with no changes (same as Cancel from the edit form directly).
- Edit a **stashed** combatant → Save writes immediately, no confirm step.
- Bio log section appears (collapsible) once there is at least one history entry.