### PR TITLE
The Workshop: publish-on-game-completion

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -508,6 +508,25 @@ export function isFinalRound(room) {
   return total > 0 && room.currentRound >= total
 }
 
+/**
+ * Returns the deduplicated set of combatant IDs to publish when a game completes.
+ * Includes every combatant from players who submitted a full roster, plus any
+ * evolution variants created during the game. Stash/publish status is not checked
+ * here — the caller (publishCombatants) performs the DB update unconditionally, which
+ * is a no-op for already-published combatants.
+ *
+ * combatants — room.combatants map: { [playerId]: [combatant, ...] }
+ * rounds     — resolved rounds array (should include the current round's result)
+ * rosterSize — expected number of combatants per player
+ */
+export function getCombatantsToPublish(combatants, rounds, rosterSize) {
+  const rosterIds  = Object.values(combatants)
+    .filter(list => list.length === rosterSize)
+    .flat().map(c => c.id)
+  const variantIds = rounds.filter(r => r.evolution).map(r => r.evolution.toId)
+  return [...new Set([...rosterIds, ...variantIds])]
+}
+
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
 /**

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -29,6 +29,7 @@ import {
   buildEvolutionRound,
   getEphemeralBadges,
   computeSuperlatives,
+  getCombatantsToPublish,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -372,6 +373,56 @@ describe('isFinalRound', () => {
     const room = makeRoom({ currentRound: 5 })
     room.combatants.p2 = room.combatants.p2.slice(0, 5)
     expect(isFinalRound(room)).toBe(true)
+  })
+})
+
+// ─── getCombatantsToPublish ───────────────────────────────────────────────────
+
+describe('getCombatantsToPublish', () => {
+  const roster = (ids) => ids.map(id => ({ id }))
+
+  it('returns all roster combatant IDs for a full-roster game', () => {
+    const combatants = { p1: roster(['a', 'b']), p2: roster(['c', 'd']) }
+    const result = getCombatantsToPublish(combatants, [], 2)
+    expect(result.sort()).toEqual(['a', 'b', 'c', 'd'].sort())
+  })
+
+  it('excludes players who submitted a partial roster (force-start case)', () => {
+    const combatants = { p1: roster(['a', 'b']), p2: roster(['c']) }
+    const result = getCombatantsToPublish(combatants, [], 2)
+    expect(result.sort()).toEqual(['a', 'b'].sort())
+  })
+
+  it('includes variant IDs from evolution rounds', () => {
+    const combatants = { p1: roster(['a']), p2: roster(['b']) }
+    const rounds = [{ evolution: { toId: 'a2' } }]
+    const result = getCombatantsToPublish(combatants, rounds, 1)
+    expect(result.sort()).toEqual(['a', 'a2', 'b'].sort())
+  })
+
+  it('deduplicates IDs appearing in both roster and variants', () => {
+    const combatants = { p1: roster(['a']), p2: roster(['b']) }
+    const rounds = [{ evolution: { toId: 'a' } }]
+    const result = getCombatantsToPublish(combatants, rounds, 1)
+    expect(result.filter(id => id === 'a').length).toBe(1)
+  })
+
+  it('skips rounds without evolution', () => {
+    const combatants = { p1: roster(['a']), p2: roster(['b']) }
+    const rounds = [{ winner: { id: 'a' } }, { evolution: { toId: 'b2' } }]
+    const result = getCombatantsToPublish(combatants, rounds, 1)
+    expect(result.sort()).toEqual(['a', 'b', 'b2'].sort())
+  })
+
+  it('returns empty array when combatants is empty', () => {
+    expect(getCombatantsToPublish({}, [], 2)).toEqual([])
+  })
+
+  it('Workshop combatants (stashed, source=created) are included by ID like any other', () => {
+    const workshopId = 'workshop-combatant-id'
+    const combatants = { p1: roster([workshopId, 'regular-id']) }
+    const result = getCombatantsToPublish(combatants, [], 2)
+    expect(result.sort()).toEqual(['regular-id', workshopId].sort())
   })
 })
 

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -9,7 +9,7 @@ import { btn, inp } from '../styles.js'
 import { sget, sset, incrementCombatantStats, publishCombatants, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
-import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges } from '../gameLogic.js'
+import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish } from '../gameLogic.js'
 
 export default function VoteScreen({ room: init, playerId, setRoom, onResult, onViewPlayer, onHome, isGuest, onLogin }) {
   const [room, setLocal] = useState(init)
@@ -107,11 +107,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       }
       if (isFinalRound(r)) {
         const { rosterSize } = normalizeRoomSettings(r.settings)
-        const rosterIds  = Object.values(r.combatants)
-          .filter(list => list.length === rosterSize)
-          .flat().map(c => c.id)
-        const variantIds = (r.rounds || []).filter(rd => rd.evolution).map(rd => rd.evolution.toId)
-        await publishCombatants([...new Set([...rosterIds, ...variantIds])])
+        await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
       }
     })()
   }
@@ -152,11 +148,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       }
       if (isFinalRound(r)) {
         const { rosterSize } = normalizeRoomSettings(r.settings)
-        const rosterIds  = Object.values(combatants)
-          .filter(list => list.length === rosterSize)
-          .flat().map(c => c.id)
-        const variantIds = rounds.filter(rd => rd.evolution).map(rd => rd.evolution.toId)
-        await publishCombatants([...new Set([...rosterIds, ...variantIds])])
+        await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
       }
     })()
   }
@@ -261,13 +253,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       }
       if (isFinalRound(r)) {
         const { rosterSize } = normalizeRoomSettings(r.settings)
-        const rosterIds  = Object.values(finalCombatants)
-          .filter(list => list.length === rosterSize)
-          .flat().map(c => c.id)
-        // Also publish any variants created during this game — they were never
-        // in the roster so they won't appear in rosterIds
-        const variantIds = rounds.filter(rd => rd.evolution).map(rd => rd.evolution.toId)
-        await publishCombatants([...new Set([...rosterIds, ...variantIds])])
+        await publishCombatants(getCombatantsToPublish(finalCombatants, rounds, rosterSize))
       }
     })()
   }


### PR DESCRIPTION
Closes #12

## What changed

- Added `getCombatantsToPublish(combatants, rounds, rosterSize)` to `gameLogic.js` — a pure function that computes the deduplicated set of combatant IDs to publish when a game completes. Includes all players who submitted full rosters (handles force-start partial rosters correctly) and all evolution variant IDs from the rounds array.
- Refactored VoteScreen's three round-outcome paths (confirm win, declare draw, evolution) to use the helper instead of the same inline logic duplicated three times.
- Added 7 unit tests covering: full rosters, partial rosters (force-start), variants, deduplication, rounds without evolution, empty combatants, and Workshop combatants (stashed, source=created) appearing by their existing ID.

## Behavior

Stashed combatants — both Workshop-created (source='created') and game-entered (source='game') — are published when the final round is confirmed. This fires in all three resolution paths: win, draw, and win-with-evolution. If a game is abandoned before the final round, no publish call is made and stashed combatants remain stashed. The publishCombatants DB call is a no-op for already-published combatants.

## Test notes

Run `npm test` — all 306 tests pass including the 7 new getCombatantsToPublish cases.