### PR TITLE
[1.1.6] Add VoteScreen coverage for room setting gates

### DIFF
--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -11,6 +11,12 @@ import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish } from '../gameLogic.js'
 
+export function resolveAllAdvanceSelection(selectedIds, allowMerges) {
+  return allowMerges
+    ? { type: 'prompt_merge', drawFlow: { step: 3, selectedIds } }
+    : { type: 'confirm_draw', combatantIds: selectedIds, drawOutcome: 'all_advance' }
+}
+
 // Form for naming a merged combatant. Used both by the host (inline) and
 // by the primary owner when the host delegates. Parent bios are shown as
 // collapsible reference cards, collapsed by default.
@@ -936,10 +942,14 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
               Neither advances
             </button>
             <button
-              onClick={() => allowMerges
-                ? setDrawFlow({ step: 3, selectedIds: drawFlow.selectedIds })
-                : confirmDraw(drawFlow.selectedIds, 'all_advance')
-              }
+              onClick={() => {
+                const resolution = resolveAllAdvanceSelection(drawFlow.selectedIds, allowMerges)
+                if (resolution.type === 'prompt_merge') {
+                  setDrawFlow(resolution.drawFlow)
+                } else {
+                  confirmDraw(resolution.combatantIds, resolution.drawOutcome)
+                }
+              }}
               style={{ ...btn(), flex: 1, fontSize: 13, padding: '10px 8px' }}
             >
               All advance

--- a/src/screens/VoteScreen.test.jsx
+++ b/src/screens/VoteScreen.test.jsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import VoteScreen, { resolveAllAdvanceSelection } from './VoteScreen.jsx'
+
+vi.mock('../supabase.js', () => ({
+  sget: vi.fn(),
+  sset: vi.fn(),
+  incrementCombatantStats: vi.fn(),
+  publishCombatants: vi.fn(),
+  subscribeToRoom: vi.fn(() => () => {}),
+  createVariantCombatant: vi.fn(),
+  checkCombatantNameExists: vi.fn(),
+  getCombatant: vi.fn(),
+  trackRoomPresence: vi.fn(() => () => {}),
+}))
+
+vi.mock('../components/AvatarWithHover.jsx', () => ({ default: ({ player }) => <span>{player?.name || 'player'}</span> }))
+vi.mock('../components/Pill.jsx', () => ({ default: ({ children }) => <span>{children}</span> }))
+vi.mock('../components/DevBanner.jsx', () => ({ default: () => <div>DevBanner</div> }))
+vi.mock('../components/RoundChat.jsx', () => ({ default: () => <div>RoundChat</div> }))
+vi.mock('../components/EvolutionForm.jsx', () => ({ default: () => <div>EvolutionForm</div> }))
+vi.mock('../components/ConnectionStatus.jsx', () => ({ default: () => <div>ConnectionStatus</div> }))
+vi.mock('../components/SpectatorList.jsx', () => ({ default: () => <div>SpectatorList</div> }))
+vi.mock('../components/CombatantSheet.jsx', () => ({ default: () => <div>CombatantSheet</div> }))
+
+function makeRoom(settings = {}) {
+  return {
+    id: 'ROOM1',
+    code: 'ROOM1',
+    host: 'p1',
+    phase: 'battle',
+    settings,
+    players: [
+      { id: 'p1', name: 'Host', color: '#111' },
+      { id: 'p2', name: 'Guest', color: '#222' },
+    ],
+    spectators: [],
+    combatants: {
+      p1: [{ id: 'c1', name: 'Alpha', ownerId: 'p1', ownerName: 'Host', wins: 0 }],
+      p2: [{ id: 'c2', name: 'Beta', ownerId: 'p2', ownerName: 'Guest', wins: 0 }],
+    },
+    rounds: [{
+      number: 1,
+      combatants: [
+        { id: 'c1', name: 'Alpha', ownerId: 'p1', ownerName: 'Host', wins: 0, losses: 0, battles: [] },
+        { id: 'c2', name: 'Beta', ownerId: 'p2', ownerName: 'Guest', wins: 0, losses: 0, battles: [] },
+      ],
+      picks: { p1: 'c1' },
+      playerReactions: {},
+      chat: [],
+    }],
+    currentRound: 1,
+  }
+}
+
+function renderVoteScreen(room) {
+  return renderToStaticMarkup(
+    <VoteScreen
+      room={room}
+      playerId="p1"
+      setRoom={() => {}}
+      onResult={() => {}}
+      onViewPlayer={() => {}}
+      onHome={() => {}}
+      isGuest={false}
+      onLogin={() => {}}
+    />
+  )
+}
+
+describe('resolveAllAdvanceSelection', () => {
+  it('routes to the merge prompt when merges are enabled', () => {
+    expect(resolveAllAdvanceSelection(['c1', 'c2'], true)).toEqual({
+      type: 'prompt_merge',
+      drawFlow: { step: 3, selectedIds: ['c1', 'c2'] },
+    })
+  })
+
+  it('skips the merge prompt when merges are disabled', () => {
+    expect(resolveAllAdvanceSelection(['c1', 'c2'], false)).toEqual({
+      type: 'confirm_draw',
+      combatantIds: ['c1', 'c2'],
+      drawOutcome: 'all_advance',
+    })
+  })
+})
+
+describe('VoteScreen room setting gates', () => {
+  it('shows the Evolve action when allowEvolutions is enabled', () => {
+    const html = renderVoteScreen(makeRoom({ allowEvolutions: true }))
+    expect(html).toContain('Evolve')
+  })
+
+  it('hides the Evolve action when allowEvolutions is disabled', () => {
+    const html = renderVoteScreen(makeRoom({ allowEvolutions: false }))
+    expect(html).not.toContain('Evolve')
+  })
+
+  it('shows Declare draw when allowDraws is enabled', () => {
+    const html = renderVoteScreen(makeRoom({ allowDraws: true }))
+    expect(html).toContain('Declare draw')
+  })
+
+  it('hides Declare draw when allowDraws is disabled', () => {
+    const html = renderVoteScreen(makeRoom({ allowDraws: false }))
+    expect(html).not.toContain('Declare draw')
+  })
+})


### PR DESCRIPTION
## Summary
- add focused VoteScreen coverage for the new llowEvolutions, llowDraws, and llowMerges runtime gates
- extract the all-advance merge decision into a tiny pure helper so the merge-skip branch is testable
- verify the host Evolve and Declare draw actions render only when their room settings allow them

## Context
- I re-read issue #61 before making changes; it does not reference any additional docs
- the core runtime gating from #61 is already present on main via the merged settings work
- this PR makes that behavior explicit and regression-resistant with tests

## Testing
- [x] 
pm test
- [x] 
pm run build
- [ ] Manual test: llowEvolutions: false hides Evolve
- [ ] Manual test: llowDraws: false hides Declare draw
- [ ] Manual test: llowDraws: true, llowMerges: false skips merge step 3
- [ ] Manual test: all three true preserves existing flow

Refs #61