### PR TITLE
[1.1.x] Combatants 2.0: achievement superlatives

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -1048,3 +1048,52 @@ export function groupRoomsForHistory(rooms) {
 
   return items.sort((a, b) => b.latestAt - a.latestAt)
 }
+
+// ─── Achievement superlatives ─────────────────────────────────────────────────
+
+/**
+ * Returns an array of narrative superlative strings for the combatant detail page.
+ *
+ * Superlatives are shown on the detail page only — not on small cards.
+ * The list is intentionally conservative: only emit a string when the stat
+ * is unambiguously worth surfacing (thresholds below).
+ *
+ * @param {object} c        - combatant record (wins, losses, draws, mvp_record)
+ * @param {Array|null} h2h  - head-to-head rows from getCombatantRoundHistory, or null if not yet loaded
+ * @returns {string[]}
+ */
+export function computeSuperlatives(c, h2h) {
+  const superlatives = []
+  const wins   = c.wins   || 0
+  const losses = c.losses || 0
+  const draws  = c.draws  || 0
+  const total  = wins + losses + draws
+
+  if (total === 0) return superlatives
+
+  // Unique opponents beaten — requires h2h data
+  if (h2h && h2h.length > 0) {
+    const beaten = h2h.filter(r => r.wins > 0).length
+    if (beaten > 0) {
+      superlatives.push(`Beat ${beaten} ${beaten === 1 ? 'opponent' : 'opponents'}`)
+    }
+  }
+
+  // Undefeated — at least one win, zero losses (draws don't break it)
+  if (wins > 0 && losses === 0) {
+    superlatives.push('Undefeated')
+  }
+
+  // Win rate — only surface when meaningful (≥5 rounds, ≥70% wins)
+  if (total >= 5 && wins / total >= 0.7) {
+    superlatives.push(`${Math.round((wins / total) * 100)}% win rate`)
+  }
+
+  // MVP wins — voting ships 1.3.x; field is captured in schema now
+  const mvpCount = (c.mvp_record || []).length
+  if (mvpCount > 0) {
+    superlatives.push(`MVP ${mvpCount === 1 ? 'once' : `${mvpCount} times`}`)
+  }
+
+  return superlatives
+}

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -28,6 +28,7 @@ import {
   replacePlayerIdInRoom,
   buildEvolutionRound,
   getEphemeralBadges,
+  computeSuperlatives,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -2021,5 +2022,86 @@ describe('getEphemeralBadges', () => {
   it('can return both on_fire and trapper', () => {
     const c = { battles: makeBattles(['win', 'win', 'win']), trapTriggered: true }
     expect(getEphemeralBadges(c)).toEqual([{ type: 'on_fire', count: 3 }, { type: 'trapper' }])
+  })
+})
+
+describe('computeSuperlatives', () => {
+  function makeCombatantStats(overrides = {}) {
+    return { wins: 0, losses: 0, draws: 0, mvp_record: [], ...overrides }
+  }
+
+  it('returns empty array when combatant has never fought', () => {
+    expect(computeSuperlatives(makeCombatantStats(), null)).toEqual([])
+  })
+
+  it('returns empty array when combatant has only draws and no wins', () => {
+    expect(computeSuperlatives(makeCombatantStats({ draws: 2 }), null)).toEqual([])
+  })
+
+  it('returns Undefeated when wins > 0 and losses === 0', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 3 }), null)
+    expect(sup).toContain('Undefeated')
+  })
+
+  it('does not return Undefeated when there is at least one loss', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 3, losses: 1 }), null)
+    expect(sup).not.toContain('Undefeated')
+  })
+
+  it('Undefeated is still returned when there are draws alongside wins', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 2, draws: 1 }), null)
+    expect(sup).toContain('Undefeated')
+  })
+
+  it('returns win rate when >= 5 rounds and >= 70% wins', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 7, losses: 3 }), null)
+    expect(sup).toContain('70% win rate')
+  })
+
+  it('does not return win rate when fewer than 5 rounds', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 4, losses: 0 }), null)
+    expect(sup.some(s => s.includes('win rate'))).toBe(false)
+  })
+
+  it('does not return win rate when below 70% threshold', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 6, losses: 4 }), null)
+    expect(sup.some(s => s.includes('win rate'))).toBe(false)
+  })
+
+  it('returns MVP once when mvp_record has one entry', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 1, mvp_record: [{ gameCode: 'ABC' }] }), null)
+    expect(sup).toContain('MVP once')
+  })
+
+  it('returns MVP N times when mvp_record has multiple entries', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 2, mvp_record: [{}, {}] }), null)
+    expect(sup).toContain('MVP 2 times')
+  })
+
+  it('returns Beat N opponents from h2h data', () => {
+    const h2h = [
+      { opponentName: 'Alpha', wins: 2, losses: 0 },
+      { opponentName: 'Beta',  wins: 1, losses: 1 },
+      { opponentName: 'Gamma', wins: 0, losses: 2 },
+    ]
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 3, losses: 3 }), h2h)
+    expect(sup).toContain('Beat 2 opponents')
+  })
+
+  it('uses singular "opponent" when exactly one opponent was beaten', () => {
+    const h2h = [{ opponentName: 'Alpha', wins: 1, losses: 0 }]
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 1 }), h2h)
+    expect(sup).toContain('Beat 1 opponent')
+  })
+
+  it('does not include Beat opponents line when h2h is null', () => {
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 3, losses: 3 }), null)
+    expect(sup.some(s => s.startsWith('Beat'))).toBe(false)
+  })
+
+  it('does not include Beat opponents when no opponents were beaten', () => {
+    const h2h = [{ opponentName: 'Alpha', wins: 0, losses: 3 }]
+    const sup = computeSuperlatives(makeCombatantStats({ wins: 0, losses: 3 }), h2h)
+    expect(sup.some(s => s.startsWith('Beat'))).toBe(false)
   })
 })

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -4,7 +4,7 @@ import TagChips from '../components/TagChips.jsx'
 import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
 import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget } from '../supabase.js'
