### PR TITLE
[1.1.6] Update docs and glossary for allowEvolutions, allowDraws, allowMerges settings

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,5 @@
 glossary
-last updated: 2026-04-14
+last updated: 2026-04-28
 
 The canonical definitions for all game layers, lifecycle states, and structural
 concepts. This is the reference document. When a term here conflicts with UI
@@ -119,6 +119,22 @@ at the game level.
   Series    | Series creator (usually host of first game)
   Season    | Season creator
   League    | League creator
+
+---
+
+ROOM SETTINGS
+
+Settings stored on a room at creation. All are booleans unless noted.
+Defaults enforced by normalizeRoomSettings in gameLogic.js.
+
+  rosterSize         integer  default: 8     Combatants each player drafts; determines round count.
+  spectatorsAllowed  boolean  default: true  When true, a separate spectate link is available in the lobby.
+  anonymousCombatants boolean default: false When true, owner names are hidden during voting.
+  blindVoting        boolean  default: false When true, votes are hidden until all players have submitted.
+  biosRequired       boolean  default: false When true, players must write a bio before locking their draft.
+  allowEvolutions    boolean  default: true  When false, the Evolve option is hidden after wins; winners confirm as-is.
+  allowDraws         boolean  default: true  When false, the host cannot declare a draw — only winner confirmation is available.
+  allowMerges        boolean  default: true  When false, draws cannot trigger a merge flow even if allowDraws is on.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,6 +35,9 @@ Tap "Create a room" on the home screen. You'll set your name and configure the r
 | Anonymous combatants | Hides the owner's name on each combatant card during the voting round. Useful if you want voting to be purely on the combatant, not the player. |
 | Blind voting | Individual votes are hidden until everyone has picked. Prevents pile-ons. The result is revealed all at once when the last vote is cast. |
 | Bios required | Forces every player to write a short bio for each combatant before locking in their roster. Recommended if your group leans into the narrative. |
+| Allow evolutions | When off, the Evolve option is hidden after wins. Winners are confirmed as-is. Evolutions are a fun ceremony — turn this off for faster games. |
+| Allow draws | When off, the host can only confirm a winner each round — no draw option. |
+| Allow merges | When draws are on, combatants that draw can merge into a new combined form. Turn this off to keep draws simple. |
 
 Once the room is created, share the 4-character code or use the copy-link buttons to invite players and spectators.
 
@@ -119,6 +122,8 @@ Evolution is the narrative heart of the game. When the host confirms a winner, t
 When a series continues, the evolved form appears in the owner's draft as a required pick — the owner must place the variant in a slot. The original is not required in its place; only the most recent evolved form is.
 
 If a combatant evolved multiple times across multiple games, only the current tip form (the most recent variant) appears as the required entry.
+
+If **Allow evolutions** is off, winners carry forward into the next series game as-is — no evolution prompt appears, and no variant is created. Champions still carry over as required picks.
 
 ### Reading the evolution in history
 


### PR DESCRIPTION
Closes #63

## What changed
- `docs/user-guide.md`: added three rows to the "Room settings" table (Allow evolutions, Allow draws, Allow merges) and a note in the Evolution → "In the next game (series)" section explaining that when Allow evolutions is off, champions carry forward as-is with no evolution prompt
- `docs/glossary.md`: added a ROOM SETTINGS section documenting all room settings with types, defaults, and one-line descriptions; updated `last updated` date

## Test notes
Docs-only change — no logic affected. Verify the new table rows read clearly alongside the existing ones and that the ROOM SETTINGS block in the glossary matches the defaults in `normalizeRoomSettings` (gameLogic.js:22–34).