### PR TITLE
Arenas: lobby delivery mode selection

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -29,7 +29,23 @@ export function normalizeRoomSettings(settings) {
     allowEvolutions:      true,
     allowDraws:           true,
     allowMerges:          true,
+    arenaMode:            'none',
+    arenaConfig:          null,
     ...settings,
+  }
+}
+
+/**
+ * Builds a round.arena snapshot from an arena DB record.
+ * Maps arena.bio → description and arena.rules → houseRules per the schema contract.
+ */
+export function buildArenaSnapshot(arena) {
+  return {
+    id:          arena.id,
+    name:        arena.name,
+    description: arena.bio   || '',
+    houseRules:  arena.rules || null,
+    tags:        arena.tags  || [],
   }
 }
 

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -3,8 +3,8 @@ import DevBanner from '../components/DevBanner.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn } from '../styles.js'
-import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence } from '../supabase.js'
-import { uid, canUndoLastRound, undoRound, tallyReactions } from '../gameLogic.js'
+import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain } from '../supabase.js'
+import { uid, canUndoLastRound, undoRound, tallyReactions, normalizeRoomSettings } from '../gameLogic.js'
 
 export default function BattleScreen({ room: init, playerId, setRoom, onVote, onChronicles, onHome, onNextGame, onRejoinNextGame }) {
   const [room, setLocal] = useState(init)
@@ -51,7 +51,25 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
   async function startRound() {
     const roundNum = room.currentRound + 1
     const matchup = room.players.map(p => (room.combatants[p.id] || [])[roundNum - 1]).filter(Boolean)
-    const newRound = { id: uid(), number: roundNum, combatants: matchup, picks: {}, winner: null, createdAt: Date.now() }
+
+    // Attach arena snapshot based on the configured delivery mode
+    const { arenaMode, arenaConfig } = normalizeRoomSettings(room.settings)
+    let arena = null
+    if (arenaMode === 'single') {
+      arena = arenaConfig?.arenaSnapshot || null
+    } else if (arenaMode === 'random-pool') {
+      // Collect arena IDs already used in this game
+      let excludeIds = (room.rounds || []).map(r => r.arena?.id).filter(Boolean)
+      // If series exclusion is on, also collect from prior games in the series
+      if (arenaConfig?.excludeSeries && room.seriesId && room.prevRoomId) {
+        const chain = await getHeritageChain(room.prevRoomId)
+        const seriesIds = chain.flatMap(r => (r.rounds || []).map(rd => rd.arena?.id)).filter(Boolean)
+        excludeIds = [...new Set([...excludeIds, ...seriesIds])]
+      }
+      arena = await getRandomArenaFromPool(arenaConfig?.pool || 'standard', excludeIds)
+    }
+
+    const newRound = { id: uid(), number: roundNum, combatants: matchup, picks: {}, winner: null, createdAt: Date.now(), arena }
     const updated = { ...room, phase: 'voting', currentRound: roundNum, rounds: [...room.rounds, newRound] }
     await sset('room:' + room.id, updated)
     setLocal(updated); setRoom(updated); onVote()
@@ -127,7 +145,10 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
           {room.rounds.map(r => (
             <div key={r.id} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', marginBottom: 8, border: '0.5px solid var(--color-border-tertiary)' }}>
               <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', minWidth: 52 }}>Round {r.number}</span>
-              <span style={{ fontSize: 13, color: 'var(--color-text-primary)', flex: 1 }}>{r.combatants.map(c => c.name).join(' vs ')}</span>
+              <span style={{ fontSize: 13, color: 'var(--color-text-primary)', flex: 1 }}>
+                {r.combatants.map(c => c.name).join(' vs ')}
+                {r.arena && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 6 }}>@ {r.arena.name}</span>}
+              </span>
               {r.winner
                 ? <>
                     <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-success)', flexShrink: 0 }}>🏆 {r.winner.name}</span>

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
-import { btn, inp, lbl } from '../styles.js'
-import { sset } from '../supabase.js'
-import { playerColor } from '../gameLogic.js'
+import { btn, inp, lbl, tab } from '../styles.js'
+import { sset, getArenaPickerOptions } from '../supabase.js'
+import { playerColor, buildArenaSnapshot } from '../gameLogic.js'
 
 function SettingRow({ label, description, value, onToggle, indented }) {
   return (
@@ -48,12 +48,58 @@ const SETTINGS = [
   ['allowDraws',             'Allow draws',             'Host can declare a round a draw instead of picking a winner.'],
 ]
 
+const ARENA_MODES = [
+  { value: 'none',        label: 'None' },
+  { value: 'single',      label: 'Single' },
+  { value: 'random-pool', label: 'Random pool' },
+  { value: 'playlist',    label: 'Playlist', disabled: true },
+]
+
+const POOL_OPTIONS = [
+  { value: 'standard',       label: 'Standard' },
+  { value: 'wacky',          label: 'Wacky' },
+  { value: 'league',         label: 'League' },
+  { value: 'weighted-liked', label: 'Fan favourites' },
+]
+
 export default function CreateRoom({ playerId, playerName, setPlayerName, lockedName, isGuest, onLogin, onCreated, onBack }) {
   const [name, setName] = useState(playerName)
   const [loading, setLoading] = useState(false)
-  const [settings, setSettings] = useState({ rosterSize: 8, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false, allowEvolutions: true, allowDraws: true, allowMerges: true })
+  const [settings, setSettings] = useState({ rosterSize: 8, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false, allowEvolutions: true, allowDraws: true, allowMerges: true, arenaMode: 'none', arenaConfig: null })
+
+  // Arena picker state for single mode
+  const [arenas,       setArenas]       = useState([])
+  const [arenaSearch,  setArenaSearch]  = useState('')
+  const [arenasLoaded, setArenasLoaded] = useState(false)
 
   function toggle(key) { setSettings(s => ({ ...s, [key]: !s[key] })) }
+
+  function selectArenaMode(mode) {
+    setSettings(s => ({ ...s, arenaMode: mode, arenaConfig: null }))
+    setArenaSearch('')
+    if (mode === 'single' && !arenasLoaded) {
+      getArenaPickerOptions(playerId).then(data => { setArenas(data); setArenasLoaded(true) })
+    }
+    if (mode === 'random-pool') {
+      setSettings(s => ({ ...s, arenaMode: mode, arenaConfig: { pool: 'standard', excludeSeries: false } }))
+    }
+  }
+
+  function pickArena(arena) {
+    setSettings(s => ({ ...s, arenaConfig: { arenaId: arena.id, arenaSnapshot: buildArenaSnapshot(arena) } }))
+  }
+
+  function clearArenaSelection() {
+    setSettings(s => ({ ...s, arenaConfig: null }))
+  }
+
+  function setPool(pool) {
+    setSettings(s => ({ ...s, arenaConfig: { ...(s.arenaConfig || {}), pool } }))
+  }
+
+  function toggleExcludeSeries() {
+    setSettings(s => ({ ...s, arenaConfig: { ...(s.arenaConfig || {}), excludeSeries: !(s.arenaConfig?.excludeSeries) } }))
+  }
 
   async function create() {
     if (!name.trim()) return
@@ -71,6 +117,12 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
     setLoading(false)
     onCreated(room)
   }
+
+  const filteredArenas = arenaSearch.trim()
+    ? arenas.filter(a => a.name.toLowerCase().includes(arenaSearch.trim().toLowerCase()) || (a.bio || '').toLowerCase().includes(arenaSearch.trim().toLowerCase()))
+    : arenas
+
+  const selectedArenaSnapshot = settings.arenaConfig?.arenaSnapshot || null
 
   return (
     <Screen title="New room" onBack={onBack}>
@@ -107,6 +159,127 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
             )}
           </div>
         ))}
+      </div>
+
+      {/* ── Arena ───────────────────────────────────────────────────────── */}
+      <h3 style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.06em', margin: '0 0 8px' }}>Arena</h3>
+      <div style={{ marginBottom: '1.5rem' }}>
+        {/* Mode selector */}
+        <div style={{ display: 'flex', gap: 4, marginBottom: 12 }}>
+          {ARENA_MODES.map(({ value, label, disabled }) => (
+            <button
+              key={value}
+              onClick={() => !disabled && selectArenaMode(value)}
+              disabled={disabled}
+              style={{
+                ...tab(settings.arenaMode === value),
+                flex: 1,
+                opacity: disabled ? 0.4 : 1,
+                cursor: disabled ? 'default' : 'pointer',
+                fontSize: 12,
+              }}
+              title={disabled ? 'Coming soon' : undefined}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Single mode: arena search + select */}
+        {settings.arenaMode === 'single' && (
+          <div>
+            {selectedArenaSnapshot ? (
+              <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{selectedArenaSnapshot.name}</div>
+                    {selectedArenaSnapshot.description && (
+                      <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                        {selectedArenaSnapshot.description}
+                      </p>
+                    )}
+                    {selectedArenaSnapshot.houseRules && (
+                      <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0', fontStyle: 'italic' }}>
+                        Rules: {selectedArenaSnapshot.houseRules.length > 60 ? selectedArenaSnapshot.houseRules.slice(0, 60) + '…' : selectedArenaSnapshot.houseRules}
+                      </p>
+                    )}
+                  </div>
+                  <button onClick={clearArenaSelection} style={{ ...btn('ghost'), padding: '3px 10px', fontSize: 12, flexShrink: 0 }}>Change</button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <input
+                  style={{ ...inp(), margin: '0 0 6px', fontSize: 14 }}
+                  value={arenaSearch}
+                  onChange={e => setArenaSearch(e.target.value)}
+                  placeholder="Search arenas…"
+                  autoFocus
+                />
+                {!arenasLoaded ? (
+                  <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+                ) : filteredArenas.length === 0 ? (
+                  <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
+                    {arenas.length === 0 ? 'No arenas yet — create one in The Workshop first.' : 'No arenas match your search.'}
+                  </p>
+                ) : (
+                  <div style={{ border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden', maxHeight: 240, overflowY: 'auto' }}>
+                    {filteredArenas.map((arena, i) => (
+                      <button
+                        key={arena.id}
+                        onClick={() => pickArena(arena)}
+                        style={{ display: 'block', width: '100%', textAlign: 'left', padding: '10px 14px', background: i % 2 === 0 ? 'var(--color-background-secondary)' : 'var(--color-background-primary)', border: 'none', borderTop: i === 0 ? 'none' : '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                          <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{arena.name}</span>
+                          {arena.status === 'stashed' && (
+                            <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>stashed</span>
+                          )}
+                        </div>
+                        {arena.bio && (
+                          <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '2px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical' }}>
+                            {arena.bio}
+                          </p>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Random pool mode: pool selector + series exclusion */}
+        {settings.arenaMode === 'random-pool' && (
+          <div>
+            <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginBottom: 6 }}>Pool</div>
+            <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 12 }}>
+              {POOL_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setPool(value)}
+                  style={{ ...tab(settings.arenaConfig?.pool === value), fontSize: 12 }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <SettingRow
+              label="Exclude series arenas"
+              description="Skip arenas already played in the current series"
+              value={settings.arenaConfig?.excludeSeries || false}
+              onToggle={toggleExcludeSeries}
+            />
+          </div>
+        )}
+
+        {/* Playlist mode: gated */}
+        {settings.arenaMode === 'playlist' && (
+          <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
+            Playlist delivery coming soon.
+          </p>
+        )}
       </div>
 
       <button style={btn('primary')} onClick={create} disabled={!name.trim() || loading}>{loading ? 'Creating…' : 'Create room'}</button>

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -5,7 +5,66 @@ import ShareLinkButton from '../components/ShareLinkButton.jsx'
 import SpectatorList from '../components/SpectatorList.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn } from '../styles.js'
-import { sset, subscribeToRoom, trackRoomPresence, getArenaPickerOptions } from '../supabase.js'
+import { sset, subscribeToRoom, trackRoomPresence } from '../supabase.js'
+import { normalizeRoomSettings } from '../gameLogic.js'
+
+const POOL_LABELS = {
+  'standard':       'Standard',
+  'wacky':          'Wacky',
+  'league':         'League',
+  'weighted-liked': 'Fan favourites',
+}
+
+function ArenaModeDisplay({ settings }) {
+  const { arenaMode, arenaConfig } = normalizeRoomSettings(settings)
+
+  if (arenaMode === 'none') return null
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h3 style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 400, margin: '0 0 8px' }}>Arena</h3>
+      <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px' }}>
+        {arenaMode === 'single' && arenaConfig?.arenaSnapshot && (
+          <>
+            <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+              {arenaConfig.arenaSnapshot.name}
+            </div>
+            {arenaConfig.arenaSnapshot.description && (
+              <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0' }}>
+                {arenaConfig.arenaSnapshot.description}
+              </p>
+            )}
+            {arenaConfig.arenaSnapshot.houseRules && (
+              <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0', fontStyle: 'italic' }}>
+                Rules: {arenaConfig.arenaSnapshot.houseRules}
+              </p>
+            )}
+          </>
+        )}
+        {arenaMode === 'single' && !arenaConfig?.arenaSnapshot && (
+          <span style={{ fontSize: 13, color: 'var(--color-text-tertiary)' }}>Single arena — not yet selected</span>
+        )}
+        {arenaMode === 'random-pool' && (
+          <div>
+            <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>
+              Random · {POOL_LABELS[arenaConfig?.pool] || arenaConfig?.pool || 'Standard'} pool
+            </span>
+            {arenaConfig?.excludeSeries && (
+              <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 8 }}>
+                (series arenas excluded)
+              </span>
+            )}
+          </div>
+        )}
+        {arenaMode === 'playlist' && (
+          <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>
+            Playlist · {arenaConfig?.playlistId || 'not configured'}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
 
 export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, onLogin, onStart, onBack, onViewPlayer }) {
   const [room, setLocal]           = useState(init)
@@ -14,19 +73,11 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
   // 'idle' | 'confirming' — guest-host gate before starting the game
   const [guestStartPrompt, setGuestStartPrompt] = useState('idle')
 
-  // Arena picker state (host only)
-  const [arenas,           setArenas]           = useState([])
-  const [arenaPickerOpen,  setArenaPickerOpen]  = useState(false)
-  // Track the currently selected arena object separately for badge display
-  const [selectedArena,    setSelectedArena]    = useState(init.settings?.arena ?? null)
-
   const isHost = room.host === playerId
 
   useEffect(() => {
     return subscribeToRoom(room.id, r => {
       setLocal(r); setRoom(r)
-      // Sync selected arena if another host session updated it
-      setSelectedArena(r.settings?.arena ?? null)
       if (r.phase === 'draft') onStart()
       if (r.phase === 'ended') onBack()
     })
@@ -37,12 +88,6 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
       onPresenceChange: setPresentIds,
     })
   }, [room.id])
-
-  // Load arena options for the host picker
-  useEffect(() => {
-    if (!isHost) return
-    getArenaPickerOptions(playerId).then(setArenas)
-  }, [isHost, playerId])
 
   async function startGame() {
     const updated = { ...room, phase: 'draft' }
@@ -62,23 +107,6 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
     const updated = { ...room, phase: 'ended', cancelledAt: Date.now() }
     await sset('room:' + room.id, updated)
     onBack()
-  }
-
-  async function pickArena(arena) {
-    const snapshot = { id: arena.id, name: arena.name, bio: arena.bio, rules: arena.rules || null, tags: arena.tags }
-    const updated  = { ...room, settings: { ...(room.settings || {}), arena: snapshot } }
-    await sset('room:' + room.id, updated)
-    setLocal(updated); setRoom(updated)
-    setSelectedArena(arena)
-    setArenaPickerOpen(false)
-  }
-
-  async function clearArena() {
-    const { arena: _removed, ...restSettings } = room.settings || {}
-    const updated = { ...room, settings: restSettings }
-    await sset('room:' + room.id, updated)
-    setLocal(updated); setRoom(updated)
-    setSelectedArena(null)
   }
 
   return (
@@ -101,103 +129,7 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
         ))}
       </div>
 
-      {/* ── Arena picker (host only) ── */}
-      {isHost && (
-        <div style={{ marginBottom: '1.5rem' }}>
-          <h3 style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 400, margin: '0 0 8px' }}>Arena (optional)</h3>
-
-          {selectedArena ? (
-            <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px' }}>
-              <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8 }}>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-                    <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{selectedArena.name}</span>
-                    {selectedArena.status === 'stashed' && (
-                      <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>
-                        🔒 stashed
-                      </span>
-                    )}
-                  </div>
-                  {selectedArena.bio && (
-                    <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
-                      {selectedArena.bio}
-                    </p>
-                  )}
-                  {selectedArena.rules && (
-                    <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0', fontStyle: 'italic' }}>
-                      Rules: {selectedArena.rules.length > 60 ? selectedArena.rules.slice(0, 60) + '…' : selectedArena.rules}
-                    </p>
-                  )}
-                </div>
-              </div>
-              <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
-                <button onClick={() => setArenaPickerOpen(true)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Change</button>
-                <button onClick={clearArena} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12, color: 'var(--color-text-tertiary)' }}>Remove</button>
-              </div>
-            </div>
-          ) : (
-            <button
-              onClick={() => setArenaPickerOpen(o => !o)}
-              style={{ ...btn('ghost'), width: '100%', fontSize: 13, color: 'var(--color-text-secondary)' }}
-            >
-              {arenaPickerOpen ? 'Close picker ↑' : '+ Choose an arena'}
-            </button>
-          )}
-
-          {arenaPickerOpen && !selectedArena && (
-            <div style={{ marginTop: 8, border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden', maxHeight: 280, overflowY: 'auto' }}>
-              {arenas.length === 0 && (
-                <p style={{ padding: '12px 14px', fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
-                  No arenas available. Create one in My Workshop or wait for published arenas to appear.
-                </p>
-              )}
-              {arenas.map((arena, i) => (
-                <button
-                  key={arena.id}
-                  onClick={() => pickArena(arena)}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    padding: '10px 14px',
-                    background: i % 2 === 0 ? 'var(--color-background-secondary)' : 'var(--color-background-primary)',
-                    border: 'none',
-                    borderTop: i === 0 ? 'none' : '0.5px solid var(--color-border-tertiary)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-                    <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{arena.name}</span>
-                    {arena.status === 'stashed' && (
-                      <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>
-                        🔒 stashed
-                      </span>
-                    )}
-                  </div>
-                  {arena.bio && (
-                    <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '2px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical' }}>
-                      {arena.bio}
-                    </p>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* ── Show selected arena to non-host players ── */}
-      {!isHost && selectedArena && (
-        <div style={{ marginBottom: '1.5rem' }}>
-          <h3 style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 400, margin: '0 0 8px' }}>Arena</h3>
-          <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px' }}>
-            <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{selectedArena.name}</span>
-            {selectedArena.bio && (
-              <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0' }}>{selectedArena.bio}</p>
-            )}
-          </div>
-        </div>
-      )}
+      <ArenaModeDisplay settings={room.settings} />
 
       {isHost ? (
         <>

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -218,7 +218,9 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       if (isFinalRound(r)) {
         const { rosterSize } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
-        if (r.settings?.arena?.id) await publishArenas([r.settings.arena.id])
+        // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
+        const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
+        if (arenaIds.length) await publishArenas(arenaIds)
       }
     })()
   }
@@ -269,7 +271,9 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       if (isFinalRound(r)) {
         const { rosterSize } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
-        if (r.settings?.arena?.id) await publishArenas([r.settings.arena.id])
+        // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
+        const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
+        if (arenaIds.length) await publishArenas(arenaIds)
       }
     })()
   }
@@ -415,7 +419,9 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       if (isFinalRound(r)) {
         const { rosterSize } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
-        if (r.settings?.arena?.id) await publishArenas([r.settings.arena.id])
+        // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
+        const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
+        if (arenaIds.length) await publishArenas(arenaIds)
       }
     })()
   }
@@ -655,9 +661,22 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
           Host is out of the room
         </div>
       )}
-      <p style={{ color: 'var(--color-text-secondary)', fontSize: 14, margin: '0 0 1.5rem' }}>
+      <p style={{ color: 'var(--color-text-secondary)', fontSize: 14, margin: '0 0 1rem' }}>
         {isHost ? 'Pick the winner, then confirm to lock it in.' : 'Tap your pick — the host will confirm the final call.'}
       </p>
+
+      {/* ── Arena context ────────────────────────────────────────────── */}
+      {round.arena && (
+        <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '8px 14px', marginBottom: '1rem' }}>
+          <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary)' }}>{round.arena.name}</div>
+          {round.arena.description && (
+            <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '2px 0 0' }}>{round.arena.description}</p>
+          )}
+          {round.arena.houseRules && (
+            <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0', fontStyle: 'italic' }}>Rules: {round.arena.houseRules}</p>
+          )}
+        </div>
+      )}
 
       {trapAnnouncement && (
         <div style={{ marginBottom: '1.5rem', padding: '16px 18px', background: 'var(--color-background-danger)', border: '1.5px solid var(--color-border-danger)', borderRadius: 'var(--border-radius-lg)', textAlign: 'center' }}>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -889,6 +889,41 @@ export async function publishArenas(ids) {
   } catch (e) { console.error('publishArenas exception', e) }
 }
 
+// Returns a random arena snapshot for random-pool delivery mode.
+// pool: 'standard' | 'wacky' | 'league' | 'weighted-liked'
+// excludeArenaIds: arena IDs to exclude (e.g. already played in the series)
+// Pool-specific curation (standard/wacky/league) deferred to Super Host #74 —
+// all published arenas are eligible across those pools for now.
+export async function getRandomArenaFromPool(pool, excludeArenaIds = []) {
+  try {
+    const { data, error } = await supabase
+      .from('arenas')
+      .select('id, name, bio, rules, tags, likes, dislikes')
+      .eq('status', 'published')
+    if (error || !data?.length) return null
+
+    let eligible = data
+    if (pool === 'weighted-liked') {
+      eligible = eligible.filter(a => (a.likes || 0) >= (a.dislikes || 0))
+    }
+    if (excludeArenaIds.length) {
+      const filtered = eligible.filter(a => !excludeArenaIds.includes(a.id))
+      // fall back to full eligible set if all are excluded
+      if (filtered.length) eligible = filtered
+    }
+    if (!eligible.length) return null
+
+    const arena = eligible[Math.floor(Math.random() * eligible.length)]
+    return {
+      id:          arena.id,
+      name:        arena.name,
+      description: arena.bio   || '',
+      houseRules:  arena.rules || null,
+      tags:        arena.tags  || [],
+    }
+  } catch (e) { console.error('getRandomArenaFromPool exception', e); return null }
+}
+
 // Returns arenas visible to a host in the lobby arena picker:
 // all published arenas + the host's own stashed arenas.
 export async function getArenaPickerOptions(ownerId) {


### PR DESCRIPTION
Closes #69
**Note:** depends on #15 (Create-an-Arena). Branched from `15-workshop-create-an-arena`; rebase onto main once #15 merges.

## What changed

- **`gameLogic.js`**: `normalizeRoomSettings` defaults `arenaMode: 'none'` and `arenaConfig: null`. Added `buildArenaSnapshot(arena)` pure helper mapping `bio → description` and `rules → houseRules` per the migration schema.

- **`supabase.js`**: Added `getRandomArenaFromPool(pool, excludeArenaIds)` — queries published arenas, applies `weighted-liked` dislike suppression, excludes specified IDs, returns a random snapshot. Pool-specific curation (standard/wacky/league) deferred to Super Host #74.

- **`CreateRoom.jsx`**: New "Arena" settings section with a four-button mode selector (None · Single · Random pool · Playlist[disabled]). Single shows inline arena picker with search. Random-pool shows pool selector and "Exclude series arenas" toggle. `arenaMode` and `arenaConfig` stored in `room.settings` at creation.

- **`LobbyScreen.jsx`**: Replaced the provisional `settings.arena` picker (added in #15) with a read-only `ArenaModeDisplay` showing the configured mode to all players.

- **`BattleScreen.jsx`**: `startRound` attaches `round.arena` per mode. Single copies `arenaConfig.arenaSnapshot`. Random-pool calls `getRandomArenaFromPool` with optional series exclusion via heritage chain. Null arena displays cleanly. Round list shows `@ Arena Name` inline when set.

- **`VoteScreen.jsx`**: Arena card above combatant cards when `round.arena` is set. Fixed `publishArenas` to collect IDs from `round.arena` across all rounds (covers all modes, not just the old `settings.arena` approach).

## Test notes

- Create room → each arena mode shows correct config UI
- Single: pick arena → lobby shows name/description; every round's vote screen shows arena card
- Random-pool: lobby shows pool label; each round gets a different random arena at open time
- Playlist: button disabled/dimmed
- None: no arena section anywhere (lobby, round list, vote screen)
- Final round with arena → arena publishes on game completion