### PR TITLE
The Archive screen

### DIFF
--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -2,7 +2,9 @@ import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import { btn, tab, inp } from '../styles.js'
-import { listCombatants, searchCast } from '../supabase.js'
+import { listCombatants, searchCast, listPublishedGroups, listPublishedArenas, listAllDistinctTags } from '../supabase.js'
+
+const PAGE_SIZE = 20
 
 const CAST_SORTS = [
   { key: 'wins',            label: 'Wins',   asc: false },
@@ -12,90 +14,42 @@ const CAST_SORTS = [
   { key: 'reactions_cry',   label: '😂',     asc: false },
   { key: 'name',            label: 'A–Z',    asc: true  },
 ]
-const PAGE_SIZE = 20
 
-export default function ArchiveScreen({ onBack, onViewCombatant }) {
-  const [items, setItems]       = useState([])
-  const [total, setTotal]       = useState(0)
-  const [page, setPage]         = useState(0)
-  const [sort, setSort]         = useState('wins')
-  const [loading, setLoading]   = useState(true)
-  const [query, setQuery]       = useState('')
-  const [activeTag, setActiveTag] = useState(null)
-  const debounceRef = useRef(null)
-  // "characters" hides variants (combatants with lineage set) so each character
-  // appears once — story-first, not form-first. "all" shows every published form.
-  const [view, setView] = useState('characters')
+// ─── The Cast tab ─────────────────────────────────────────────────────────────
+
+function CastTab({ query, activeTag, onFilterTag, onViewCombatant }) {
+  const [items, setItems]     = useState([])
+  const [total, setTotal]     = useState(0)
+  const [page, setPage]       = useState(0)
+  const [sort, setSort]       = useState('wins')
+  const [loading, setLoading] = useState(true)
+  // "characters" hides variants so each character appears once — story-first.
+  const [view, setView]       = useState('characters')
+
+  useEffect(() => { setPage(0) }, [query, activeTag])
 
   useEffect(() => {
     setLoading(true)
     const sortDef = CAST_SORTS.find(s => s.key === sort)
-    // baseOnly filters variants server-side so pagination counts are accurate
     const opts = { sort, ascending: sortDef?.asc ?? false, page, pageSize: PAGE_SIZE, baseOnly: view === 'characters', tag: activeTag }
-    const fn = query.trim()
-      ? searchCast(query.trim(), opts)
-      : listCombatants(opts)
+    const fn = query.trim() ? searchCast(query.trim(), opts) : listCombatants(opts)
     fn.then(({ items, total }) => { setItems(items); setTotal(total); setLoading(false) })
   }, [sort, page, query, view, activeTag])
 
-  function changeSort(key) {
-    if (sort === key) return
-    setSort(key); setPage(0)
-  }
-
-  function handleSearch(val) {
-    clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => { setQuery(val); setPage(0) }, 280)
-  }
-
-  function filterByTag(tag) {
-    setActiveTag(tag); setPage(0)
-  }
-
-  function clearTagFilter() {
-    setActiveTag(null); setPage(0)
-  }
+  function changeSort(key) { if (sort !== key) { setSort(key); setPage(0) } }
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
 
   return (
-    <Screen title="The Cast" onBack={onBack}>
-      <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '-0.75rem 0 1rem' }}>Every fighter ever entered, across all games.</p>
+    <>
+      <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '0 0 1rem' }}>Every fighter ever entered, across all games.</p>
 
-      <input
-        style={{ ...inp(), margin: '0 0 1rem' }}
-        placeholder="Search by name, bio, or player…"
-        onChange={e => handleSearch(e.target.value)}
-      />
-
-      {/* Active tag filter pill */}
-      {activeTag && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: '0.75rem' }}>
-          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Tag:</span>
-          <span style={{
-            display: 'inline-flex', alignItems: 'center', gap: 4,
-            padding: '3px 9px',
-            background: 'var(--color-background-info)',
-            border: '0.5px solid var(--color-border-info)',
-            borderRadius: 99, fontSize: 12, color: 'var(--color-text-info)',
-          }}>
-            {activeTag}
-            <button
-              onClick={clearTagFilter}
-              style={{ background: 'none', border: 'none', padding: '0 0 0 2px', cursor: 'pointer', color: 'var(--color-text-info)', fontSize: 13, lineHeight: 1 }}
-            >×</button>
-          </span>
-        </div>
-      )}
-
-      {/* View toggle */}
       <div style={{ display: 'flex', gap: 6, marginBottom: '1rem' }}>
         {[['characters', 'Characters'], ['all', 'All forms']].map(([key, label]) => (
-          <button key={key} onClick={() => setView(key)} style={tab(view === key)}>{label}</button>
+          <button key={key} onClick={() => { setView(key); setPage(0) }} style={tab(view === key)}>{label}</button>
         ))}
       </div>
 
