### PR TITLE
Add allowEvolutions, allowDraws, and allowMerges to room settings

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -26,6 +26,9 @@ export function normalizeRoomSettings(settings) {
     anonymousCombatants:  false,
     blindVoting:          false,
     biosRequired:         false,
+    allowEvolutions:      true,
+    allowDraws:           true,
+    allowMerges:          true,
     ...settings,
   }
 }

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -1144,12 +1144,18 @@ describe('normalizeRoomSettings', () => {
     expect(s.anonymousCombatants).toBe(false)
     expect(s.blindVoting).toBe(false)
     expect(s.biosRequired).toBe(false)
+    expect(s.allowEvolutions).toBe(true)
+    expect(s.allowDraws).toBe(true)
+    expect(s.allowMerges).toBe(true)
   })
 
   it('fills all defaults when passed an empty object', () => {
     const s = normalizeRoomSettings({})
     expect(s.rosterSize).toBe(8)
     expect(s.spectatorsAllowed).toBe(true)
+    expect(s.allowEvolutions).toBe(true)
+    expect(s.allowDraws).toBe(true)
+    expect(s.allowMerges).toBe(true)
   })
 
   it('preserves explicit values', () => {
@@ -1162,6 +1168,21 @@ describe('normalizeRoomSettings', () => {
   it('preserves false explicitly set', () => {
     const s = normalizeRoomSettings({ spectatorsAllowed: false })
     expect(s.spectatorsAllowed).toBe(false)
+  })
+
+  it('allowEvolutions defaults to true, can be set false', () => {
+    expect(normalizeRoomSettings({}).allowEvolutions).toBe(true)
+    expect(normalizeRoomSettings({ allowEvolutions: false }).allowEvolutions).toBe(false)
+  })
+
+  it('allowDraws defaults to true, can be set false', () => {
+    expect(normalizeRoomSettings({}).allowDraws).toBe(true)
+    expect(normalizeRoomSettings({ allowDraws: false }).allowDraws).toBe(false)
+  })
+
+  it('allowMerges defaults to true, can be set false', () => {
+    expect(normalizeRoomSettings({}).allowMerges).toBe(true)
+    expect(normalizeRoomSettings({ allowMerges: false }).allowMerges).toBe(false)
   })
 
   it('is non-destructive — does not mutate the input', () => {

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -4,9 +4,9 @@ import { btn, inp, lbl } from '../styles.js'
 import { sset } from '../supabase.js'
 import { playerColor } from '../gameLogic.js'
 
-function SettingRow({ label, description, value, onToggle }) {
+function SettingRow({ label, description, value, onToggle, indented }) {
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 0', borderBottom: '0.5px solid var(--color-border-tertiary)' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 0', borderBottom: '0.5px solid var(--color-border-tertiary)', paddingLeft: indented ? 16 : 0 }}>
       <div>
         <div style={{ fontSize: 14, color: 'var(--color-text-primary)' }}>{label}</div>
         <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 1 }}>{description}</div>
@@ -44,12 +44,14 @@ const SETTINGS = [
   ['anonymousCombatants',    'Anonymous combatants',    'Hide owner names during voting'],
   ['blindVoting',            'Blind voting',            'Hide votes until everyone has picked'],
   ['biosRequired',           'Bios required',           'Players must write a bio for each combatant'],
+  ['allowEvolutions',        'Allow evolutions',        'Winners can be evolved into a new form after a round.'],
+  ['allowDraws',             'Allow draws',             'Host can declare a round a draw instead of picking a winner.'],
 ]
 
 export default function CreateRoom({ playerId, playerName, setPlayerName, lockedName, isGuest, onLogin, onCreated, onBack }) {
   const [name, setName] = useState(playerName)
   const [loading, setLoading] = useState(false)
-  const [settings, setSettings] = useState({ rosterSize: 8, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false })
+  const [settings, setSettings] = useState({ rosterSize: 8, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false, allowEvolutions: true, allowDraws: true, allowMerges: true })
 
   function toggle(key) { setSettings(s => ({ ...s, [key]: !s[key] })) }
 
@@ -87,7 +89,23 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
       <div style={{ marginBottom: '1.5rem' }}>
         <RosterSizeRow value={settings.rosterSize} onChange={v => setSettings(s => ({ ...s, rosterSize: v }))} />
         {SETTINGS.map(([key, label, desc]) => (
-          <SettingRow key={key} label={label} description={desc} value={settings[key]} onToggle={() => toggle(key)} />
+          <div key={key}>
+            <SettingRow label={label} description={desc} value={settings[key]} onToggle={() => toggle(key)} />
+            {key === 'allowEvolutions' && !settings.allowEvolutions && (
+              <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', padding: '2px 0 6px', marginTop: -4 }}>
+                Winners carry forward unchanged in a series.
+              </div>
+            )}
+            {key === 'allowDraws' && settings.allowDraws && (
+              <SettingRow
+                label="Allow merges"
+                description="Combatants that draw can merge into a new combined form."
+                value={settings.allowMerges}
+                onToggle={() => toggle('allowMerges')}
+                indented
+              />
+            )}
+          </div>
         ))}
       </div>
 

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -143,6 +143,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
 
   const round   = room.rounds[room.currentRound - 1]
   const isHost  = room.host === playerId
+  const { allowEvolutions, allowDraws, allowMerges } = normalizeRoomSettings(room.settings)
 
   useEffect(() => {
     return subscribeToRoom(room.id, async r => {
@@ -771,15 +772,17 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
                   <button onClick={() => confirmWinner(c.id)} style={{ ...btn('primary'), flex: 2, padding: '10px', fontSize: 14 }}>
                     Confirm win ✓
                   </button>
-                  <button
-                    onClick={() => setEvolveFlow({
-                      stage:       c.ownerId === playerId ? 'writing' : 'pending',
-                      combatantId: c.id,
-                    })}
-                    style={{ ...btn(), flex: 1, padding: '8px 10px', fontSize: 13 }}
-                  >
-                    Evolve ⚡
-                  </button>
+                  {allowEvolutions && (
+                    <button
+                      onClick={() => setEvolveFlow({
+                        stage:       c.ownerId === playerId ? 'writing' : 'pending',
+                        combatantId: c.id,
+                      })}
+                      style={{ ...btn(), flex: 1, padding: '8px 10px', fontSize: 13 }}
+                    >
+                      Evolve ⚡
+                    </button>
+                  )}
                 </div>
               )}
 
@@ -874,7 +877,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       )}
 
       {/* ── Declare draw (host only, no evolution in progress) ───────────── */}
-      {isHost && !evolveFlow && !evolutionPending && !drawFlow && (
+      {isHost && allowDraws && !evolveFlow && !evolutionPending && !drawFlow && (
         <button onClick={startDrawFlow} style={{ ...btn('ghost'), width: '100%', fontSize: 13, marginTop: 8, color: 'var(--color-text-tertiary)', borderColor: 'var(--color-border-tertiary)' }}>
           🤝 Declare draw
         </button>
@@ -933,7 +936,10 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
               Neither advances
             </button>
             <button
-              onClick={() => setDrawFlow({ step: 3, selectedIds: drawFlow.selectedIds })}
+              onClick={() => allowMerges
+                ? setDrawFlow({ step: 3, selectedIds: drawFlow.selectedIds })
+                : confirmDraw(drawFlow.selectedIds, 'all_advance')
+              }
               style={{ ...btn(), flex: 1, fontSize: 13, padding: '10px 8px' }}
             >
               All advance


### PR DESCRIPTION
Closes #60

## What changed
- `normalizeRoomSettings` in `gameLogic.js` now defaults `allowEvolutions`, `allowDraws`, and `allowMerges` to `true` — existing rooms without these keys behave identically to before
- `CreateRoom.jsx`: all three keys in initial settings state; `allowEvolutions` and `allowDraws` appear as toggle rows; `allowMerges` renders as an indented sub-toggle beneath `allowDraws` (only when draws are on); a note appears beneath `allowEvolutions` when off ("Winners carry forward unchanged in a series.")
- `VoteScreen.jsx`: destructures the three flags from `normalizeRoomSettings`; gates "Evolve ⚡" on `allowEvolutions`, "Declare draw" on `allowDraws`, and step 3 (merge prompt) on `allowMerges` — when merges are off, "All advance" in step 2 resolves immediately without the merge offer
- Unit tests added for all three new defaults and their explicit-false cases (310 total, all passing)

## Test notes
- All 310 unit tests pass
- Manual: create room with each flag individually false to verify buttons/steps disappear
- Old rooms without these keys default to all-true via normalizeRoomSettings — no visible change