### PR TITLE
Draw outcomes: no_advance vs all_advance

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -362,12 +362,15 @@ export function applyWinner(room, round, winnerId) {
  * Applies draw (and optional partial loss) outcomes and appends round records.
  * round.draw === true  → all combatants in round.combatants drew (legacy).
  * round.draw.combatantIds → those ids drew; remaining combatants in round took a loss.
+ * round.drawOutcome === 'all_advance' → drawers get wins instead of draws.
+ * round.drawOutcome === 'no_advance' (default/missing) → drawers get draws.
  * Does NOT mutate the input — returns a new deep-copied map.
  */
 export function applyDraw(room, round) {
   const combatants = JSON.parse(JSON.stringify(room.combatants))
-  const isLegacy = !round.draw || round.draw === true
-  const drawIds  = isLegacy ? null : (round.draw?.combatantIds ?? [])
+  const isLegacy   = !round.draw || round.draw === true
+  const drawIds    = isLegacy ? null : (round.draw?.combatantIds ?? [])
+  const allAdvance = round.drawOutcome === 'all_advance'
 
   Object.keys(combatants).forEach(pid => {
     combatants[pid] = combatants[pid].map(c => {
@@ -375,14 +378,15 @@ export function applyDraw(room, round) {
       const drew = isLegacy || drawIds.includes(c.id)
       return {
         ...c,
-        draws:  drew ? (c.draws  || 0) + 1 : (c.draws  || 0),
-        losses: drew ? (c.losses || 0)     : (c.losses || 0) + 1,
+        wins:   allAdvance && drew ? (c.wins   || 0) + 1 : (c.wins   || 0),
+        draws:  !allAdvance && drew ? (c.draws  || 0) + 1 : (c.draws  || 0),
+        losses: drew ? (c.losses || 0) : (c.losses || 0) + 1,
         battles: [
           ...(c.battles || []),
           {
             roundId:  round.id,
             opponent: round.combatants.filter(rc => rc.id !== c.id).map(rc => rc.name).join(', '),
-            result:   drew ? 'draw' : 'loss',
+            result:   drew ? (allAdvance ? 'win' : 'draw') : 'loss',
           },
         ],
       }
@@ -404,12 +408,14 @@ export function undoRound(room, round) {
     combatants[pid] = combatants[pid].map(c => {
       if (!round.combatants.find(rc => rc.id === c.id)) return c
       if (round.draw) {
-        const isLegacy = round.draw === true  // object draw is always non-legacy
-        const drawIds  = isLegacy ? null : (round.draw?.combatantIds ?? [])
-        const drew     = isLegacy || drawIds.includes(c.id)
+        const isLegacy   = round.draw === true  // object draw is always non-legacy
+        const drawIds    = isLegacy ? null : (round.draw?.combatantIds ?? [])
+        const drew       = isLegacy || drawIds.includes(c.id)
+        const allAdvance = round.drawOutcome === 'all_advance'
         return {
           ...c,
-          draws:   drew ? Math.max(0, (c.draws  || 0) - 1) : (c.draws  || 0),
+          wins:    allAdvance && drew ? Math.max(0, (c.wins   || 0) - 1) : (c.wins   || 0),
+          draws:   !allAdvance && drew ? Math.max(0, (c.draws  || 0) - 1) : (c.draws  || 0),
           losses:  drew ? (c.losses || 0) : Math.max(0, (c.losses || 0) - 1),
           battles: (c.battles || []).filter(b => b.roundId !== round.id),
         }

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -1920,6 +1920,147 @@ describe('undoRound (partial draw)', () => {
   })
 })
 
+// ─── drawOutcome: all_advance / no_advance ────────────────────────────────────
+
+describe('applyDraw (all_advance)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', name: 'A', wins: 0, losses: 0, draws: 0, battles: [] }],
+      p2: [{ id: 'c2', name: 'B', wins: 0, losses: 0, draws: 0, battles: [] }],
+    },
+  }
+  const round = {
+    id: 'r1',
+    draw: true,
+    drawOutcome: 'all_advance',
+    combatants: [{ id: 'c1', name: 'A', ownerId: 'p1' }, { id: 'c2', name: 'B', ownerId: 'p2' }],
+  }
+
+  it('increments wins (not draws) for all combatants', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].wins).toBe(1)
+    expect(result.p2[0].wins).toBe(1)
+    expect(result.p1[0].draws).toBe(0)
+    expect(result.p2[0].draws).toBe(0)
+  })
+
+  it('does not touch losses', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].losses).toBe(0)
+    expect(result.p2[0].losses).toBe(0)
+  })
+
+  it('appends win battle records', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].battles[0]).toMatchObject({ roundId: 'r1', result: 'win' })
+    expect(result.p2[0].battles[0]).toMatchObject({ roundId: 'r1', result: 'win' })
+  })
+})
+
+describe('applyDraw (no_advance default)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', name: 'A', wins: 0, losses: 0, draws: 0, battles: [] }],
+      p2: [{ id: 'c2', name: 'B', wins: 0, losses: 0, draws: 0, battles: [] }],
+    },
+  }
+
+  it('increments draws when drawOutcome is no_advance', () => {
+    const round = { id: 'r1', draw: true, drawOutcome: 'no_advance', combatants: [{ id: 'c1', name: 'A', ownerId: 'p1' }, { id: 'c2', name: 'B', ownerId: 'p2' }] }
+    const result = applyDraw(room, round)
+    expect(result.p1[0].draws).toBe(1)
+    expect(result.p1[0].wins).toBe(0)
+  })
+
+  it('increments draws when drawOutcome is absent (default)', () => {
+    const round = { id: 'r1', draw: true, combatants: [{ id: 'c1', name: 'A', ownerId: 'p1' }, { id: 'c2', name: 'B', ownerId: 'p2' }] }
+    const result = applyDraw(room, round)
+    expect(result.p1[0].draws).toBe(1)
+    expect(result.p1[0].wins).toBe(0)
+  })
+})
+
+describe('applyDraw (all_advance + partial draw)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', name: 'A', wins: 0, losses: 0, draws: 0, battles: [] }],
+      p2: [{ id: 'c2', name: 'B', wins: 0, losses: 0, draws: 0, battles: [] }],
+      p3: [{ id: 'c3', name: 'C', wins: 0, losses: 0, draws: 0, battles: [] }],
+    },
+  }
+  const round = {
+    id: 'r1',
+    draw: { combatantIds: ['c1', 'c2'] },
+    drawOutcome: 'all_advance',
+    combatants: [
+      { id: 'c1', name: 'A', ownerId: 'p1' },
+      { id: 'c2', name: 'B', ownerId: 'p2' },
+      { id: 'c3', name: 'C', ownerId: 'p3' },
+    ],
+  }
+
+  it('gives wins to drawers and losses to non-drawers', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].wins).toBe(1)
+    expect(result.p2[0].wins).toBe(1)
+    expect(result.p3[0].wins).toBe(0)
+    expect(result.p3[0].losses).toBe(1)
+  })
+
+  it('does not increment draws for anyone', () => {
+    const result = applyDraw(room, round)
+    expect(result.p1[0].draws).toBe(0)
+    expect(result.p2[0].draws).toBe(0)
+    expect(result.p3[0].draws).toBe(0)
+  })
+})
+
+describe('undoRound (all_advance draw)', () => {
+  const room = {
+    combatants: {
+      p1: [{ id: 'c1', wins: 1, draws: 0, losses: 0, battles: [{ roundId: 'r1', result: 'win' }] }],
+      p2: [{ id: 'c2', wins: 1, draws: 0, losses: 0, battles: [{ roundId: 'r1', result: 'win' }] }],
+    },
+  }
+  const round = {
+    id: 'r1',
+    draw: true,
+    drawOutcome: 'all_advance',
+    combatants: [{ id: 'c1', ownerId: 'p1' }, { id: 'c2', ownerId: 'p2' }],
+  }
+
+  it('decrements wins (not draws) for all drawers', () => {
+    const result = undoRound(room, round)
+    expect(result.p1[0].wins).toBe(0)
+    expect(result.p2[0].wins).toBe(0)
+    expect(result.p1[0].draws).toBe(0)
+    expect(result.p2[0].draws).toBe(0)
+  })
+
+  it('does not touch losses', () => {
+    const result = undoRound(room, round)
+    expect(result.p1[0].losses).toBe(0)
+    expect(result.p2[0].losses).toBe(0)
+  })
+
+  it('removes battle records', () => {
+    const result = undoRound(room, round)
+    expect(result.p1[0].battles).toHaveLength(0)
+    expect(result.p2[0].battles).toHaveLength(0)
+  })
+
+  it('clamps wins to 0 never negative', () => {
+    const noWins = {
+      combatants: {
+        p1: [{ id: 'c1', wins: 0, draws: 0, losses: 0, battles: [] }],
+        p2: [{ id: 'c2', wins: 0, draws: 0, losses: 0, battles: [] }],
+      },
+    }
+    const result = undoRound(noWins, round)
+    expect(result.p1[0].wins).toBe(0)
+  })
+})
+
 // ─── replacePlayerIdInRoom ────────────────────────────────────────────────────
 
 describe('replacePlayerIdInRoom', () => {


### PR DESCRIPTION
Closes #39

## What changed
- `applyDraw`: reads `round.drawOutcome`. `all_advance` → drawers get `wins += 1` and a `'win'` battle record instead of a draw. `no_advance` or absent → existing draw behavior unchanged.
- `undoRound`: mirrors the split — when `drawOutcome === 'all_advance'`, decrements wins (not draws) for drawing combatants; all other paths unchanged.
- Both changes compose correctly with the partial-draw `combatantIds` logic from #38.

## Test notes
- All 327 tests pass (316 pre-existing + 11 new from this issue).
- Added: `applyDraw (all_advance)` — wins credited, draws untouched, battle result is `'win'`.
- Added: `applyDraw (no_advance default)` — explicit `'no_advance'` and absent `drawOutcome` both produce draw behavior.
- Added: `applyDraw (all_advance + partial draw)` — drawers get wins, non-drawers get losses, no draws recorded for anyone.
- Added: `undoRound (all_advance draw)` — wins decremented, draws untouched, clamped to 0.