-      {/* Sort bar */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: '1.25rem' }}>
         {CAST_SORTS.map(s => (
           <button key={s.key} onClick={() => changeSort(s.key)} style={tab(sort === s.key)}>{s.label}</button>
@@ -156,7 +110,7 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
             {c.bio && <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '4px 0 0 32px', lineHeight: 1.4 }}>{c.bio.length > 90 ? c.bio.slice(0, 90) + '…' : c.bio}</p>}
             {tags.length > 0 && (
               <div style={{ marginTop: 6, paddingLeft: 32 }} onClick={e => e.stopPropagation()}>
-                <TagChips tags={tags} onFilter={filterByTag} />
+                <TagChips tags={tags} onFilter={onFilterTag} />
               </div>
             )}
           </button>
@@ -170,6 +124,249 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
           <button onClick={() => setPage(p => p + 1)} disabled={page >= totalPages - 1} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13 }}>Next →</button>
         </div>
       )}
+    </>
+  )
+}
+
+// ─── Groups tab ───────────────────────────────────────────────────────────────
+
+function GroupsTab({ query, activeTag, onFilterTag }) {
+  const [groups, setGroups]   = useState([])
+  const [loading, setLoading] = useState(true)
+  const [expanded, setExpanded] = useState(null)
+
+  useEffect(() => {
+    setLoading(true)
+    listPublishedGroups({ query, tag: activeTag }).then(data => { setGroups(data); setLoading(false) })
+  }, [query, activeTag])
+
+  if (loading) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>
+
+  if (!groups.length) return (
+    <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+      {activeTag
+        ? `No groups tagged "${activeTag}".`
+        : query.trim()
+          ? `No groups matching "${query.trim()}".`
+          : 'No groups yet.'}
+    </p>
+  )
+
+  return (
+    <>
+      {groups.map(g => {
+        const isExpanded = expanded === g.id
+        const tags = g.tags || []
+        return (
+          <div key={g.id} style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: 8, overflow: 'hidden' }}>
+            <button
+              onClick={() => setExpanded(isExpanded ? null : g.id)}
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '12px 14px', background: 'none', border: 'none', cursor: 'pointer' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 2 }}>
+                <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{g.name}</span>
+                <span style={{ fontSize: 12, color: 'var(--color-text-secondary)', flexShrink: 0, marginLeft: 8 }}>{g.wins}W – {g.losses}L</span>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', display: 'flex', gap: 12 }}>
+                <span>{g.member_count} {g.member_count === 1 ? 'member' : 'members'}</span>
+                {g.most_decorated && <span>Top: {g.most_decorated}</span>}
+              </div>
+              {tags.length > 0 && (
+                <div style={{ marginTop: 6 }} onClick={e => e.stopPropagation()}>
+                  <TagChips tags={tags} onFilter={onFilterTag} />
+                </div>
+              )}
+            </button>
+            {isExpanded && (
+              <div style={{ padding: '0 14px 12px', borderTop: '0.5px solid var(--color-border-tertiary)' }}>
+                {g.description
+                  ? <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: '8px 0 4px', lineHeight: 1.5 }}>{g.description}</p>
+                  : <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: '8px 0 4px', fontStyle: 'italic' }}>No description.</p>}
+                <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: 0 }}>by {g.owner_name}</p>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+// ─── Arenas tab ───────────────────────────────────────────────────────────────
+
+function ArenasTab({ query, activeTag, onFilterTag }) {
+  const [items, setItems]     = useState([])
+  const [total, setTotal]     = useState(0)
+  const [page, setPage]       = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [expanded, setExpanded] = useState(null)
+
+  useEffect(() => { setPage(0) }, [query, activeTag])
+
+  useEffect(() => {
+    setLoading(true)
+    listPublishedArenas({ query, tag: activeTag, page, pageSize: PAGE_SIZE }).then(({ items, total }) => {
+      setItems(items); setTotal(total); setLoading(false)
+    })
+  }, [query, activeTag, page])
+
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  if (loading) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>
+
+  if (!items.length) return (
+    <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+      {activeTag
+        ? `No arenas tagged "${activeTag}".`
+        : query.trim()
+          ? `No arenas matching "${query.trim()}".`
+          : 'No arenas yet — create some in The Workshop.'}
+    </p>
+  )
+
+  return (
+    <>
+      {items.map(a => {
+        const isExpanded = expanded === a.id
+        const tags = a.tags || []
+        const hasRules = !!a.rules?.trim()
+        return (
+          <div key={a.id} style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: 8, overflow: 'hidden' }}>
+            <button
+              onClick={() => setExpanded(isExpanded ? null : a.id)}
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '12px 14px', background: 'none', border: 'none', cursor: 'pointer' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 2 }}>
+                <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{a.name}</span>
+                <div style={{ display: 'flex', gap: 8, fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0, marginLeft: 8 }}>
+                  {a.likes    > 0 && <span>👍 {a.likes}</span>}
+                  {a.dislikes > 0 && <span>👎 {a.dislikes}</span>}
+                  {hasRules && <span style={{ fontSize: 11 }}>+ rules</span>}
+                </div>
+              </div>
+              {a.bio && (
+                <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '2px 0 0', lineHeight: 1.4 }}>
+                  {!isExpanded && a.bio.length > 100 ? a.bio.slice(0, 100) + '…' : a.bio}
+                </p>
+              )}
+              {tags.length > 0 && (
+                <div style={{ marginTop: 6 }} onClick={e => e.stopPropagation()}>
+                  <TagChips tags={tags} onFilter={onFilterTag} />
+                </div>
+              )}
+            </button>
+            {isExpanded && hasRules && (
+              <div style={{ padding: '0 14px 12px', borderTop: '0.5px solid var(--color-border-tertiary)' }}>
+                <p style={{ fontSize: 11, fontWeight: 600, color: 'var(--color-text-tertiary)', margin: '8px 0 4px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>House rules</p>
+                <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: '0 0 6px', lineHeight: 1.5 }}>{a.rules}</p>
+                <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: 0 }}>by {a.owner_name}</p>
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      {totalPages > 1 && (
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 16, marginTop: '1.25rem' }}>
+          <button onClick={() => setPage(p => p - 1)} disabled={page === 0} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13 }}>← Prev</button>
+          <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>{page + 1} / {totalPages}</span>
+          <button onClick={() => setPage(p => p + 1)} disabled={page >= totalPages - 1} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13 }}>Next →</button>
+        </div>
+      )}
+    </>
+  )
+}
+
+// ─── Tags tab ─────────────────────────────────────────────────────────────────
+
+function TagsTab({ activeTag, onFilterTag }) {
+  const [tags, setTags]       = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    listAllDistinctTags().then(data => { setTags(data); setLoading(false) })
+  }, [])
+
+  if (loading) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>
+  if (!tags.length) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>No tags yet.</p>
+
+  return (
+    <>
+      <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '0 0 1rem' }}>Tap a tag to filter across all tabs.</p>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        {tags.map(({ tag, count }) => (
+          <button
+            key={tag}
+            onClick={() => onFilterTag(tag === activeTag ? null : tag)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 5,
+              padding: '5px 11px',
+              background:   activeTag === tag ? 'var(--color-background-info)' : 'var(--color-background-secondary)',
+              border:       `0.5px solid ${activeTag === tag ? 'var(--color-border-info)' : 'var(--color-border-tertiary)'}`,
+              borderRadius: 99, fontSize: 13,
+              color:        activeTag === tag ? 'var(--color-text-info)' : 'var(--color-text-primary)',
+              cursor: 'pointer',
+            }}>
+            {tag}
+            <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>{count}</span>
+          </button>
+        ))}
+      </div>
+    </>
+  )
+}
+
+// ─── Archive screen ───────────────────────────────────────────────────────────
+
+const TABS = [
+  { key: 'cast',   label: 'The Cast' },
+  { key: 'groups', label: 'Groups'   },
+  { key: 'arenas', label: 'Arenas'   },
+  { key: 'tags',   label: 'Tags'     },
+]
+
+export default function ArchiveScreen({ onBack, onViewCombatant }) {
+  const [activeTab, setActiveTab] = useState('cast')
+  const [query, setQuery]         = useState('')
+  const [activeTag, setActiveTag] = useState(null)
+  const debounceRef = useRef(null)
+
+  function handleSearch(val) {
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => setQuery(val), 280)
+  }
+
+  function handleFilterTag(tag) { setActiveTag(tag) }
+  function clearTag()           { setActiveTag(null) }
+
+  return (
+    <Screen title="The Archive" onBack={onBack}>
+      <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '-0.75rem 0 1rem' }}>The world the games have built.</p>
+
+      <input
+        style={{ ...inp(), margin: '0 0 0.75rem' }}
+        placeholder="Search by name…"
+        onChange={e => handleSearch(e.target.value)}
+      />
+
+      {activeTag && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: '0.75rem' }}>
+          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Tag:</span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '3px 9px', background: 'var(--color-background-info)', border: '0.5px solid var(--color-border-info)', borderRadius: 99, fontSize: 12, color: 'var(--color-text-info)' }}>
+            {activeTag}
+            <button onClick={clearTag} style={{ background: 'none', border: 'none', padding: '0 0 0 2px', cursor: 'pointer', color: 'var(--color-text-info)', fontSize: 13, lineHeight: 1 }}>×</button>
+          </span>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 6, marginBottom: '1.25rem', flexWrap: 'wrap' }}>
+        {TABS.map(t => (
+          <button key={t.key} onClick={() => setActiveTab(t.key)} style={tab(activeTab === t.key)}>{t.label}</button>
+        ))}
+      </div>
+
+      {activeTab === 'cast'   && <CastTab   query={query} activeTag={activeTag} onFilterTag={handleFilterTag} onViewCombatant={onViewCombatant} />}
+      {activeTab === 'groups' && <GroupsTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} />}
+      {activeTab === 'arenas' && <ArenasTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} />}
+      {activeTab === 'tags'   && <TagsTab   activeTag={activeTag} onFilterTag={handleFilterTag} />}
     </Screen>
   )
 }

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -939,3 +939,80 @@ export async function getArenaPickerOptions(ownerId) {
     return (data || []).filter(a => { if (seen.has(a.id)) return false; seen.add(a.id); return true })
   } catch (e) { console.error('getArenaPickerOptions exception', e); return [] }
 }
