### PR TITLE
The Workshop: Create-a-Combatant flow

### DIFF
--- a/src/screens/WorkshopScreen.jsx
+++ b/src/screens/WorkshopScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagInput from '../components/TagInput.jsx'
 import TagChips from '../components/TagChips.jsx'
@@ -10,6 +10,9 @@ import {
   updateWorkshopCombatant,
   setWorkshopCombatantStatus,
   deleteWorkshopCombatant,
+  getGroupsForPicker,
+  getCombatantGroupIds,
+  setCombatantGroups,
 } from '../supabase.js'
 
 // ─── Guest gate ───────────────────────────────────────────────────────────────
@@ -33,28 +36,87 @@ function GuestGate({ onLogin }) {
   )
 }
 
+// ─── Group picker ─────────────────────────────────────────────────────────────
+
+function GroupPicker({ selectedIds, onChange, ownerId }) {
+  const [available, setAvailable] = useState(null)  // null = loading
+
+  useEffect(() => {
+    getGroupsForPicker(ownerId).then(setAvailable)
+  }, [ownerId])
+
+  if (available === null) return <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>Loading groups…</p>
+
+  if (available.length === 0) return (
+    <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>
+      No groups yet. Create groups in the Workshop to assign combatants to them.
+    </p>
+  )
+
+  function toggle(id) {
+    onChange(selectedIds.includes(id) ? selectedIds.filter(x => x !== id) : [...selectedIds, id])
+  }
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 12 }}>
+      {available.map(g => {
+        const active = selectedIds.includes(g.id)
+        return (
+          <button
+            key={g.id}
+            onClick={() => toggle(g.id)}
+            style={{
+              ...btn('ghost'),
+              padding: '4px 12px',
+              fontSize: 12,
+              background:  active ? 'var(--color-background-info)' : 'transparent',
+              color:       active ? 'var(--color-text-info)'       : 'var(--color-text-secondary)',
+              borderColor: active ? 'var(--color-border-info)'     : 'var(--color-border-tertiary)',
+            }}
+          >
+            {g.name}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 // ─── Create / Edit form ───────────────────────────────────────────────────────
 
 function CombatantForm({ existing, onSave, onCancel, currentUser }) {
-  const isEdit     = !!existing
+  const isEdit      = !!existing
   const isPublished = existing?.status === 'published'
 
-  const [name,    setName]    = useState(existing?.name    || '')
-  const [bio,     setBio]     = useState(existing?.bio     || '')
-  const [tags,    setTags]    = useState(existing?.tags    || [])
-  const [status,  setStatus]  = useState(existing?.status  || 'stashed')
-  const [saving,  setSaving]  = useState(false)
-  const [confirm, setConfirm] = useState(false)  // bio-edit confirm for published
-  const [error,   setError]   = useState('')
+  const [name,       setName]       = useState(existing?.name   || '')
+  const [bio,        setBio]        = useState(existing?.bio    || '')
+  const [tags,       setTags]       = useState(existing?.tags   || [])
+  const [groupIds,     setGroupIds]     = useState([])
+  const initialGroupIds               = useRef(null)  // set once when memberships load
+  const [status,       setStatus]     = useState(existing?.status || 'stashed')
+  const [saving,       setSaving]     = useState(false)
+  const [confirm,      setConfirm]    = useState(false)  // bio-edit confirm for published
+  const [error,        setError]      = useState('')
 
-  const bioChanged  = isEdit && bio.trim() !== (existing.bio || '').trim()
-  const nameChanged = isEdit && name.trim() !== existing.name.trim()
-  const tagsChanged = isEdit && JSON.stringify(tags) !== JSON.stringify(existing.tags || [])
-  const hasChanges  = !isEdit || nameChanged || bioChanged || tagsChanged
+  // Load existing group memberships when editing
+  useEffect(() => {
+    if (existing?.id) {
+      getCombatantGroupIds(existing.id).then(ids => {
+        setGroupIds(ids)
+        initialGroupIds.current = ids
+      })
+    }
+  }, [existing?.id])
+
+  const bioChanged    = isEdit && bio.trim() !== (existing.bio || '').trim()
+  const nameChanged   = isEdit && name.trim() !== existing.name.trim()
+  const tagsChanged   = isEdit && JSON.stringify(tags) !== JSON.stringify(existing.tags || [])
+  const groupsChanged = isEdit && initialGroupIds.current !== null &&
+    JSON.stringify([...groupIds].sort()) !== JSON.stringify([...initialGroupIds.current].sort())
+  const hasChanges    = !isEdit || nameChanged || bioChanged || tagsChanged || groupsChanged
 
   function validate() {
-    if (!name.trim())       { setError('Name is required.'); return false }
-    if (!bio.trim())        { setError('Bio is required — even a single line.'); return false }
+    if (!name.trim()) { setError('Name is required.'); return false }
     return true
   }
 
@@ -72,23 +134,28 @@ function CombatantForm({ existing, onSave, onCancel, currentUser }) {
         updatedAt: new Date().toISOString(),
         updatedBy: currentUser.username,
       }
-      const ok = await updateWorkshopCombatant(
-        existing.id,
-        { name: name.trim(), bio: bio.trim(), tags },
-        bioHistoryEntry,
-        existing.bio_history || [],
-      )
+      const [ok] = await Promise.all([
+        updateWorkshopCombatant(
+          existing.id,
+          { name: name.trim(), bio: bio.trim(), tags },
+          bioHistoryEntry,
+          existing.bio_history || [],
+        ),
+        setCombatantGroups(existing.id, groupIds, currentUser.id),
+      ])
       if (!ok) { setError('Save failed. Try again.'); setSaving(false); return }
-      onSave({ ...existing, name: name.trim(), bio: bio.trim(), tags, bio_history: [...(existing.bio_history || []), bioHistoryEntry].slice(-20) })
+      onSave({ ...existing, name: name.trim(), bio: bio.trim(), tags, groupIds, bio_history: [...(existing.bio_history || []), bioHistoryEntry].slice(-20) })
     } else {
-      const id = uid()
-      const ok = await createWorkshopCombatant({
+      const id  = uid()
+      const ok  = await createWorkshopCombatant({
         id, name: name.trim(), bio: bio.trim(), tags,
         ownerId: currentUser.id, ownerName: currentUser.username,
         status,
       })
       if (!ok) { setError('Save failed. Try again.'); setSaving(false); return }
-      onSave({ id, name: name.trim(), bio: bio.trim(), tags, status, source: 'created', wins: 0, losses: 0, draws: 0, bio_history: [], owner_id: currentUser.id, owner_name: currentUser.username, lineage: null })
+      // Set group memberships after the combatant row exists
+      if (groupIds.length) await setCombatantGroups(id, groupIds, currentUser.id)
+      onSave({ id, name: name.trim(), bio: bio.trim(), tags, groupIds, status, source: 'created', wins: 0, losses: 0, draws: 0, bio_history: [], owner_id: currentUser.id, owner_name: currentUser.username, lineage: null })
     }
     setSaving(false)
   }
@@ -109,7 +176,7 @@ function CombatantForm({ existing, onSave, onCancel, currentUser }) {
         autoFocus={!isEdit}
       />
 
-      <label style={lbl}>Bio *</label>
+      <label style={lbl}>Bio</label>
       <textarea
         style={{ ...inp(), minHeight: 80, resize: 'vertical', fontFamily: 'var(--font-sans)' }}
         placeholder="Give them a line. Even one sentence."
@@ -117,11 +184,19 @@ function CombatantForm({ existing, onSave, onCancel, currentUser }) {
         onChange={e => { setBio(e.target.value); setError(''); setConfirm(false) }}
         maxLength={500}
       />
+      {!bio.trim() && (
+        <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '-8px 0 12px' }}>
+          No bio yet — you can add one before they fight.
+        </p>
+      )}
 
       <label style={lbl}>Tags</label>
       <div style={{ marginBottom: 12 }}>
         <TagInput value={tags} onChange={setTags} />
       </div>
+
+      <label style={lbl}>Groups</label>
+      <GroupPicker selectedIds={groupIds} onChange={setGroupIds} ownerId={currentUser.id} />
 
       {!isEdit && (
         <div style={{ marginBottom: 16 }}>
@@ -131,7 +206,7 @@ function CombatantForm({ existing, onSave, onCancel, currentUser }) {
               onClick={() => setStatus('stashed')}
               style={{ ...tab(status === 'stashed'), fontSize: 13, padding: '6px 14px' }}
             >
-              🔒 Stash (private)
+              Stash (private)
             </button>
             <button
               onClick={() => setStatus('published')}

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -673,6 +673,54 @@ export async function getPlayerRooms(playerId) {
 // query layer: stashed rows are only fetched when querying with the owner's userId.
 // (See auth note in backlog.md — RLS policies can't use auth.uid() with PIN auth.)
 
+// ─── Group helpers (used by Create-a-Combatant group picker) ─────────────────
+
+// Fetch all groups available to a user for the group picker:
+// their own groups (any status) plus any published groups not already included.
+// Returns array of { id, name, owner_id }.
+export async function getGroupsForPicker(ownerId) {
+  try {
+    const { data, error } = await supabase
+      .from('groups')
+      .select('id, name, owner_id, status')
+      .or(`owner_id.eq.${ownerId},status.eq.published`)
+      .order('name', { ascending: true })
+    if (error) { console.error('getGroupsForPicker error', error); return [] }
+    // Dedupe by id (owner's stashed groups may also be published)
+    const seen = new Set()
+    return (data || []).filter(g => { if (seen.has(g.id)) return false; seen.add(g.id); return true })
+  } catch (e) { console.error('getGroupsForPicker exception', e); return [] }
+}
+
+// Fetch group_ids for a combatant — used when opening the edit form.
+export async function getCombatantGroupIds(combatantId) {
+  try {
+    const { data, error } = await supabase
+      .from('combatant_groups')
+      .select('group_id')
+      .eq('combatant_id', combatantId)
+    if (error) { console.error('getCombatantGroupIds error', error); return [] }
+    return (data || []).map(r => r.group_id)
+  } catch (e) { console.error('getCombatantGroupIds exception', e); return [] }
+}
+
+// Replace all group memberships for a combatant.
+// Deletes existing rows, then inserts the new set. addedBy is the userId.
+export async function setCombatantGroups(combatantId, groupIds, addedBy) {
+  try {
+    const { error: delErr } = await supabase
+      .from('combatant_groups')
+      .delete()
+      .eq('combatant_id', combatantId)
+    if (delErr) { console.error('setCombatantGroups delete error', delErr); return false }
+    if (!groupIds.length) return true
+    const rows = groupIds.map(group_id => ({ combatant_id: combatantId, group_id, added_by: addedBy }))
+    const { error: insErr } = await supabase.from('combatant_groups').insert(rows)
+    if (insErr) console.error('setCombatantGroups insert error', insErr)
+    return !insErr
+  } catch (e) { console.error('setCombatantGroups exception', e); return false }
+}
+
 // Create a new combatant from The Workshop.
 // Status defaults to 'stashed' unless the caller explicitly passes 'published'.
 export async function createWorkshopCombatant({ id, name, bio, tags = [], ownerId, ownerName, status = 'stashed' }) {
@@ -729,8 +777,12 @@ export async function setWorkshopCombatantStatus(id, status) {
 
 // Delete a Workshop combatant. Only valid for stashed items — callers must
 // verify status === 'stashed' before calling. Published combatants are permanent.
+// Removes combatant_groups rows first (no cascade FK, so done at app level).
 export async function deleteWorkshopCombatant(id) {
   try {
+    // Clean up group memberships before deleting the combatant
+    const { error: grpErr } = await supabase.from('combatant_groups').delete().eq('combatant_id', id)
+    if (grpErr) console.error('deleteWorkshopCombatant group cleanup error', grpErr)
     const { error } = await supabase.from('combatants').delete().eq('id', id)
     if (error) console.error('deleteWorkshopCombatant error', error)
     return !error


### PR DESCRIPTION
Closes #10

## What changed

**`supabase.js` — three new group helpers:**
- `getGroupsForPicker(ownerId)` — returns the user's own groups plus all published groups (deduped), used to populate the group picker
- `getCombatantGroupIds(combatantId)` — returns the group IDs a combatant belongs to; used when opening the edit form
- `setCombatantGroups(combatantId, groupIds, addedBy)` — replaces all group memberships atomically (delete + insert); called on save
- Updated `deleteWorkshopCombatant` to clean up `combatant_groups` rows before deleting the combatant (no cascade FK)

**`WorkshopScreen.jsx` — group membership + bio tweak:**
- Added `GroupPicker` component — toggleable chip list of available groups; shows a dormant "no groups yet" message until groups are created in 1.2.x
- `CombatantForm` loads existing group memberships on edit open, tracks initial state via `useRef` so group-only changes enable the Save button
- Group memberships are saved/updated alongside the combatant on every save
- Bio is now optional at creation — a soft hint replaces the hard error. Combatants without a bio can be drafted; bio can be added before they fight

## Test notes
- Create a combatant with name only — should save with the "no bio yet" hint visible and no error
- Create a combatant with all fields filled — saves to stash or publishes per toggle
- Edit a combatant — fields pre-populate; Save is disabled until something changes
- Groups picker shows "No groups yet" (expected until 1.2.x Create-a-Group ships)
- Delete a stashed combatant — confirm it removes the row (combatant_groups cleanup is silent since there are no memberships yet)