### PR TITLE
Follow-up: move resolveAllAdvanceSelection to gameLogic, tighten test assertions

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -361,6 +361,15 @@ export function applyWinner(room, round, winnerId) {
   return combatants
 }
 
+// Returns the next state when the host taps "All advance" in the draw flow.
+// When merges are enabled the flow proceeds to the merge-name step (step 3).
+// When disabled it short-circuits to a plain all_advance confirmation.
+export function resolveAllAdvanceSelection(selectedIds, allowMerges) {
+  return allowMerges
+    ? { type: 'prompt_merge', drawFlow: { step: 3, selectedIds } }
+    : { type: 'confirm_draw', combatantIds: selectedIds, drawOutcome: 'all_advance' }
+}
+
 /**
  * Applies draw (and optional partial loss) outcomes and appends round records.
  * round.draw === true  → all combatants in round.combatants drew (legacy).

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -9,13 +9,7 @@ import { btn, inp } from '../styles.js'
 import { sget, sset, incrementCombatantStats, publishCombatants, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
-import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish } from '../gameLogic.js'
-
-export function resolveAllAdvanceSelection(selectedIds, allowMerges) {
-  return allowMerges
-    ? { type: 'prompt_merge', drawFlow: { step: 3, selectedIds } }
-    : { type: 'confirm_draw', combatantIds: selectedIds, drawOutcome: 'all_advance' }
-}
+import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish, resolveAllAdvanceSelection } from '../gameLogic.js'
 
 // Form for naming a merged combatant. Used both by the host (inline) and
 // by the primary owner when the host delegates. Parent bios are shown as

--- a/src/screens/VoteScreen.test.jsx
+++ b/src/screens/VoteScreen.test.jsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
-import VoteScreen, { resolveAllAdvanceSelection } from './VoteScreen.jsx'
+import VoteScreen from './VoteScreen.jsx'
+import { resolveAllAdvanceSelection } from '../gameLogic.js'
 
 vi.mock('../supabase.js', () => ({
   sget: vi.fn(),
@@ -88,12 +89,12 @@ describe('resolveAllAdvanceSelection', () => {
 describe('VoteScreen room setting gates', () => {
   it('shows the Evolve action when allowEvolutions is enabled', () => {
     const html = renderVoteScreen(makeRoom({ allowEvolutions: true }))
-    expect(html).toContain('Evolve')
+    expect(html).toContain('Evolve ⚡')
   })
 
   it('hides the Evolve action when allowEvolutions is disabled', () => {
     const html = renderVoteScreen(makeRoom({ allowEvolutions: false }))
-    expect(html).not.toContain('Evolve')
+    expect(html).not.toContain('Evolve ⚡')
   })
 
   it('shows Declare draw when allowDraws is enabled', () => {
@@ -105,4 +106,7 @@ describe('VoteScreen room setting gates', () => {
     const html = renderVoteScreen(makeRoom({ allowDraws: false }))
     expect(html).not.toContain('Declare draw')
   })
+
+  // allowMerges gates the draw flow's "All advance" branch at runtime (drawFlow.step === 2),
+  // not the initial render. That branching is covered by the resolveAllAdvanceSelection unit tests above.
 })


### PR DESCRIPTION
Follow-up to #65.

## What changed

- **`resolveAllAdvanceSelection` moved to `gameLogic.js`** — it's pure game logic with no React or Supabase dependencies. Exporting it from a screen file violated the thin-screens principle in CLAUDE.md. `VoteScreen.jsx` now imports it from `gameLogic.js` alongside `applyDraw`/`applyMerge`.
- **Test assertions tightened** — `toContain('Evolve')` was a substring match that would also hit `"EvolutionForm"` from the mocked component. Changed to `toContain('Evolve ⚡')` and kept `toContain('Declare draw')` (no substring collision).
- **`allowMerges` coverage note added** — `allowMerges` is a behavioral gate (what "All advance" does at `drawFlow.step === 2`), not a visibility gate, so it can't be tested with a static render. Added a comment in the test file documenting this and pointing to the `resolveAllAdvanceSelection` unit tests as the correct coverage layer.

## Test notes

- `npm test` passes: 354/354