+
+// ─── Archive listing functions ────────────────────────────────────────────────
+
+// Published groups with aggregated member count, combined W/L, and most-decorated
+// member name. Three queries aggregated client-side (acceptable at expected scale).
+export async function listPublishedGroups({ query = '', tag = null } = {}) {
+  try {
+    const [groupsRes, membershipsRes, combatantsRes] = await Promise.all([
+      supabase.from('groups').select('id, name, description, owner_name, tags').eq('status', 'published'),
+      supabase.from('combatant_groups').select('combatant_id, group_id'),
+      supabase.from('combatants').select('id, name, wins, losses, reactions_heart, reactions_angry, reactions_cry').eq('status', 'published'),
+    ])
+    if (groupsRes.error || membershipsRes.error || combatantsRes.error) return []
+
+    const combatantMap = Object.fromEntries((combatantsRes.data || []).map(c => [c.id, c]))
+    const membersByGroup = {}
+    for (const row of (membershipsRes.data || [])) {
+      if (!membersByGroup[row.group_id]) membersByGroup[row.group_id] = []
+      if (combatantMap[row.combatant_id]) membersByGroup[row.group_id].push(combatantMap[row.combatant_id])
+    }
+
+    let groups = (groupsRes.data || []).map(g => {
+      const members = membersByGroup[g.id] || []
+      const wins   = members.reduce((s, c) => s + (c.wins   || 0), 0)
+      const losses = members.reduce((s, c) => s + (c.losses || 0), 0)
+      const mostDecorated = members.reduce((best, c) => {
+        const score     = (c.wins || 0) * 3 + (c.reactions_heart || 0) + (c.reactions_angry || 0) + (c.reactions_cry || 0)
+        const bestScore = best ? (best.wins || 0) * 3 + (best.reactions_heart || 0) + (best.reactions_angry || 0) + (best.reactions_cry || 0) : -1
+        return score > bestScore ? c : best
+      }, null)
+      return { ...g, member_count: members.length, wins, losses, most_decorated: mostDecorated?.name ?? null }
+    })
+
+    if (tag)         groups = groups.filter(g => (g.tags || []).includes(tag))
+    if (query.trim()) {
+      const q = query.trim().toLowerCase()
+      groups = groups.filter(g => g.name.toLowerCase().includes(q) || g.description.toLowerCase().includes(q))
+    }
+
+    return groups.sort((a, b) => b.wins - a.wins || a.name.localeCompare(b.name))
+  } catch (e) { console.error('listPublishedGroups exception', e); return [] }
+}
+
+// Published arenas with pagination and optional name/bio search + tag filter.
+export async function listPublishedArenas({ query = '', tag = null, page = 0, pageSize = 20 } = {}) {
+  try {
+    let q = supabase
+      .from('arenas')
+      .select('id, name, bio, rules, tags, likes, dislikes, owner_name', { count: 'exact' })
+      .eq('status', 'published')
+    if (tag)          q = q.contains('tags', [tag])
+    if (query.trim()) q = q.or(`name.ilike.%${query.trim()}%,bio.ilike.%${query.trim()}%`)
+    q = q.order('name', { ascending: true }).range(page * pageSize, page * pageSize + pageSize - 1)
+    const { data, count, error } = await q
+    if (error) { console.error('listPublishedArenas error', error); return { items: [], total: 0 } }
+    return { items: data || [], total: count || 0 }
+  } catch (e) { console.error('listPublishedArenas exception', e); return { items: [], total: 0 } }
+}
+
+// All distinct tags across published combatants, groups, and arenas.
+// Returns [{tag, count}] sorted by frequency desc then alphabetical.
+export async function listAllDistinctTags() {
+  try {
+    const [combRes, grpRes, arenaRes] = await Promise.all([
+      supabase.from('combatants').select('tags').eq('status', 'published'),
+      supabase.from('groups').select('tags').eq('status', 'published'),
+      supabase.from('arenas').select('tags').eq('status', 'published'),
+    ])
+    const counts = {}
+    for (const row of [...(combRes.data || []), ...(grpRes.data || []), ...(arenaRes.data || [])]) {
+      for (const t of (row.tags || [])) counts[t] = (counts[t] || 0) + 1
+    }
+    return Object.entries(counts)
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+  } catch (e) { console.error('listAllDistinctTags exception', e); return [] }
+}