-import { buildStoryFromLineageTree } from '../gameLogic.js'
+import { buildStoryFromLineageTree, computeSuperlatives } from '../gameLogic.js'
 import { downloadFile, formatCombatantHistory } from '../export.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
 
@@ -204,6 +204,8 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
         if (story.length > 1) setOwnChainStory(story)
       })
     }
+    // Load h2h eagerly so superlatives can show on first render.
+    getCombatantRoundHistory(c.id).then(setH2hRows)
   }, [rootId, c.id])
 
   function nameSlug() {
@@ -224,9 +226,6 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   }
 
   function toggleH2h() {
-    if (!h2hOpen && h2hRows === null) {
-      getCombatantRoundHistory(c.id).then(setH2hRows)
-    }
     setH2hOpen(o => !o)
   }
 
@@ -311,6 +310,20 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
           </div>
         ))}
       </div>
+
+      {/* ── Superlatives ─────────────────────────────────────────────────── */}
+      {(() => {
+        const sup = computeSuperlatives(c, h2hRows)
+        return sup.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: '1.5rem' }}>
+            {sup.map(s => (
+              <span key={s} style={{ fontSize: 12, padding: '3px 10px', background: 'var(--color-background-secondary)', color: 'var(--color-text-secondary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 99 }}>
+                {s}
+              </span>
+            ))}
+          </div>
+        ) : null
+      })()}
 
       {(c.reactions_heart > 0 || c.reactions_angry > 0 || c.reactions_cry > 0) && (
         <div style={{ display: 'flex', gap: 8, marginBottom: '1.5rem' }}>


### PR DESCRIPTION
Closes #8

## What changed

- Added `computeSuperlatives(c, h2h)` pure function to `gameLogic.js` — derives narrative distinction strings from a combatant's record and head-to-head data. Superlatives emitted: "Beat N opponents" (from h2h), "Undefeated" (wins > 0, losses === 0), win rate (≥5 rounds, ≥70% wins), MVP count (from `mvp_record`).
- Updated `GlobalCombatantDetail.jsx` to load h2h data eagerly on mount (previously lazy on user toggle) so superlatives are populated on first render. The h2h toggle still works identically — it just uses data already in state.
- Superlatives render as pill badges between the stats grid and reactions row. Section is hidden when no superlatives apply.
- 15 new unit tests for `computeSuperlatives` covering all branches.

## Test notes

- `npm test` — all 294 tests pass.
- UI: open a combatant detail page for a combatant with ≥1 win. Superlative pills should appear below the W/L/D/Rounds grid. A brand-new combatant with no rounds shows no pills. An undefeated combatant shows "Undefeated". A combatant with 7+ wins and ≥5 total rounds shows a win rate.
- MVP superlative is wired but requires data — MVP voting ships 1.3.x per spec.