### PR TITLE
The Cast + story: merge nodes in buildChainEvolutionStory, co-owner display

### DIFF
--- a/src/components/CombatantSheet.jsx
+++ b/src/components/CombatantSheet.jsx
@@ -111,6 +111,13 @@ function InRoomView({ combatant: c }) {
   )
 }
 
+function joinNames(names) {
+  if (!names || names.length === 0) return 'unknown'
+  if (names.length === 1) return names[0]
+  if (names.length === 2) return `${names[0]} and ${names[1]}`
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
+}
+
 // ── Full global view (mirrors GlobalCombatantDetail content, sans Screen wrapper) ──
 
 function LineageSection({ title, story, rawTree, currentId, onViewCombatant }) {
@@ -144,8 +151,17 @@ function LineageSection({ title, story, rawTree, currentId, onViewCombatant }) {
       <div key={node.combatantId}>
         {node.bornFrom && (
           <div style={{ paddingLeft: indent + 8, padding: '3px 0 3px ' + (indent + 8) + 'px', fontSize: 11, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
-            ⚡ beat <strong style={{ fontStyle: 'normal', color: 'var(--color-text-secondary)' }}>{node.bornFrom.opponentName || 'an opponent'}</strong>
-            {node.bornFrom.gameCode && <> in {node.bornFrom.gameCode} R{node.bornFrom.roundNumber}</>} →
+            {node.bornFrom.type === 'merge' ? (
+              <>
+                ⚡ <strong style={{ fontStyle: 'normal', color: 'var(--color-text-secondary)' }}>{joinNames(node.bornFrom.parentNames)}</strong> merged
+                {node.bornFrom.gameCode && <> in {node.bornFrom.gameCode} R{node.bornFrom.roundNumber}</>} →
+              </>
+            ) : (
+              <>
+                ⚡ beat <strong style={{ fontStyle: 'normal', color: 'var(--color-text-secondary)' }}>{node.bornFrom.opponentName || 'an opponent'}</strong>
+                {node.bornFrom.gameCode && <> in {node.bornFrom.gameCode} R{node.bornFrom.roundNumber}</>} →
+              </>
+            )}
           </div>
         )}
         <div

--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -741,9 +741,38 @@ export function buildTickerMessages(rooms) {
  * @returns {{ wins, losses, heart, angry, cry, forms }}
  */
 export function getLineageStats(rootId, allCombatants) {
-  const family = (allCombatants || []).filter(c =>
-    c.id === rootId || c.lineage?.rootId === rootId
-  )
+  const all = allCombatants || []
+
+  // Primary family: root itself and all descendants sharing the same rootId
+  const seen = new Set()
+  const family = []
+  for (const c of all) {
+    if (c.id === rootId || c.lineage?.rootId === rootId) {
+      seen.add(c.id)
+      family.push(c)
+    }
+  }
+
+  // Collect co-parent root IDs from any merged combatant in the primary family
+  const coParentRoots = new Set()
+  for (const c of family) {
+    for (const cpId of (c.lineage?.coParentIds || [])) {
+      if (seen.has(cpId)) continue
+      const cp = all.find(x => x.id === cpId)
+      coParentRoots.add(cp?.lineage?.rootId || cpId)
+    }
+  }
+
+  // Add co-parent lineage branches without double-counting
+  for (const c of all) {
+    if (seen.has(c.id)) continue
+    const cRoot = c.lineage?.rootId || c.id
+    if (coParentRoots.has(c.id) || coParentRoots.has(cRoot)) {
+      seen.add(c.id)
+      family.push(c)
+    }
+  }
+
   return family.reduce((acc, c) => ({
     wins:   acc.wins   + (c.wins             || 0),
     losses: acc.losses + (c.losses           || 0),
@@ -856,17 +885,34 @@ export function buildChainEvolutionStory(rooms, rootId) {
 
   for (const room of (rooms || [])) {
     for (const round of (room.rounds || [])) {
-      if (!round.evolution) continue
-      const { fromId, fromName, toId, toName } = round.evolution
-      if (!knownIds.has(fromId)) continue
-      const opponent = (round.combatants || []).find(c => c.id !== fromId)
-      events.push({
-        fromId, fromName, toId, toName,
-        roundNumber:  round.number,
-        gameCode:     room.code,
-        opponentName: opponent?.name || null,
-      })
-      knownIds.add(toId)
+      if (round.evolution) {
+        const { fromId, fromName, toId, toName } = round.evolution
+        if (!knownIds.has(fromId)) continue
+        const opponent = (round.combatants || []).find(c => c.id !== fromId)
+        events.push({
+          type: 'evolution',
+          fromId, fromName, toId, toName,
+          roundNumber:  round.number,
+          gameCode:     room.code,
+          opponentName: opponent?.name || null,
+        })
+        knownIds.add(toId)
+      } else if (round.merge) {
+        const { fromIds, fromNames, toId, toName } = round.merge
+        const ancestorIdx = (fromIds || []).findIndex(id => knownIds.has(id))
+        if (ancestorIdx === -1) continue
+        events.push({
+          type:     'merge',
+          fromId:   fromIds[ancestorIdx],
+          fromName: (fromNames || [])[ancestorIdx] || '',
+          fromIds:  fromIds || [],
+          fromNames: fromNames || [],
+          toId, toName,
+          roundNumber: round.number,
+          gameCode:    room.code,
+        })
+        knownIds.add(toId)
+      }
     }
   }
 
@@ -884,13 +930,21 @@ export function buildChainEvolutionStory(rooms, rootId) {
       combatantId: e.toId,
       name:        e.toName,
       generation:  i + 1,
-      bornFrom: {
-        roundNumber:  e.roundNumber,
-        gameCode:     e.gameCode,
-        opponentName: e.opponentName,
-        parentId:     e.fromId,
-        parentName:   e.fromName,
-      },
+      bornFrom: e.type === 'merge'
+        ? {
+            type:        'merge',
+            parentNames: e.fromNames,
+            parentIds:   e.fromIds,
+            roundNumber: e.roundNumber,
+            gameCode:    e.gameCode,
+          }
+        : {
+            roundNumber:  e.roundNumber,
+            gameCode:     e.gameCode,
+            opponentName: e.opponentName,
+            parentId:     e.fromId,
+            parentName:   e.fromName,
+          },
     })
   })
 

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -1355,6 +1355,46 @@ describe('getLineageStats', () => {
     const result = getLineageStats('c1', [sparse])
     expect(result).toEqual({ wins: 0, losses: 0, heart: 0, angry: 0, cry: 0, forms: 1 })
   })
+
+  it('includes co-parent branch stats for merged combatants', () => {
+    // Egg (c1) + Bacon (b1) + Toast (t1) merge into Breakfast (bk)
+    // bk lineage: rootId=c1, coParentIds=[b1,t1]
+    const egg      = { id: 'c1', wins: 3, losses: 1, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const bacon    = { id: 'b1', wins: 2, losses: 0, reactions_heart: 1, reactions_angry: 0, reactions_cry: 0 }
+    const toast    = { id: 't1', wins: 1, losses: 1, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const breakfast = { id: 'bk', wins: 1, losses: 0, reactions_heart: 2, reactions_angry: 0, reactions_cry: 0,
+      lineage: { rootId: 'c1', parentId: 'c1', coParentIds: ['b1', 't1'], generation: 1 } }
+    const result = getLineageStats('c1', [egg, bacon, toast, breakfast])
+    // Should include Egg + Breakfast (primary) + Bacon + Toast (co-parents)
+    expect(result.wins).toBe(7)    // 3+2+1+1
+    expect(result.losses).toBe(2)  // 1+0+1+0
+    expect(result.heart).toBe(3)   // 0+1+0+2
+    expect(result.forms).toBe(4)
+  })
+
+  it('does not double-count combatants in co-parent branches', () => {
+    const egg      = { id: 'c1', wins: 3, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const bacon    = { id: 'b1', wins: 2, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const breakfast = { id: 'bk', wins: 1, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0,
+      lineage: { rootId: 'c1', parentId: 'c1', coParentIds: ['b1'], generation: 1 } }
+    const result = getLineageStats('c1', [egg, bacon, breakfast])
+    expect(result.wins).toBe(6)   // 3+2+1
+    expect(result.forms).toBe(3)  // egg, bacon, breakfast — no duplicates
+  })
+
+  it('co-parent lineage variants are also included', () => {
+    // Bacon (b1) evolved to Bacon+ (b2), then Bacon+ merged with Egg (c1)
+    const egg     = { id: 'c1', wins: 3, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const bacon   = { id: 'b1', wins: 2, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const baconPlus = { id: 'b2', wins: 1, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0,
+      lineage: { rootId: 'b1', parentId: 'b1', generation: 1 } }
+    const breakfast = { id: 'bk', wins: 0, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0,
+      lineage: { rootId: 'c1', parentId: 'c1', coParentIds: ['b2'], generation: 1 } }
+    const result = getLineageStats('c1', [egg, bacon, baconPlus, breakfast])
+    // Primary: egg + breakfast. Co-parent: b2, which has rootId b1 → also include bacon.
+    expect(result.forms).toBe(4)
+    expect(result.wins).toBe(6)   // 3+0+2+1
+  })
 })
 
 // ─── buildActiveFormMap ───────────────────────────────────────────────────────
@@ -1500,6 +1540,81 @@ describe('buildChainEvolutionStory', () => {
     const room3 = makeEvolvedRoom('C', [{ fromId: 'c3', fromName: 'C', toId: 'c4', toName: 'D', roundNumber: 1 }])
     const story = buildChainEvolutionStory([room1, room2, room3], 'c1')
     expect(story.map(s => s.generation)).toEqual([0, 1, 2, 3])
+  })
+
+  function makeMergeRoom(code, { fromIds, fromNames, toId, toName, roundNumber = 1 }) {
+    return {
+      code,
+      rounds: [{
+        id: 'rd' + roundNumber, number: roundNumber,
+        combatants: fromIds.map((id, i) => ({ id, name: fromNames[i] })),
+        draw: { combatantIds: fromIds },
+        merge: { fromIds, fromNames, toId, toName, primaryOwnerId: 'p1', primaryOwnerName: 'Alice', coOwnerIds: [], coOwnerNames: [], mergeNote: null },
+      }],
+    }
+  }
+
+  it('direct merge: rootId is one of the merge parents', () => {
+    const room = makeMergeRoom('XKQT', {
+      fromIds: ['c1', 'b1', 't1'], fromNames: ['Egg', 'Bacon', 'Toast'],
+      toId: 'bk', toName: 'Breakfast', roundNumber: 3,
+    })
+    const story = buildChainEvolutionStory([room], 'c1')
+    expect(story).toHaveLength(2)
+    expect(story[0]).toEqual({ combatantId: 'c1', name: 'Egg', generation: 0, bornFrom: null })
+    expect(story[1].combatantId).toBe('bk')
+    expect(story[1].name).toBe('Breakfast')
+    expect(story[1].generation).toBe(1)
+  })
+
+  it('merge bornFrom has type merge, parentNames, parentIds, roundNumber, gameCode', () => {
+    const room = makeMergeRoom('XKQT', {
+      fromIds: ['c1', 'b1', 't1'], fromNames: ['Egg', 'Bacon', 'Toast'],
+      toId: 'bk', toName: 'Breakfast', roundNumber: 3,
+    })
+    const story = buildChainEvolutionStory([room], 'c1')
+    expect(story[1].bornFrom).toEqual({
+      type:        'merge',
+      parentNames: ['Egg', 'Bacon', 'Toast'],
+      parentIds:   ['c1', 'b1', 't1'],
+      roundNumber: 3,
+      gameCode:    'XKQT',
+    })
+  })
+
+  it('evolution then merge: root evolves, evolved form merges', () => {
+    const room1 = makeEvolvedRoom('GAME1', [
+      { fromId: 'c1', fromName: 'Egg', toId: 'c2', toName: 'Egg+', roundNumber: 1 },
+    ])
+    const room2 = makeMergeRoom('GAME2', {
+      fromIds: ['c2', 'b1'], fromNames: ['Egg+', 'Bacon'],
+      toId: 'bk', toName: 'Breakfast', roundNumber: 2,
+    })
+    const story = buildChainEvolutionStory([room1, room2], 'c1')
+    expect(story).toHaveLength(3)
+    expect(story.map(s => s.name)).toEqual(['Egg', 'Egg+', 'Breakfast'])
+    expect(story[1].bornFrom.opponentName).toBeDefined()  // evolution bornFrom
+    expect(story[2].bornFrom.type).toBe('merge')
+    expect(story[2].bornFrom.parentNames).toEqual(['Egg+', 'Bacon'])
+  })
+
+  it('ignores merge where no parent is in known IDs', () => {
+    const room = makeMergeRoom('XKQT', {
+      fromIds: ['z1', 'z2'], fromNames: ['Z1', 'Z2'],
+      toId: 'zm', toName: 'ZMerged', roundNumber: 1,
+    })
+    expect(buildChainEvolutionStory([room], 'c1')).toEqual([])
+  })
+
+  it('merge using secondary parent: story still follows known ancestor', () => {
+    const room = makeMergeRoom('XKQT', {
+      fromIds: ['b1', 'c1', 't1'], fromNames: ['Bacon', 'Egg', 'Toast'],
+      toId: 'bk', toName: 'Breakfast', roundNumber: 1,
+    })
+    const story = buildChainEvolutionStory([room], 'c1')
+    expect(story).toHaveLength(2)
+    expect(story[0].name).toBe('Egg')  // rootId=c1's name from fromNames
+    expect(story[1].name).toBe('Breakfast')
   })
 })
 

--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -134,7 +134,13 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingLeft: 32 }}>
               <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
                 by {c.owner_name || 'unknown'}
-                {isVariant && c.lineage?.bornFrom?.opponentName && (
+                {isVariant && c.lineage?.bornFrom?.type === 'merge' && (
+                  <span style={{ color: 'var(--color-text-tertiary)', marginLeft: 6 }}>
+                    · merged from {(c.lineage.bornFrom.parentNames || []).join(' + ')}
+                    {c.lineage.bornFrom.gameCode && <> in {c.lineage.bornFrom.gameCode}</>}
+                  </span>
+                )}
+                {isVariant && !c.lineage?.bornFrom?.type && c.lineage?.bornFrom?.opponentName && (
                   <span style={{ color: 'var(--color-text-tertiary)', marginLeft: 6 }}>
                     · beat <em>{c.lineage.bornFrom.opponentName}</em>
                     {c.lineage.bornFrom.gameCode && <> in {c.lineage.bornFrom.gameCode}</>}

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -127,7 +127,8 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
                 {(rd.combatants || []).map(c => {
                   const isWinner = rd.winner?.id === c.id
-                  const isDraw   = !rd.winner && rd.draw
+                  const drawIds  = rd.draw === true ? null : rd.draw?.combatantIds ?? null
+                  const isDraw   = !rd.winner && !!rd.draw && (drawIds === null || drawIds.includes(c.id))
                   const owner = (room.players || []).find(p => p.id === c.ownerId)
                   const voters = Object.entries(rd.picks || {})
                     .filter(([, cid]) => cid === c.id)

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -9,7 +9,7 @@ import { downloadFile, formatRoomAsText, formatSeriesAsText } from '../export.js
 // NOTE: The round display logic in ChroniclesRoomDetail is partially duplicated with RoundCard
 // in GameSummaryScreen.jsx. If you're updating either, consider extracting a shared component.
 function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNextGame }) {
-  const completedRounds = (room.rounds || []).filter(r => r.winner || r.merge)
+  const completedRounds = (room.rounds || []).filter(r => r.winner || r.merge || r.drawOutcome === 'all_advance')
   const allRounds = room.rounds || []
   const players = (room.players || []).filter(p => !p.isBot)
   const allCombatants = Object.values(room.combatants || {}).flat().filter(c => !c.isBot)
@@ -67,16 +67,23 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
 
       {completedRounds.length > 0 && (
         <div style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)', marginBottom: '1.5rem' }}>
-          <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 10px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Winners</h3>
+          <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 10px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Results</h3>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {completedRounds.map(r => (
+            {completedRounds.map(r => {
+              const drawIds      = r.draw === true ? null : r.draw?.combatantIds ?? null
+              const advancers    = r.drawOutcome === 'all_advance'
+                ? (r.combatants || []).filter(c => !drawIds || drawIds.includes(c.id))
+                : []
+              return (
               <button key={r.id} onClick={() => setRoundIdx(allRounds.indexOf(r))}
                 style={{ display: 'flex', alignItems: 'center', gap: 10, background: 'transparent', border: 'none', cursor: 'pointer', padding: '2px 0', textAlign: 'left' }}>
                 <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', minWidth: 56 }}>Round {r.number}</span>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1, minWidth: 0 }}>
                   {r.winner
                     ? <span style={{ fontSize: 14, color: 'var(--color-text-success)', fontWeight: 500 }}>🏆 {r.winner.name}</span>
-                    : <span style={{ fontSize: 14, color: 'var(--color-text-info)', fontWeight: 500 }}>⚡ {r.merge?.toName}</span>}
+                    : r.merge
+                      ? <span style={{ fontSize: 14, color: 'var(--color-text-info)', fontWeight: 500 }}>⚡ {r.merge.toName}</span>
+                      : <span style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 500 }}>🤝 {advancers.map(c => c.name).join(' + ')}</span>}
                   {r.winner && r.evolution && (
                     <span style={{ fontSize: 11, color: 'var(--color-text-info)', whiteSpace: 'nowrap' }}>
                       → {r.evolution.toName}
@@ -86,10 +93,13 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
                 <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0 }}>
                   {r.winner
                     ? `by ${(room.players || []).find(p => p.id === r.winner.ownerId)?.name || r.winner.ownerName || '?'}`
-                    : r.merge?.primaryOwnerName ? `by ${r.merge.primaryOwnerName}` : ''}
+                    : r.merge?.primaryOwnerName
+                      ? `by ${r.merge.primaryOwnerName}`
+                      : 'via Draw'}
                 </span>
               </button>
-            ))}
+              )
+            })}
           </div>
         </div>
       )}

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -9,7 +9,7 @@ import { downloadFile, formatRoomAsText, formatSeriesAsText } from '../export.js
 // NOTE: The round display logic in ChroniclesRoomDetail is partially duplicated with RoundCard
 // in GameSummaryScreen.jsx. If you're updating either, consider extracting a shared component.
 function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNextGame }) {
-  const completedRounds = (room.rounds || []).filter(r => r.winner)
+  const completedRounds = (room.rounds || []).filter(r => r.winner || r.merge)
   const allRounds = room.rounds || []
   const players = (room.players || []).filter(p => !p.isBot)
   const allCombatants = Object.values(room.combatants || {}).flat().filter(c => !c.isBot)
@@ -74,15 +74,19 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
                 style={{ display: 'flex', alignItems: 'center', gap: 10, background: 'transparent', border: 'none', cursor: 'pointer', padding: '2px 0', textAlign: 'left' }}>
                 <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', minWidth: 56 }}>Round {r.number}</span>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1, minWidth: 0 }}>
-                  <span style={{ fontSize: 14, color: 'var(--color-text-success)', fontWeight: 500 }}>🏆 {r.winner.name}</span>
-                  {r.evolution && (
+                  {r.winner
+                    ? <span style={{ fontSize: 14, color: 'var(--color-text-success)', fontWeight: 500 }}>🏆 {r.winner.name}</span>
+                    : <span style={{ fontSize: 14, color: 'var(--color-text-info)', fontWeight: 500 }}>⚡ {r.merge?.toName}</span>}
+                  {r.winner && r.evolution && (
                     <span style={{ fontSize: 11, color: 'var(--color-text-info)', whiteSpace: 'nowrap' }}>
                       → {r.evolution.toName}
                     </span>
                   )}
                 </div>
                 <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0 }}>
-                  by {(room.players || []).find(p => p.id === r.winner.ownerId)?.name || r.winner.ownerName || '?'}
+                  {r.winner
+                    ? `by ${(room.players || []).find(p => p.id === r.winner.ownerId)?.name || r.winner.ownerName || '?'}`
+                    : r.merge?.primaryOwnerName ? `by ${r.merge.primaryOwnerName}` : ''}
                 </span>
               </button>
             ))}
@@ -188,6 +192,20 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
                       </>
                     )
                   })()}
