### PR TITLE
Combatants 2.0: ephemeral/topical tags

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -238,6 +238,46 @@ export function canEditCombatant(ownerId, playerId, hostId) {
   return ownerId === playerId || playerId === hostId
 }
 
+// ─── Ephemeral badges ─────────────────────────────────────────────────────────
+
+/**
+ * Derives ephemeral system badges from a combatant's in-game battle record.
+ * Not stored — computed fresh from the combatant's battles array each render.
+ *
+ * Returns an array of badge objects, each with a `type` and optional fields:
+ *   { type: 'on_fire',     count: number }   — won last 3+ rounds in a row
+ *   { type: 'cold_streak', count: number }   — lost last 3+ rounds in a row
+ *   { type: 'trapper' }                      — trapTriggered is true
+ *
+ * @param {object} combatant — in-room combatant with battles[] and trapTriggered
+ * @returns {Array}
+ */
+export function getEphemeralBadges(combatant) {
+  const badges = []
+  const battles = combatant?.battles || []
+
+  if (battles.length >= 3) {
+    // Count consecutive matching results from the end of the list
+    const lastResult = battles[battles.length - 1].result
+    if (lastResult === 'win' || lastResult === 'loss') {
+      let streak = 0
+      for (let i = battles.length - 1; i >= 0; i--) {
+        if (battles[i].result === lastResult) streak++
+        else break
+      }
+      if (streak >= 3) {
+        badges.push({ type: lastResult === 'win' ? 'on_fire' : 'cold_streak', count: streak })
+      }
+    }
+  }
+
+  if (combatant?.trapTriggered) {
+    badges.push({ type: 'trapper' })
+  }
+
+  return badges
+}
+
 // ─── Room lifecycle ───────────────────────────────────────────────────────────
 
 /**

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -27,6 +27,7 @@ import {
   applyDraw,
   replacePlayerIdInRoom,
   buildEvolutionRound,
+  getEphemeralBadges,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -1941,5 +1942,84 @@ describe('buildEvolutionRound', () => {
   it('throws when newName is blank', () => {
     expect(() => buildEvolutionRound(makeRound(), 'c1', 'v1', '   ', '', 'p1', 'p1'))
       .toThrow('newName is required')
+  })
+})
+
+describe('getEphemeralBadges', () => {
+  function makeBattles(results) {
+    return results.map((result, i) => ({ roundId: `r${i}`, opponent: 'Someone', result }))
+  }
+
+  it('returns empty array for a combatant with no battles', () => {
+    expect(getEphemeralBadges({ battles: [] })).toEqual([])
+  })
+
+  it('returns empty array when no battles field exists', () => {
+    expect(getEphemeralBadges({})).toEqual([])
+  })
+
+  it('returns no badge for 2 consecutive wins', () => {
+    const c = { battles: makeBattles(['win', 'win']) }
+    expect(getEphemeralBadges(c)).toEqual([])
+  })
+
+  it('returns on_fire with count 3 for exactly 3 consecutive wins', () => {
+    const c = { battles: makeBattles(['win', 'win', 'win']) }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'on_fire', count: 3 }])
+  })
+
+  it('returns on_fire with count 5 for 5 consecutive wins', () => {
+    const c = { battles: makeBattles(['win', 'win', 'win', 'win', 'win']) }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'on_fire', count: 5 }])
+  })
+
+  it('streak is broken by a non-win — 2 wins after a loss gives no badge', () => {
+    const c = { battles: makeBattles(['win', 'loss', 'win', 'win']) }
+    expect(getEphemeralBadges(c)).toEqual([])
+  })
+
+  it('streak counts only tail run — 1 loss then 3 wins gives on_fire 3', () => {
+    const c = { battles: makeBattles(['win', 'win', 'loss', 'win', 'win', 'win']) }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'on_fire', count: 3 }])
+  })
+
+  it('returns no badge for 2 consecutive losses', () => {
+    const c = { battles: makeBattles(['loss', 'loss']) }
+    expect(getEphemeralBadges(c)).toEqual([])
+  })
+
+  it('returns cold_streak with count 3 for exactly 3 consecutive losses', () => {
+    const c = { battles: makeBattles(['loss', 'loss', 'loss']) }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'cold_streak', count: 3 }])
+  })
+
+  it('returns cold_streak with count 4 for 4 consecutive losses', () => {
+    const c = { battles: makeBattles(['win', 'loss', 'loss', 'loss', 'loss']) }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'cold_streak', count: 4 }])
+  })
+
+  it('draws break a win streak', () => {
+    const c = { battles: makeBattles(['win', 'win', 'win', 'draw', 'win', 'win']) }
+    expect(getEphemeralBadges(c)).toEqual([])
+  })
+
+  it('draws do not themselves trigger on_fire or cold_streak', () => {
+    const c = { battles: makeBattles(['draw', 'draw', 'draw']) }
+    expect(getEphemeralBadges(c)).toEqual([])
+  })
+
+  it('returns trapper badge when trapTriggered is true', () => {
+    const c = { battles: [], trapTriggered: true }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'trapper' }])
+  })
+
+  it('does not return trapper badge when trapTriggered is false', () => {
+    const c = { battles: [], trapTriggered: false }
+    expect(getEphemeralBadges(c)).toEqual([])
+  })
+
+  it('can return both on_fire and trapper', () => {
+    const c = { battles: makeBattles(['win', 'win', 'win']), trapTriggered: true }
+    expect(getEphemeralBadges(c)).toEqual([{ type: 'on_fire', count: 3 }, { type: 'trapper' }])
   })
 })

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -9,7 +9,7 @@ import { btn, inp } from '../styles.js'
 import { sget, sset, incrementCombatantStats, publishCombatants, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
-import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound } from '../gameLogic.js'
+import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges } from '../gameLogic.js'
 
 export default function VoteScreen({ room: init, playerId, setRoom, onResult, onViewPlayer, onHome, isGuest, onLogin }) {
   const [room, setLocal] = useState(init)
@@ -421,6 +421,8 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
           const isEditing  = editingId === c.id
           const isEvolving = evolveFlow?.combatantId === c.id
 
+          const ephemeralBadges = getEphemeralBadges(c)
+
           return (
             <div key={c.id} style={{ background: isPicked ? 'var(--color-background-info)' : 'var(--color-background-secondary)', border: isPicked ? '2px solid var(--color-border-info)' : '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-lg)', overflow: 'hidden', transition: 'border 0.15s' }}>
 
@@ -439,6 +441,28 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
                   <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', display: 'flex', alignItems: 'center', gap: 5 }}>
                     by {owner && !owner.isBot ? <AvatarWithHover player={owner} onViewProfile={onViewPlayer} /> : null}
                     {owner?.name}
+                  </div>
+                )}
+                {ephemeralBadges.length > 0 && (
+                  <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+                    {ephemeralBadges.map(badge => {
+                      if (badge.type === 'on_fire') return (
+                        <span key="on_fire" style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-warning)', color: 'var(--color-text-warning)', border: '0.5px solid var(--color-border-warning)', borderRadius: 99 }}>
+                          🔥 on fire{badge.count > 3 ? ` ×${badge.count}` : ''}
+                        </span>
+                      )
+                      if (badge.type === 'cold_streak') return (
+                        <span key="cold_streak" style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-secondary)', color: 'var(--color-text-secondary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 99 }}>
+                          🧊 cold streak{badge.count > 3 ? ` ×${badge.count}` : ''}
+                        </span>
+                      )
+                      if (badge.type === 'trapper') return (
+                        <span key="trapper" style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-danger)', color: 'var(--color-text-danger)', border: '0.5px solid var(--color-border-danger)', borderRadius: 99 }}>
+                          🪤 trapper
+                        </span>
+                      )
+                      return null
+                    })}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Closes #7

## What changed

- Added `getEphemeralBadges(combatant)` pure function to `gameLogic.js` — derives On fire / Cold streak / Trapper badges from a combatant's `battles` array and `trapTriggered` field. Not stored, not permanent.
- Added 17 unit tests covering all badge scenarios (streak thresholds, streak breaks, draws, trapper, combinations).
- Rendered badges on combatant cards in VoteScreen: 🔥 on fire (with count if 4+), 🧊 cold streak (with count if 4+), 🪤 trapper.

## Test notes

- Run `npx vitest run` — all 280 tests pass.
- To see badges in-game: start a dev room, play 3 rounds where the same combatant wins back-to-back to trigger 🔥. Set a trap in the draft against a combatant who appears in the same round to trigger 🪤.
- Streak count annotation (×4, ×5 etc.) only appears when streak exceeds 3 — at exactly 3 it just reads "on fire" / "cold streak".