### PR TITLE
The Workshop: draft autocomplete integration

### DIFF
--- a/src/components/FighterAutocomplete.jsx
+++ b/src/components/FighterAutocomplete.jsx
@@ -2,10 +2,20 @@ import { useState, useEffect } from 'react'
 import { inp } from '../styles.js'
 import { searchCombatants, getPlayerRecentCombatants } from '../supabase.js'
 
+const sectionHeader = (extra = {}) => ({
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  width: '100%', padding: '5px 12px 4px', fontSize: 10,
+  textTransform: 'uppercase', letterSpacing: '0.07em',
+  background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left',
+  ...extra,
+})
+
 export default function FighterAutocomplete({ value, onChange, onSelect, placeholder, playerId, substitutions = {}, pinnedItems = [], stashedItems = [] }) {
   const [open, setOpen] = useState(false)
   const [results, setResults] = useState([])
   const [recent, setRecent] = useState([])
+  const [championsOpen, setChampionsOpen] = useState(true)
+  const [stashOpen, setStashOpen] = useState(true)
 
   useEffect(() => {
     if (playerId) getPlayerRecentCombatants(playerId).then(setRecent)
@@ -24,42 +34,62 @@ export default function FighterAutocomplete({ value, onChange, onSelect, placeho
     const out = []
     for (const f of list) {
       const sub = substitutions[f.id]
-      const resolved = sub ? { ...sub, _evolvedFrom: f.name, _isStashed: f._isStashed } : f
+      const resolved = sub ? { ...sub, _evolvedFrom: f.name } : f
       if (!seen.has(resolved.id)) { seen.add(resolved.id); out.push(resolved) }
     }
     return out
   }
 
-  // Mark stashed items so they survive resolveItems and can be styled distinctly
-  const markedStashed = stashedItems.map(s => ({ ...s, _isStashed: true }))
+  const q = value.trim().toLowerCase()
 
-  const filteredPinned = value.trim()
-    ? pinnedItems.filter(p => p.name.toLowerCase().includes(value.trim().toLowerCase()))
+  const filteredPinned = q
+    ? pinnedItems.filter(p => p.name.toLowerCase().includes(q))
     : pinnedItems
 
-  const filteredStashed = value.trim()
-    ? markedStashed.filter(s => s.name.toLowerCase().includes(value.trim().toLowerCase()))
-    : markedStashed
+  const filteredStashed = q
+    ? stashedItems.filter(s => s.name.toLowerCase().includes(q))
+    : stashedItems
 
   const dbItems = value.trim() ? results : recent
 
-  // Build the item list in section order: champions → stash → recent/search
-  // Each later section deduplicates against all earlier ones.
+  // Cross-section deduplication: later sections exclude IDs already shown earlier
   const stashedDeduped = filteredStashed.filter(s => !filteredPinned.some(p => p.id === s.id))
-  const rawItems = [
-    ...filteredPinned,
-    ...stashedDeduped,
-    ...dbItems.filter(d => !filteredPinned.some(p => p.id === d.id) && !stashedDeduped.some(s => s.id === d.id)),
-  ]
-  const items = resolveItems(rawItems)
+  const dbDeduped = dbItems.filter(d =>
+    !filteredPinned.some(p => p.id === d.id) &&
+    !filteredStashed.some(s => s.id === d.id)
+  )
 
-  const showPinnedHeader  = !value.trim() && filteredPinned.length > 0
-  const showStashedHeader = !value.trim() && stashedDeduped.length > 0
-  const showRecentHeader  = !value.trim() && dbItems.length > 0
+  const resolvedPinned  = resolveItems(filteredPinned)
+  const resolvedStashed = resolveItems(stashedDeduped)
+  const resolvedDb      = resolveItems(dbDeduped)
 
-  // Section boundary indices (used to place section headers)
-  const stashedStart = filteredPinned.length
-  const recentStart  = stashedStart + stashedDeduped.length
+  const hasAny = resolvedPinned.length > 0 || resolvedStashed.length > 0 || resolvedDb.length > 0
+
+  function renderItem(f, { isPinned = false, isStashed = false } = {}) {
+    return (
+      <button key={f.id} onMouseDown={() => { onSelect(f); setOpen(false) }}
+        style={{ display: 'block', width: '100%', textAlign: 'left', padding: '9px 12px',
+          background: isPinned ? 'var(--color-background-success)' : isStashed ? 'var(--color-background-tertiary)' : 'transparent',
+          border: 'none', borderTop: '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ fontSize: 14, fontWeight: 500, color: isPinned ? 'var(--color-text-success)' : 'var(--color-text-primary)' }}>
+            {f.name}
+          </span>
+          {isStashed && (
+            <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)', flexShrink: 0 }}>
+              🔒 stashed
+            </span>
+          )}
+        </div>
+        {f._evolvedFrom && (
+          <div style={{ fontSize: 10, color: 'var(--color-text-info)', marginTop: 1 }}>↗ evolved from {f._evolvedFrom}</div>
+        )}
+        <div style={{ fontSize: 11, color: isPinned ? 'var(--color-text-success)' : 'var(--color-text-tertiary)', marginTop: 1 }}>
+          {f.wins}W – {f.losses}L · {f.owner_name || ''}{f.bio ? ` · ${f.bio.slice(0, 40)}${f.bio.length > 40 ? '…' : ''}` : ''}
+        </div>
+      </button>
+    )
+  }
 
   return (
     <div style={{ position: 'relative', flex: 1 }}>
@@ -71,46 +101,56 @@ export default function FighterAutocomplete({ value, onChange, onSelect, placeho
         onFocus={() => setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 160)}
       />
-      {open && items.length > 0 && (
-        <div style={{ position: 'absolute', top: 'calc(100% + 2px)', left: 0, right: 0, background: 'var(--color-background-primary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', zIndex: 200, overflow: 'hidden', boxShadow: '0 6px 18px rgba(0,0,0,0.18)' }}>
-          {showPinnedHeader && <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-success)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>🏆 Champions from last game</div>}
-          {items.map((f, idx) => {
-            const isPinned  = filteredPinned.some(p => p.id === f.id)
-            const isStashed = !!f._isStashed
-            const isFirstStashed = showStashedHeader && idx === stashedStart
-            const isFirstRecent  = showRecentHeader  && idx === recentStart
-            return (
-              <div key={f.id}>
-                {isFirstStashed && (
-                  <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', borderTop: filteredPinned.length > 0 ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
-                    🔒 Your stash
-                  </div>
-                )}
-                {isFirstRecent && (
-                  <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', borderTop: (filteredPinned.length > 0 || stashedDeduped.length > 0) ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
-                    Your recent fighters
-                  </div>
-                )}
-                <button onMouseDown={() => { onSelect(f); setOpen(false) }}
-                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '9px 12px', background: isPinned ? 'var(--color-background-success)' : isStashed ? 'var(--color-background-tertiary)' : 'transparent', border: 'none', borderTop: '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                    <span style={{ fontSize: 14, fontWeight: 500, color: isPinned ? 'var(--color-text-success)' : 'var(--color-text-primary)' }}>{f.name}</span>
-                    {isStashed && !isPinned && (
-                      <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)', flexShrink: 0 }}>
-                        🔒 stashed
-                      </span>
-                    )}
-                  </div>
-                  {f._evolvedFrom && (
-                    <div style={{ fontSize: 10, color: 'var(--color-text-info)', marginTop: 1 }}>↗ evolved from {f._evolvedFrom}</div>
-                  )}
-                  <div style={{ fontSize: 11, color: isPinned ? 'var(--color-text-success)' : 'var(--color-text-tertiary)', marginTop: 1 }}>
-                    {f.wins}W – {f.losses}L · {f.owner_name || ''}{f.bio ? ` · ${f.bio.slice(0, 40)}${f.bio.length > 40 ? '…' : ''}` : ''}
-                  </div>
-                </button>
-              </div>
-            )
-          })}
+      {open && hasAny && (
+        <div style={{ position: 'absolute', top: 'calc(100% + 2px)', left: 0, right: 0,
+          background: 'var(--color-background-primary)', border: '0.5px solid var(--color-border-secondary)',
+          borderRadius: 'var(--border-radius-md)', zIndex: 200, overflow: 'hidden',
+          boxShadow: '0 6px 18px rgba(0,0,0,0.18)' }}>
+
+          {/* Champions section — collapsible */}
+          {resolvedPinned.length > 0 && (
+            <>
+              <button
+                onMouseDown={e => { e.preventDefault(); setChampionsOpen(v => !v) }}
+                style={sectionHeader({ color: 'var(--color-text-success)' })}
+              >
+                <span>🏆 Champions from last game</span>
+                <span>{championsOpen ? '▾' : '▸'}</span>
+              </button>
+              {championsOpen && resolvedPinned.map(f => renderItem(f, { isPinned: true }))}
+            </>
+          )}
+
+          {/* Stash section — collapsible with count */}
+          {resolvedStashed.length > 0 && (
+            <>
+              <button
+                onMouseDown={e => { e.preventDefault(); setStashOpen(v => !v) }}
+                style={sectionHeader({
+                  color: 'var(--color-text-tertiary)',
+                  borderTop: resolvedPinned.length > 0 ? '0.5px solid var(--color-border-tertiary)' : 'none',
+                })}
+              >
+                <span>🔒 Your stash ({resolvedStashed.length})</span>
+                <span>{stashOpen ? '▾' : '▸'}</span>
+              </button>
+              {stashOpen && resolvedStashed.map(f => renderItem(f, { isStashed: true }))}
+            </>
+          )}
+
+          {/* Recent fighters / search results — not collapsible */}
+          {resolvedDb.length > 0 && (
+            <>
+              {!value.trim() && (
+                <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-tertiary)',
+                  textTransform: 'uppercase', letterSpacing: '0.07em',
+                  borderTop: (resolvedPinned.length > 0 || resolvedStashed.length > 0) ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
+                  Your recent fighters
+                </div>
+              )}
+              {resolvedDb.map(f => renderItem(f))}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/FighterAutocomplete.jsx
+++ b/src/components/FighterAutocomplete.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { inp } from '../styles.js'
 import { searchCombatants, getPlayerRecentCombatants } from '../supabase.js'
 
-export default function FighterAutocomplete({ value, onChange, onSelect, placeholder, playerId, substitutions = {}, pinnedItems = [] }) {
+export default function FighterAutocomplete({ value, onChange, onSelect, placeholder, playerId, substitutions = {}, pinnedItems = [], stashedItems = [] }) {
   const [open, setOpen] = useState(false)
   const [results, setResults] = useState([])
   const [recent, setRecent] = useState([])
@@ -24,22 +24,42 @@ export default function FighterAutocomplete({ value, onChange, onSelect, placeho
     const out = []
     for (const f of list) {
       const sub = substitutions[f.id]
-      const resolved = sub ? { ...sub, _evolvedFrom: f.name } : f
+      const resolved = sub ? { ...sub, _evolvedFrom: f.name, _isStashed: f._isStashed } : f
       if (!seen.has(resolved.id)) { seen.add(resolved.id); out.push(resolved) }
     }
     return out
   }
 
-  // When empty, show pinned prevWinners first, then recent DB combatants (deduped).
-  // When typing, filter pinned items by name match before DB results.
+  // Mark stashed items so they survive resolveItems and can be styled distinctly
+  const markedStashed = stashedItems.map(s => ({ ...s, _isStashed: true }))
+
   const filteredPinned = value.trim()
     ? pinnedItems.filter(p => p.name.toLowerCase().includes(value.trim().toLowerCase()))
     : pinnedItems
+
+  const filteredStashed = value.trim()
+    ? markedStashed.filter(s => s.name.toLowerCase().includes(value.trim().toLowerCase()))
+    : markedStashed
+
   const dbItems = value.trim() ? results : recent
-  const rawItems = [...filteredPinned, ...dbItems.filter(d => !filteredPinned.some(p => p.id === d.id))]
+
+  // Build the item list in section order: champions → stash → recent/search
+  // Each later section deduplicates against all earlier ones.
+  const stashedDeduped = filteredStashed.filter(s => !filteredPinned.some(p => p.id === s.id))
+  const rawItems = [
+    ...filteredPinned,
+    ...stashedDeduped,
+    ...dbItems.filter(d => !filteredPinned.some(p => p.id === d.id) && !stashedDeduped.some(s => s.id === d.id)),
+  ]
   const items = resolveItems(rawItems)
-  const showPinnedHeader = !value.trim() && filteredPinned.length > 0
-  const showRecentHeader = !value.trim() && dbItems.length > 0
+
+  const showPinnedHeader  = !value.trim() && filteredPinned.length > 0
+  const showStashedHeader = !value.trim() && stashedDeduped.length > 0
+  const showRecentHeader  = !value.trim() && dbItems.length > 0
+
+  // Section boundary indices (used to place section headers)
+  const stashedStart = filteredPinned.length
+  const recentStart  = stashedStart + stashedDeduped.length
 
   return (
     <div style={{ position: 'relative', flex: 1 }}>
@@ -55,14 +75,32 @@ export default function FighterAutocomplete({ value, onChange, onSelect, placeho
         <div style={{ position: 'absolute', top: 'calc(100% + 2px)', left: 0, right: 0, background: 'var(--color-background-primary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', zIndex: 200, overflow: 'hidden', boxShadow: '0 6px 18px rgba(0,0,0,0.18)' }}>
           {showPinnedHeader && <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-success)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>🏆 Champions from last game</div>}
           {items.map((f, idx) => {
-            const isPinned = filteredPinned.some(p => p.id === f.id)
-            const isFirstRecent = !value.trim() && showRecentHeader && idx === filteredPinned.length
+            const isPinned  = filteredPinned.some(p => p.id === f.id)
+            const isStashed = !!f._isStashed
+            const isFirstStashed = showStashedHeader && idx === stashedStart
+            const isFirstRecent  = showRecentHeader  && idx === recentStart
             return (
               <div key={f.id}>
-                {isFirstRecent && <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', borderTop: filteredPinned.length > 0 ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>Your recent fighters</div>}
+                {isFirstStashed && (
+                  <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', borderTop: filteredPinned.length > 0 ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
+                    🔒 Your stash
+                  </div>
+                )}
+                {isFirstRecent && (
+                  <div style={{ padding: '5px 12px 3px', fontSize: 10, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', borderTop: (filteredPinned.length > 0 || stashedDeduped.length > 0) ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
+                    Your recent fighters
+                  </div>
+                )}
                 <button onMouseDown={() => { onSelect(f); setOpen(false) }}
-                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '9px 12px', background: isPinned ? 'var(--color-background-success)' : 'transparent', border: 'none', borderTop: '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}>
-                  <div style={{ fontSize: 14, fontWeight: 500, color: isPinned ? 'var(--color-text-success)' : 'var(--color-text-primary)' }}>{f.name}</div>
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '9px 12px', background: isPinned ? 'var(--color-background-success)' : isStashed ? 'var(--color-background-tertiary)' : 'transparent', border: 'none', borderTop: '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ fontSize: 14, fontWeight: 500, color: isPinned ? 'var(--color-text-success)' : 'var(--color-text-primary)' }}>{f.name}</span>
+                    {isStashed && !isPinned && (
+                      <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)', flexShrink: 0 }}>
+                        🔒 stashed
+                      </span>
+                    )}
+                  </div>
                   {f._evolvedFrom && (
                     <div style={{ fontSize: 10, color: 'var(--color-text-info)', marginTop: 1 }}>↗ evolved from {f._evolvedFrom}</div>
                   )}

--- a/src/screens/DraftScreen.jsx
+++ b/src/screens/DraftScreen.jsx
@@ -6,7 +6,7 @@ import DevBanner from '../components/DevBanner.jsx'
 import FighterAutocomplete from '../components/FighterAutocomplete.jsx'
 import CombatantStatsPill from '../components/CombatantStatsPill.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, upsertGlobalCombatant, subscribeToRoom, getHeritageChain, getCombatantsByIds } from '../supabase.js'
+import { sget, sset, upsertGlobalCombatant, subscribeToRoom, getHeritageChain, getCombatantsByIds, getPlayerStashedCombatants } from '../supabase.js'
 import {
   ownerLabel, slotMatchesPrevWinner, areAllPrevWinnersPlaced,
   getUnplacedWinners, buildCombatantFromDraft, isDraftComplete,
@@ -19,6 +19,8 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
   const { rosterSize } = normalizeRoomSettings(init.settings)
   // substitutions: { [originalId]: combatant } — active-form overrides for heritage games
   const [substitutions, setSubstitutions] = useState({})
+  // stashedCombatants: logged-in player's private stash — shown only in their own autocomplete
+  const [stashedCombatants, setStashedCombatants] = useState([])
   const myPlayer = room.players.find(p => p.id === playerId)
   const existing = room.combatants[playerId] || []
   const savedDraft = existing.length === 0 ? (room.drafts?.[playerId] ?? null) : null
@@ -95,6 +97,12 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
       setSubstitutions(subs)
     })
   }, [init.prevRoomId])
+
+  // Fetch the player's stashed combatants so they appear in their own autocomplete.
+  // Guests have no stash, so skip if isGuest.
+  useEffect(() => {
+    if (!isGuest && playerId) getPlayerStashedCombatants(playerId).then(setStashedCombatants)
+  }, [playerId, isGuest])
 
   const biosRequired = normalizeRoomSettings(room.settings).biosRequired
   const myPrevWinners = room.prevWinners?.[playerId] || []
@@ -269,6 +277,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
                 playerId={playerId}
                 substitutions={substitutions}
                 pinnedItems={myPrevWinners.map(w => ({ ...w, wins: w.wins || 0, losses: w.losses || 0, owner_name: myPlayer?.name || '' }))}
+                stashedItems={stashedCombatants}
               />
               {isPrevWinnerSlot && globalIds[i] && (
                 <CombatantStatsPill globalId={globalIds[i]} label="🏆 champion" pillStyle={{ background: 'var(--color-background-success)', color: 'var(--color-text-success)', border: '0.5px solid var(--color-border-success)' }} />

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -374,6 +374,20 @@ export async function getPlayerRecentCombatants(ownerId, limit = 8) {
   } catch (e) { console.error('getPlayerRecentCombatants exception', e); return [] }
 }
 
+// Player's stashed (private) combatants — shown only to the owner in their own draft autocomplete
+export async function getPlayerStashedCombatants(ownerId, limit = 20) {
+  try {
+    const { data, error } = await supabase
+      .from('combatants').select('id, name, bio, wins, losses, owner_name')
+      .eq('owner_id', ownerId)
+      .eq('status', 'stashed')
+      .order('updated_at', { ascending: false })
+      .limit(limit)
+    if (error) { console.error('getPlayerStashedCombatants error', error); return [] }
+    return data || []
+  } catch (e) { console.error('getPlayerStashedCombatants exception', e); return [] }
+}
+
 // ─── Lineage / variant combatants ────────────────────────────────────────────
 
 // Insert a new variant combatant. lineage = { rootId, parentId, generation, bornFrom }.

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -374,13 +374,16 @@ export async function getPlayerRecentCombatants(ownerId, limit = 8) {
   } catch (e) { console.error('getPlayerRecentCombatants exception', e); return [] }
 }
 
-// Player's stashed (private) combatants — shown only to the owner in their own draft autocomplete
+// Player's stashed Workshop combatants — shown only to the owner in their own draft autocomplete.
+// Scoped to source='created' so game-played combatants (which default to 'stashed' until
+// publish-on-game-completion runs) are not included.
 export async function getPlayerStashedCombatants(ownerId, limit = 20) {
   try {
     const { data, error } = await supabase
       .from('combatants').select('id, name, bio, wins, losses, owner_name')
       .eq('owner_id', ownerId)
       .eq('status', 'stashed')
+      .eq('source', 'created')
       .order('updated_at', { ascending: false })
       .limit(limit)
     if (error) { console.error('getPlayerStashedCombatants error', error); return [] }


### PR DESCRIPTION
Closes #11

## What changed
- **`supabase.js`** — added `getPlayerStashedCombatants(ownerId)`, scoped to `source='created'` so only Workshop-created combatants appear. Game-played combatants default to `status='stashed'` until #12 (publish-on-game-completion) ships, so without this filter they'd all show the lock badge.
- **`FighterAutocomplete`** — restructured dropdown into three explicit sections (champions, stash, recent). Champions and stash sections are collapsible with a ▾/▸ toggle. Stash header shows a count — `🔒 Your stash (3)` — so the count is visible even when collapsed. Section headers use `onMouseDown + e.preventDefault()` to keep the input focused while toggling.
- **`DraftScreen`** — fetches the current player's stashed Workshop combatants on mount (skipped for guests) and passes them to each `FighterAutocomplete` slot as `stashedItems`. Other players' slots receive an empty array so they never see the stash.

## Test notes
- Log in, create combatants in the Workshop as stashed (not published), then start or join a draft
- Focus a name slot — stash section should appear with count, collapsible
- Collapse the stash section — count remains visible in the header as a reminder
- Champions section (prev winners in a series game) should also be collapsible
- Second player in the same draft should see no stash section at all
- Guests should see no stash section
- Previously used game combatants (not created in Workshop) should NOT appear in the stash section