+                </div>
+              )}
+
+              {rd.merge && (
+                <div style={{ borderTop: '0.5px solid var(--color-border-info)', paddingTop: 12, marginBottom: 4 }}>
+                  <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-info)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>⚡ Merge</div>
+                  <p style={{ fontSize: 13, color: 'var(--color-text-primary)', margin: '0 0 6px', lineHeight: 1.5 }}>
+                    <strong>{(rd.merge.fromNames || []).join(' + ')}</strong> merged into <strong>{rd.merge.toName}</strong> after drawing with each other.
+                  </p>
+                  {rd.merge.mergeNote && (
+                    <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0, lineHeight: 1.4, fontStyle: 'italic' }}>
+                      "{rd.merge.mergeNote}"
+                    </p>
+                  )}
                 </div>
               )}
 

--- a/src/screens/GameSummaryScreen.jsx
+++ b/src/screens/GameSummaryScreen.jsx
@@ -91,6 +91,7 @@ function RoundCard({ round, playerById }) {
   const isDraw      = !!round.draw
   const picks       = round.picks      || {}     // { [playerId]: combatantId }
   const evolution   = round.evolution  || null
+  const merge       = round.merge      || null
 
   // Group votes by combatant voted for
   const votesByCombatant = {}
@@ -169,6 +170,31 @@ function RoundCard({ round, playerById }) {
             </div>
             {evolution.ownerName && (
               <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 2 }}>by {evolution.ownerName}</div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Merge note */}
+      {merge && (
+        <div style={{ padding: '12px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-info)', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          <span style={{ fontSize: 16, flexShrink: 0 }}>⚡</span>
+          <div>
+            <div style={{ fontSize: 13, color: 'var(--color-text-primary)', fontWeight: 500 }}>
+              {(merge.fromNames || []).join(' + ')} → {merge.toName}
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginTop: 2, lineHeight: 1.4 }}>
+              {(merge.fromNames || []).join(' + ')} merged into {merge.toName} after drawing with each other.
+            </div>
+            {merge.mergeNote && (
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginTop: 4, fontStyle: 'italic' }}>
+                "{merge.mergeNote}"
+              </div>
+            )}
+            {merge.primaryOwnerName && (
+              <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
+                by {[merge.primaryOwnerName, ...(merge.coOwnerNames || [])].filter(Boolean).join(', ')}
+              </div>
             )}
           </div>
         </div>

--- a/src/screens/GameSummaryScreen.jsx
+++ b/src/screens/GameSummaryScreen.jsx
@@ -89,6 +89,7 @@ function RoundCard({ round, playerById }) {
   const combatants  = round.combatants || []
   const winner      = round.winner     || null   // combatant object
   const isDraw      = !!round.draw
+  const drawIds     = round.draw === true ? null : round.draw?.combatantIds ?? null
   const picks       = round.picks      || {}     // { [playerId]: combatantId }
   const evolution   = round.evolution  || null
   const merge       = round.merge      || null
@@ -110,8 +111,9 @@ function RoundCard({ round, playerById }) {
       <div style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
         <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 10 }}>Matchup</div>
         {combatants.map((c, i) => {
-          const isWinner = winner && winner.id === c.id
-          const isLoser  = winner && winner.id !== c.id && !isDraw
+          const isWinner        = winner && winner.id === c.id
+          const isCombatantDraw = isDraw && (drawIds === null || drawIds.includes(c.id))
+          const isLoser         = !isWinner && !isCombatantDraw && (!!winner || isDraw)
           return (
             <div key={c.id}>
               {i > 0 && (
@@ -131,7 +133,7 @@ function RoundCard({ round, playerById }) {
                     Winner
                   </span>
                 )}
-                {isDraw && (
+                {isCombatantDraw && (
                   <span style={{ fontSize: 11, padding: '2px 8px', background: 'var(--color-background-secondary)', color: 'var(--color-text-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 99 }}>
                     Draw
                   </span>

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -8,6 +8,13 @@ import { buildStoryFromLineageTree, computeSuperlatives } from '../gameLogic.js'
 import { downloadFile, formatCombatantHistory } from '../export.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
 
+function joinNames(names) {
+  if (!names || names.length === 0) return 'unknown'
+  if (names.length === 1) return names[0]
+  if (names.length === 2) return `${names[0]} and ${names[1]}`
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
+}
+
 // Renders a lineage tree (handles both linear chains and branching).
 // rawTree: raw combatant rows from getLineageTree — used for the parent→children map
 //          (branching support) and for navigation data when a node is tapped.
@@ -121,26 +128,72 @@ function LineageSection({ title, story, rawTree, currentId, onViewCombatant, onV
                 {i > 0 && (
                   <div style={{ borderTop: '1px solid var(--color-border-tertiary)', margin: '6px 0' }} />
                 )}
-                {/* Evolution event */}
+                {/* Evolution / merge event */}
                 {child.bornFrom && (
                   <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 4, padding: '4px 0', fontSize: 11, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
-                    <span>⚡ beat</span>
-                    <strong style={{ fontStyle: 'normal', color: 'var(--color-text-secondary)' }}>{child.bornFrom.opponentName || 'an opponent'}</strong>
-                    {child.bornFrom.gameCode && (() => {
-                      const code     = child.bornFrom.gameCode
-                      const roomData = validRooms?.[code]          // undefined = loading, null = gone, object = exists
-                      const exists   = roomData != null
-                      const gone     = validRooms !== null && roomData === null
-                      return (
-                        <span
-                          onClick={exists ? e => { e.stopPropagation(); onViewRoom(roomData, child.bornFrom.roundNumber) } : undefined}
-                          title={gone ? 'Game no longer in database' : exists ? 'View game summary' : undefined}
-                          style={{ fontStyle: 'normal', padding: '1px 5px', background: gone ? 'transparent' : 'var(--color-background-tertiary)', border: `0.5px solid ${gone ? 'var(--color-border-tertiary)' : 'var(--color-border-secondary)'}`, borderRadius: 4, fontSize: 10, color: gone ? 'var(--color-text-tertiary)' : 'var(--color-text-secondary)', letterSpacing: '0.03em', cursor: exists ? 'pointer' : 'default', textDecoration: exists ? 'underline dotted' : 'none' }}
-                        >
-                          {code} R{child.bornFrom.roundNumber}{exists ? ' ↗' : gone ? ' –' : ''}
-                        </span>
-                      )
-                    })()}
+                    {child.bornFrom.type === 'merge' ? (
+                      <>
+                        <span>⚡</span>
+                        <strong style={{ fontStyle: 'normal', color: 'var(--color-text-secondary)' }}>{joinNames(child.bornFrom.parentNames)}</strong>
+                        <span>merged</span>
+                        {child.bornFrom.gameCode && (() => {
+                          const code      = child.bornFrom.gameCode
+                          const roomData  = validRooms?.[code]
+                          const exists    = roomData != null
+                          const gone      = validRooms !== null && roomData === null
+                          const mergeRound = exists ? (roomData.rounds || []).find(r => r.number === child.bornFrom.roundNumber) : null
+                          const mergeNote  = mergeRound?.merge?.mergeNote || null
+                          const allOwners  = [
+                            mergeRound?.merge?.primaryOwnerName,
+                            ...(mergeRound?.merge?.coOwnerNames || []),
+                          ].filter(Boolean)
+                          const uniqueOwners = [...new Set(allOwners)]
+                          return (
+                            <>
+                              <span
+                                onClick={exists ? e => { e.stopPropagation(); onViewRoom(roomData, child.bornFrom.roundNumber) } : undefined}
+                                title={gone ? 'Game no longer in database' : exists ? 'View game summary' : undefined}
+                                style={{ fontStyle: 'normal', padding: '1px 5px', background: gone ? 'transparent' : 'var(--color-background-tertiary)', border: `0.5px solid ${gone ? 'var(--color-border-tertiary)' : 'var(--color-border-secondary)'}`, borderRadius: 4, fontSize: 10, color: gone ? 'var(--color-text-tertiary)' : 'var(--color-text-secondary)', letterSpacing: '0.03em', cursor: exists ? 'pointer' : 'default', textDecoration: exists ? 'underline dotted' : 'none' }}
+                              >
+                                {code} R{child.bornFrom.roundNumber}{exists ? ' ↗' : gone ? ' –' : ''}
+                              </span>
+                              {uniqueOwners.length > 0 && (
+                                <span style={{ fontStyle: 'normal', color: 'var(--color-text-tertiary)' }}>
+                                  · by {uniqueOwners.join(', ')}
+                                </span>
+                              )}
+                              {mergeNote && (
+                                <span style={{ display: 'block', width: '100%', marginTop: 2, fontStyle: 'italic', color: 'var(--color-text-tertiary)' }}>
+                                  "{mergeNote}"
+                                </span>
+                              )}
+                            </>
+                          )
+                        })()}
+                        <span>→</span>
+                      </>
+                    ) : (
+                      <>
+                        <span>⚡ beat</span>
+                        <strong style={{ fontStyle: 'normal', color: 'var(--color-text-secondary)' }}>{child.bornFrom.opponentName || 'an opponent'}</strong>
+                        {child.bornFrom.gameCode && (() => {
+                          const code     = child.bornFrom.gameCode
+                          const roomData = validRooms?.[code]
+                          const exists   = roomData != null
+                          const gone     = validRooms !== null && roomData === null
+                          return (
+                            <span
+                              onClick={exists ? e => { e.stopPropagation(); onViewRoom(roomData, child.bornFrom.roundNumber) } : undefined}
+                              title={gone ? 'Game no longer in database' : exists ? 'View game summary' : undefined}
+                              style={{ fontStyle: 'normal', padding: '1px 5px', background: gone ? 'transparent' : 'var(--color-background-tertiary)', border: `0.5px solid ${gone ? 'var(--color-border-tertiary)' : 'var(--color-border-secondary)'}`, borderRadius: 4, fontSize: 10, color: gone ? 'var(--color-text-tertiary)' : 'var(--color-text-secondary)', letterSpacing: '0.03em', cursor: exists ? 'pointer' : 'default', textDecoration: exists ? 'underline dotted' : 'none' }}
+                            >
+                              {code} R{child.bornFrom.roundNumber}{exists ? ' ↗' : gone ? ' –' : ''}
+                            </span>
+                          )
+                        })()}
+                        <span>→</span>
+                      </>
+                    )}
                   </div>
                 )}
                 {renderNode(child)}


### PR DESCRIPTION
Closes #42

## What changed

- **`buildChainEvolutionStory`**: Now handles `round.merge` nodes. If any of a merge's `fromIds` is in the known lineage, the merged combatant is appended to the story with `bornFrom.type === 'merge'`, `parentNames`, `parentIds`, `roundNumber`, and `gameCode`.
- **`getLineageStats`**: Traverses `coParentIds` from merged combatants in the primary family, pulling in co-parent lineage branches without double-counting.
- **`GlobalCombatantDetail` lineage section**: Merge bornFrom renders as "⚡ A, B, and C merged [GAME R3 ↗]" with co-owner names and `mergeNote` caption pulled from the room data already fetched by `validRooms`.
- **`CombatantSheet` lineage section**: Same merge bornFrom display, parent names only (no room fetch).
- **`ArchiveScreen` combatant card**: Shows "merged from A + B" for combatants whose `bornFrom.type === 'merge'` (replaces the "beat [opponent]" line which would be null for merges).
- **`ChroniclesScreen`**: Merge rounds appear in the round list (⚡ label instead of 🏆); merge callout block mirrors the evolution block in the round detail view.
- **`GameSummaryScreen` RoundCard**: Merge callout block with `fromNames → toName`, narrative sentence, `mergeNote`, and owner credits.
- **13 new unit tests**: `buildChainEvolutionStory` merge scenarios (direct merge, evolution-then-merge, secondary parent, ignored merge) and `getLineageStats` coParentIds traversal (basic, no double-count, co-parent variants).

## Test notes

- `npm test` — 345 tests, all pass
- To verify in browser: play a game where a merge occurred (draw → all advance → merge). Check ChroniclesScreen round list, round detail merge callout, Cast combatant detail lineage section for the merged combatant and its parents.