### PR TITLE
Partial draw support: applyDraw + undoRound

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -359,24 +359,30 @@ export function applyWinner(room, round, winnerId) {
 }
 
 /**
- * Both combatants drew — increments draws for each and appends round records.
+ * Applies draw (and optional partial loss) outcomes and appends round records.
+ * round.draw === true  → all combatants in round.combatants drew (legacy).
+ * round.draw.combatantIds → those ids drew; remaining combatants in round took a loss.
  * Does NOT mutate the input — returns a new deep-copied map.
  */
 export function applyDraw(room, round) {
   const combatants = JSON.parse(JSON.stringify(room.combatants))
+  const isLegacy = !round.draw || round.draw === true
+  const drawIds  = isLegacy ? null : (round.draw?.combatantIds ?? [])
 
   Object.keys(combatants).forEach(pid => {
     combatants[pid] = combatants[pid].map(c => {
       if (!round.combatants.find(rc => rc.id === c.id)) return c
+      const drew = isLegacy || drawIds.includes(c.id)
       return {
         ...c,
-        draws: (c.draws || 0) + 1,
+        draws:  drew ? (c.draws  || 0) + 1 : (c.draws  || 0),
+        losses: drew ? (c.losses || 0)     : (c.losses || 0) + 1,
         battles: [
           ...(c.battles || []),
           {
             roundId:  round.id,
             opponent: round.combatants.filter(rc => rc.id !== c.id).map(rc => rc.name).join(', '),
-            result:   'draw',
+            result:   drew ? 'draw' : 'loss',
           },
         ],
       }
@@ -398,9 +404,13 @@ export function undoRound(room, round) {
     combatants[pid] = combatants[pid].map(c => {
       if (!round.combatants.find(rc => rc.id === c.id)) return c
       if (round.draw) {
+        const isLegacy = round.draw === true  // object draw is always non-legacy
+        const drawIds  = isLegacy ? null : (round.draw?.combatantIds ?? [])
+        const drew     = isLegacy || drawIds.includes(c.id)
         return {
           ...c,
-          draws:   Math.max(0, (c.draws || 0) - 1),
+          draws:   drew ? Math.max(0, (c.draws  || 0) - 1) : (c.draws  || 0),
+          losses:  drew ? (c.losses || 0) : Math.max(0, (c.losses || 0) - 1),
           battles: (c.battles || []).filter(b => b.roundId !== round.id),
         }
       }

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -1794,6 +1794,132 @@ describe('canUndoLastRound (draw)', () => {
   })
 })
 
+// ─── applyDraw partial draw ───────────────────────────────────────────────────
+
+describe('applyDraw (partial draw)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', name: 'A', wins: 0, losses: 0, draws: 0, battles: [] }],
+      p2: [{ id: 'c2', name: 'B', wins: 0, losses: 0, draws: 0, battles: [] }],
+      p3: [{ id: 'c3', name: 'C', wins: 0, losses: 0, draws: 0, battles: [] }],
+    },
+  }
+  const round = {
+    id: 'r1',
+    draw: { combatantIds: ['c1', 'c2'] },
+    combatants: [
+      { id: 'c1', name: 'A', ownerId: 'p1' },
+      { id: 'c2', name: 'B', ownerId: 'p2' },
+      { id: 'c3', name: 'C', ownerId: 'p3' },
+    ],
+  }
+
+  it('increments draws only for combatants in combatantIds', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].draws).toBe(1)
+    expect(result.p2[0].draws).toBe(1)
+    expect(result.p3[0].draws).toBe(0)
+  })
+
+  it('increments losses for combatants not in combatantIds', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].losses).toBe(0)
+    expect(result.p2[0].losses).toBe(0)
+    expect(result.p3[0].losses).toBe(1)
+  })
+
+  it('appends draw battle records for drawers and loss record for the rest', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].battles[0]).toMatchObject({ roundId: 'r1', result: 'draw' })
+    expect(result.p2[0].battles[0]).toMatchObject({ roundId: 'r1', result: 'draw' })
+    expect(result.p3[0].battles[0]).toMatchObject({ roundId: 'r1', result: 'loss' })
+  })
+
+  it('does not mutate input', () => {
+    const original = JSON.parse(JSON.stringify(room))
+    applyDraw(room, round)
+    expect(room).toEqual(original)
+  })
+})
+
+describe('applyDraw (legacy boolean)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', name: 'A', wins: 0, losses: 2, draws: 0, battles: [] }],
+      p2: [{ id: 'c2', name: 'B', wins: 0, losses: 1, draws: 0, battles: [] }],
+    },
+  }
+  const round = {
+    id: 'r1',
+    draw: true,
+    combatants: [{ id: 'c1', name: 'A', ownerId: 'p1' }, { id: 'c2', name: 'B', ownerId: 'p2' }],
+  }
+
+  it('increments draws for all combatants and does not touch losses', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].draws).toBe(1)
+    expect(result.p2[0].draws).toBe(1)
+    expect(result.p1[0].losses).toBe(2)
+    expect(result.p2[0].losses).toBe(1)
+  })
+})
+
+describe('undoRound (partial draw)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', draws: 1, losses: 0, battles: [{ roundId: 'r1', result: 'draw' }] }],
+      p2: [{ id: 'c2', draws: 1, losses: 0, battles: [{ roundId: 'r1', result: 'draw' }] }],
+      p3: [{ id: 'c3', draws: 0, losses: 1, battles: [{ roundId: 'r1', result: 'loss' }] }],
+    },
+  }
+  const round = {
+    id: 'r1',
+    draw: { combatantIds: ['c1', 'c2'] },
+    combatants: [
+      { id: 'c1', ownerId: 'p1' },
+      { id: 'c2', ownerId: 'p2' },
+      { id: 'c3', ownerId: 'p3' },
+    ],
+  }
+
+  it('decrements draws for drawers and losses for the rest', () => {
+    const result = undoRound(room, round)
+    expect(result.p1[0].draws).toBe(0)
+    expect(result.p2[0].draws).toBe(0)
+    expect(result.p3[0].losses).toBe(0)
+  })
+
+  it('does not decrement draws for the loser', () => {
+    const result = undoRound(room, round)
+    expect(result.p3[0].draws).toBe(0)
+  })
+
+  it('does not decrement losses for drawers', () => {
+    const result = undoRound(room, round)
+    expect(result.p1[0].losses).toBe(0)
+    expect(result.p2[0].losses).toBe(0)
+  })
+
+  it('removes battle records for the round from all combatants', () => {
+    const result = undoRound(room, round)
+    expect(result.p1[0].battles).toHaveLength(0)
+    expect(result.p2[0].battles).toHaveLength(0)
+    expect(result.p3[0].battles).toHaveLength(0)
+  })
+
+  it('clamps losses to 0 never negative', () => {
+    const noLoss = {
+      combatants: {
+        p1: [{ id: 'c1', draws: 1, losses: 0, battles: [] }],
+        p2: [{ id: 'c2', draws: 1, losses: 0, battles: [] }],
+        p3: [{ id: 'c3', draws: 0, losses: 0, battles: [] }],
+      },
+    }
+    const result = undoRound(noLoss, round)
+    expect(result.p3[0].losses).toBe(0)
+  })
+})
+
 // ─── replacePlayerIdInRoom ────────────────────────────────────────────────────
 
 describe('replacePlayerIdInRoom', () => {


### PR DESCRIPTION
Closes #38

## What changed
- `applyDraw`: handles `round.draw.combatantIds` — drawers get `draws += 1`, non-drawers in the round get `losses += 1` and a `result: 'loss'` battle record. `round.draw === true` and `round.draw` absent both produce the original all-drew behavior (backward compat).
- `undoRound`: mirrors the same branching logic — decrements draws for drawers and losses for non-drawers; legacy boolean draw still decrements draws for everyone.

## Test notes
- All 316 existing tests continue to pass.
- Added `applyDraw (partial draw)` — verifies draws, losses, and battle records are split correctly.
- Added `applyDraw (legacy boolean)` — confirms losses are untouched when `draw: true`.
- Added `undoRound (partial draw)` — verifies each stat is reversed for the right combatants, clamped to 0.