### PR DESCRIPTION
Closes #20

## What changed

**ArchiveScreen.jsx** — converted from a single Cast list to a 4-tab screen:
- **The Cast** (default) — existing combatant list, unchanged behaviour. Sort bar, Characters/All forms toggle, tag chips, pagination.
- **Groups** — lists published groups with member count, combined W/L record, and most-decorated member. Tap to expand description. Client-side filtered by query/tag.
- **Arenas** — lists published arenas with likes/dislikes counts. Bio shown inline; tap to expand house rules. Server-side paginated and filtered by query/tag.
- **Tags** — chip cloud of all distinct tags across combatants, groups, and arenas. Tap a tag to set the cross-tab filter; tap again to clear. Active tag highlighted.

**Shared state across all tabs:**
- Single debounced search bar — each tab filters its own entity type by name/bio.
- Active tag filter pill shown above the tab row when a tag is active. × to clear. Applies to all tabs.

**supabase.js** — three new Archive-specific query functions:
- `listPublishedGroups({ query, tag })` — three parallel queries (groups + combatant_groups + combatant stats) aggregated client-side.
- `listPublishedArenas({ query, tag, page, pageSize })` — server-side paginated, name/bio ilike search, tag filter.
- `listAllDistinctTags()` — collects distinct tags from all three published entity tables, sorted by frequency.

## Test notes
- Open The Archive from home → lands on The Cast (existing data shows as before)
- Switch to Arenas → arenas listed; tap to expand house rules
- Switch to Groups → groups listed (empty state if no published groups yet)
- Switch to Tags → tag cloud; tap a tag → filter pill appears above tabs
- Switch back to The Cast with tag active → combatants filtered to that tag
- Type in search bar → each tab filters to matching entities
- Clear tag with × → filter clears across all tabs