### PR TITLE
The Archive: Arenas tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import PlayersScreen from './screens/PlayersScreen.jsx'
 import PlayerProfile from './screens/PlayerProfile.jsx'
 import ArchiveScreen from './screens/ArchiveScreen.jsx'
 import GlobalCombatantDetail from './screens/GlobalCombatantDetail.jsx'
+import ArenaDetailScreen from './screens/ArenaDetailScreen.jsx'
 import SpectateScreen from './screens/SpectateScreen.jsx'
 import GameSummaryScreen from './screens/GameSummaryScreen.jsx'
 import WorkshopScreen from './screens/WorkshopScreen.jsx'
@@ -133,6 +134,7 @@ export default function App() {
   const [viewChronicles, setViewChronicles] = useState(false)
   const [viewArchive, setViewArchive] = useState(false)
   const [viewGlobalCombatant, setViewGlobalCombatant] = useState(null)
+  const [viewArena, setViewArena] = useState(null)
   const [viewPlayers, setViewPlayers] = useState(false)
   const [viewPlayerProfile, setViewPlayerProfile] = useState(null)
   const [viewHelp, setViewHelp] = useState(false)
@@ -256,8 +258,10 @@ export default function App() {
     content = <PlayersScreen playerId={playerId} onBack={() => setViewPlayers(false)} onViewPlayer={id => setViewPlayerProfile(id)} />
   else if (viewGlobalCombatant)
     content = <GlobalCombatantDetail key={viewGlobalCombatant?.id} combatant={viewGlobalCombatant} playerId={playerId} playerName={effectiveName} onBack={() => setViewGlobalCombatant(null)} onViewCombatant={setViewGlobalCombatant} />
+  else if (viewArena)
+    content = <ArenaDetailScreen key={viewArena?.id} arena={viewArena} playerId={playerId} onBack={() => setViewArena(null)} onViewArena={setViewArena} />
   else if (viewArchive)
-    content = <ArchiveScreen playerId={playerId} onBack={() => setViewArchive(false)} onViewCombatant={c => setViewGlobalCombatant(c)} />
+    content = <ArchiveScreen playerId={playerId} onBack={() => setViewArchive(false)} onViewCombatant={c => setViewGlobalCombatant(c)} onViewArena={a => setViewArena(a)} />
   else if (viewChronicles)
     content = <ChroniclesScreen onBack={() => setViewChronicles(false)} setViewCombatant={c => { setViewCombatant(c); setViewChronicles(false) }} playerId={playerId} onNextGame={r => { setViewChronicles(false); handleHostNextGame(r) }} />
   else if (viewCombatant)

--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -191,76 +191,91 @@ function GroupsTab({ query, activeTag, onFilterTag }) {
   )
 }
 
-// ─── Arenas tab ───────────────────────────────────────────────────────────────
+// ─── Arenas tab ─────────────────────────────────────────────────────────��─────
 
-function ArenasTab({ query, activeTag, onFilterTag }) {
+const POOL_LABEL = { standard: 'Standard', wacky: 'Wacky', league: 'League', 'weighted-liked': 'Popular' }
+const ARENA_POOLS = ['standard', 'wacky', 'league', 'weighted-liked']
+
+function ArenasTab({ query, activeTag, activePool, onFilterTag, onFilterPool, onViewArena }) {
   const [items, setItems]     = useState([])
   const [total, setTotal]     = useState(0)
   const [page, setPage]       = useState(0)
   const [loading, setLoading] = useState(true)
-  const [expanded, setExpanded] = useState(null)
 
-  useEffect(() => { setPage(0) }, [query, activeTag])
+  useEffect(() => { setPage(0) }, [query, activeTag, activePool])
 
   useEffect(() => {
     setLoading(true)
-    listPublishedArenas({ query, tag: activeTag, page, pageSize: PAGE_SIZE }).then(({ items, total }) => {
+    listPublishedArenas({ query, tag: activeTag, pool: activePool, page, pageSize: PAGE_SIZE }).then(({ items, total }) => {
       setItems(items); setTotal(total); setLoading(false)
     })
-  }, [query, activeTag, page])
+  }, [query, activeTag, activePool, page])
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
 
-  if (loading) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>
-
-  if (!items.length) return (
-    <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
-      {activeTag
-        ? `No arenas tagged "${activeTag}".`
-        : query.trim()
-          ? `No arenas matching "${query.trim()}".`
-          : 'No arenas yet — create some in The Workshop.'}
-    </p>
-  )
-
   return (
     <>
-      {items.map(a => {
-        const isExpanded = expanded === a.id
-        const tags = a.tags || []
+      {/* Pool filter row */}
+      <div style={{ display: 'flex', gap: 6, marginBottom: '1rem', flexWrap: 'wrap' }}>
+        {ARENA_POOLS.map(p => (
+          <button key={p} onClick={() => onFilterPool(activePool === p ? null : p)} style={tab(activePool === p)}>
+            {POOL_LABEL[p]}
+          </button>
+        ))}
+      </div>
+
+      {loading && <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>}
+
+      {!loading && items.length === 0 && (
+        <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+          {activePool
+            ? `No arenas in the ${POOL_LABEL[activePool]} pool yet.`
+            : activeTag
+              ? `No arenas tagged "${activeTag}".`
+              : query.trim()
+                ? `No arenas matching "${query.trim()}".`
+                : 'No arenas yet — create some in The Workshop.'}
+        </p>
+      )}
+
+      {!loading && items.map(a => {
+        const tags   = a.tags || []
+        const pools  = (a.pools || []).filter(p => POOL_LABEL[p])
         const hasRules = !!a.rules?.trim()
         return (
-          <div key={a.id} style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: 8, overflow: 'hidden' }}>
-            <button
-              onClick={() => setExpanded(isExpanded ? null : a.id)}
-              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '12px 14px', background: 'none', border: 'none', cursor: 'pointer' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 2 }}>
-                <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{a.name}</span>
-                <div style={{ display: 'flex', gap: 8, fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0, marginLeft: 8 }}>
-                  {a.likes    > 0 && <span>👍 {a.likes}</span>}
-                  {a.dislikes > 0 && <span>👎 {a.dislikes}</span>}
-                  {hasRules && <span style={{ fontSize: 11 }}>+ rules</span>}
-                </div>
+          <button key={a.id} onClick={() => onViewArena(a)}
+            style={{ display: 'block', width: '100%', textAlign: 'left', padding: '12px 14px',
+              background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)',
+              borderRadius: 'var(--border-radius-md)', marginBottom: 8, cursor: 'pointer' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 2 }}>
+              <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{a.name}</span>
+              <div style={{ display: 'flex', gap: 6, fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0, marginLeft: 8, alignItems: 'center' }}>
+                {a.likes    > 0 && <span>👍 {a.likes}</span>}
+                {a.dislikes > 0 && <span>👎 {a.dislikes}</span>}
+                {hasRules              && <span style={{ fontSize: 11 }}>+ rules</span>}
               </div>
-              {a.bio && (
-                <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '2px 0 0', lineHeight: 1.4 }}>
-                  {!isExpanded && a.bio.length > 100 ? a.bio.slice(0, 100) + '…' : a.bio}
-                </p>
-              )}
-              {tags.length > 0 && (
-                <div style={{ marginTop: 6 }} onClick={e => e.stopPropagation()}>
-                  <TagChips tags={tags} onFilter={onFilterTag} />
-                </div>
-              )}
-            </button>
-            {isExpanded && hasRules && (
-              <div style={{ padding: '0 14px 12px', borderTop: '0.5px solid var(--color-border-tertiary)' }}>
-                <p style={{ fontSize: 11, fontWeight: 600, color: 'var(--color-text-tertiary)', margin: '8px 0 4px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>House rules</p>
-                <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: '0 0 6px', lineHeight: 1.5 }}>{a.rules}</p>
-                <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: 0 }}>by {a.owner_name}</p>
+            </div>
+            {pools.length > 0 && (
+              <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 4 }}>
+                {pools.map(p => (
+                  <span key={p} style={{ fontSize: 10, padding: '2px 6px', background: 'var(--color-background-success)',
+                    color: 'var(--color-text-success)', border: '0.5px solid var(--color-border-success)', borderRadius: 99 }}>
+                    {POOL_LABEL[p]}
+                  </span>
+                ))}
               </div>
             )}
-          </div>
+            {a.bio && (
+              <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '2px 0 0', lineHeight: 1.4 }}>
+                {a.bio.length > 100 ? a.bio.slice(0, 100) + '…' : a.bio}
+              </p>
+            )}
+            {tags.length > 0 && (
+              <div style={{ marginTop: 6 }} onClick={e => e.stopPropagation()}>
+                <TagChips tags={tags} onFilter={onFilterTag} />
+              </div>
+            )}
+          </button>
         )
       })}
 
@@ -323,10 +338,11 @@ const TABS = [
   { key: 'tags',   label: 'Tags'     },
 ]
 
-export default function ArchiveScreen({ onBack, onViewCombatant }) {
-  const [activeTab, setActiveTab] = useState('cast')
-  const [query, setQuery]         = useState('')
-  const [activeTag, setActiveTag] = useState(null)
+export default function ArchiveScreen({ onBack, onViewCombatant, onViewArena }) {
+  const [activeTab,  setActiveTab]  = useState('cast')
+  const [query,      setQuery]      = useState('')
+  const [activeTag,  setActiveTag]  = useState(null)
+  const [activePool, setActivePool] = useState(null)
   const debounceRef = useRef(null)
 
   function handleSearch(val) {
@@ -334,8 +350,9 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
     debounceRef.current = setTimeout(() => setQuery(val), 280)
   }
 
-  function handleFilterTag(tag) { setActiveTag(tag) }
-  function clearTag()           { setActiveTag(null) }
+  function handleFilterTag(tag)   { setActiveTag(tag) }
+  function handleFilterPool(pool) { setActivePool(pool) }
+  function clearTag()             { setActiveTag(null) }
 
   return (
     <Screen title="The Archive" onBack={onBack}>
@@ -365,7 +382,7 @@ export default function ArchiveScreen({ onBack, onViewCombatant }) {
 
       {activeTab === 'cast'   && <CastTab   query={query} activeTag={activeTag} onFilterTag={handleFilterTag} onViewCombatant={onViewCombatant} />}
       {activeTab === 'groups' && <GroupsTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} />}
-      {activeTab === 'arenas' && <ArenasTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} />}
+      {activeTab === 'arenas' && <ArenasTab query={query} activeTag={activeTag} activePool={activePool} onFilterTag={handleFilterTag} onFilterPool={handleFilterPool} onViewArena={onViewArena} />}
       {activeTab === 'tags'   && <TagsTab   activeTag={activeTag} onFilterTag={handleFilterTag} />}
     </Screen>
   )

--- a/src/screens/ArenaDetailScreen.jsx
+++ b/src/screens/ArenaDetailScreen.jsx
@@ -1,0 +1,318 @@
+import { useState, useEffect } from 'react'
+import Screen from '../components/Screen.jsx'
+import TagChips from '../components/TagChips.jsx'
+import { btn } from '../styles.js'
+import { getArena, getArenaLineageTree, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getArenaAppearances } from '../supabase.js'
+import GameSummaryScreen from './GameSummaryScreen.jsx'
+
+const POOL_LABELS = { standard: 'Standard', wacky: 'Wacky', league: 'League', 'weighted-liked': 'Popular' }
+
+// ─── Lineage tree ─────────────────────────────────────────────────────────────
+
+function ArenaLineageTree({ tree, currentId, onViewArena }) {
+  // Build parent→children map
+  const childMap = {}
+  tree.forEach(a => {
+    const pid = a.parent_id
+    if (!pid) return
+    if (!childMap[pid]) childMap[pid] = []
+    childMap[pid].push(a)
+  })
+
+  const root = tree.find(a => !a.parent_id)
+  if (!root) return null
+
+  function renderNode(a) {
+    const isCurrent  = a.id === currentId
+    const children   = childMap[a.id] || []
+    const canTap     = !isCurrent && onViewArena
+
+    return (
+      <div key={a.id}>
+        <div
+          onClick={canTap ? () => onViewArena(a) : undefined}
+          style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '4px 6px', margin: '1px -6px', borderRadius: 6,
+            background: isCurrent ? 'var(--color-background-info)' : 'transparent', cursor: canTap ? 'pointer' : 'default' }}>
+          <div style={{ width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+            background: isCurrent ? 'var(--color-text-info)' : 'var(--color-border-secondary)' }} />
+          <span style={{ fontSize: 14, fontWeight: isCurrent ? 500 : 400,
+            color: isCurrent ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+            textDecoration: canTap ? 'underline' : 'none', textDecorationColor: 'var(--color-border-tertiary)' }}>
+            {a.name}
+          </span>
+          {isCurrent && (
+            <span style={{ fontSize: 11, padding: '2px 6px', background: 'var(--color-background-info)',
+              color: 'var(--color-text-info)', border: '0.5px solid var(--color-border-info)', borderRadius: 99 }}>
+              this arena
+            </span>
+          )}
+        </div>
+        {children.length > 0 && (
+          <div style={{ marginLeft: 3, paddingLeft: 13, borderLeft: '1.5px solid var(--color-border-tertiary)' }}>
+            {children.map((child, i) => (
+              <div key={child.id}>
+                {i > 0 && <div style={{ borderTop: '1px solid var(--color-border-tertiary)', margin: '6px 0' }} />}
+                {child.born_from && (
+                  <div style={{ padding: '4px 0', fontSize: 11, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
+                    ⚡ variant
+                    {child.born_from.gameCode && (
+                      <span style={{ fontStyle: 'normal', marginLeft: 4, padding: '1px 5px',
+                        background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)',
+                        borderRadius: 4, fontSize: 10, color: 'var(--color-text-secondary)', letterSpacing: '0.03em' }}>
+                        {child.born_from.gameCode} R{child.born_from.roundNumber}
+                      </span>
+                    )}
+                    <span style={{ marginLeft: 4 }}>→</span>
+                  </div>
+                )}
+                {renderNode(child)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-secondary)',
+      borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+      <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 12px',
+        textTransform: 'uppercase', letterSpacing: '0.06em' }}>Variants</h3>
+      {renderNode(root)}
+    </div>
+  )
+}
+
+// ─── Arena detail ─────────────────────────────────────────────────────────────
+
+export default function ArenaDetailScreen({ arena: init, playerId, onBack, onViewArena }) {
+  // init is the card-level row (id, name, bio, rules, tags, pools, likes, dislikes, owner_name).
+  // full is the complete DB row; loaded in background for bio_history + lineage columns.
+  const [full, setFull]               = useState(null)
+  const [lineageTree, setLineageTree] = useState([])
+  const [reaction, setReaction]       = useState(null)   // 'like' | 'dislike' | null
+  const [reacting, setReacting]       = useState(false)
+  const [counts, setCounts]           = useState({ likes: init.likes || 0, dislikes: init.dislikes || 0 })
+  const [appearances, setAppearances] = useState(null)   // null = not yet loaded
+  const [appearancesOpen, setAppearancesOpen] = useState(false)
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [roomOverlay, setRoomOverlay] = useState(null)   // { room, initialRound }
+
+  const arena = full || init
+
+  useEffect(() => {
+    getArena(init.id).then(row => {
+      if (!row) return
+      setFull(row)
+      setCounts({ likes: row.likes || 0, dislikes: row.dislikes || 0 })
+      const rootId = row.root_id || row.id
+      getArenaLineageTree(rootId).then(setLineageTree)
+    })
+    if (playerId) getArenaReaction(init.id, playerId).then(setReaction)
+  }, [init.id, playerId])
+
+  // Lazy-load appearances when section is opened
+  useEffect(() => {
+    if (!appearancesOpen || appearances !== null) return
+    const allIds = lineageTree.length > 0 ? lineageTree.map(a => a.id) : [init.id]
+    getArenaAppearances(allIds).then(setAppearances)
+  }, [appearancesOpen, lineageTree, init.id, appearances])
+
+  async function handleReaction(value) {
+    if (!playerId || reacting) return
+    setReacting(true)
+    let updated
+    if (reaction === value) {
+      // Toggle off
+      updated = await deleteArenaReaction(init.id, playerId)
+      setReaction(null)
+    } else {
+      updated = await upsertArenaReaction(init.id, playerId, value)
+      setReaction(value)
+    }
+    if (updated) setCounts({ likes: updated.likes, dislikes: updated.dislikes })
+    setReacting(false)
+  }
+
+  // Build timeline: creation + edits from bio_history + variant births from lineage
+  const bioHistory = full?.bio_history || []
+  const children   = lineageTree.filter(a => a.parent_id === init.id)
+
+  const timeline = []
+  if (full?.created_at) {
+    timeline.push({ type: 'created', at: full.created_at, by: arena.owner_name })
+  }
+  for (const h of bioHistory) {
+    timeline.push({ type: 'edit', at: h.updatedAt, by: h.updatedBy })
+  }
+  for (const child of children) {
+    timeline.push({ type: 'variant', at: child.created_at, childName: child.name, born_from: child.born_from, childArena: child })
+  }
+  timeline.sort((a, b) => new Date(a.at) - new Date(b.at))
+
+  const showLineage = lineageTree.length > 1
+
+  const curated = (arena.pools || []).filter(p => p !== 'weighted-liked')
+  const isPopular = (counts.dislikes || 0) <= (counts.likes || 0) * 3 && counts.likes > 0
+  const allPools = isPopular ? [...curated, 'weighted-liked'] : curated
+
+  const hasRules = !!arena.rules?.trim()
+
+  return (
+    <Screen title={arena.name} onBack={onBack}>
+
+      {/* ── Pool badges ──────────────────────────────────────────────────── */}
+      {allPools.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: '1rem' }}>
+          {allPools.map(p => (
+            <span key={p} style={{ fontSize: 11, padding: '3px 9px',
+              background: 'var(--color-background-success)', color: 'var(--color-text-success)',
+              border: '0.5px solid var(--color-border-success)', borderRadius: 99 }}>
+              {POOL_LABELS[p] || p}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* ── Description ──────────────────────────────────────────────────── */}
+      {arena.bio ? (
+        <p style={{ fontSize: 14, color: 'var(--color-text-primary)', margin: '0 0 1rem', lineHeight: 1.55 }}>{arena.bio}</p>
+      ) : (
+        <p style={{ fontSize: 14, color: 'var(--color-text-tertiary)', margin: '0 0 1rem', fontStyle: 'italic' }}>No description.</p>
+      )}
+
+      {/* ── House rules ──────────────────────────────────────────────────── */}
+      {hasRules && (
+        <div style={{ marginBottom: '1rem', padding: '10px 14px', background: 'var(--color-background-secondary)',
+          borderRadius: 'var(--border-radius-md)', border: '0.5px solid var(--color-border-tertiary)' }}>
+          <p style={{ fontSize: 11, fontWeight: 600, color: 'var(--color-text-tertiary)', margin: '0 0 4px',
+            textTransform: 'uppercase', letterSpacing: '0.05em' }}>House rules</p>
+          <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0, lineHeight: 1.5 }}>{arena.rules}</p>
+        </div>
+      )}
+
+      {/* ── Tags ─────────────────────────────────────────────────────────── */}
+      {(arena.tags || []).length > 0 && (
+        <div style={{ marginBottom: '1rem' }}>
+          <TagChips tags={arena.tags} />
+        </div>
+      )}
+
+      {/* ��─ Likes / dislikes + reaction ──────────────────────────────────── */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: '1.5rem' }}>
+        {playerId ? (
+          <>
+            <button
+              onClick={() => handleReaction('like')}
+              disabled={reacting}
+              style={{ ...btn(reaction === 'like' ? 'primary' : 'ghost'), padding: '6px 14px', fontSize: 13 }}>
+              👍 {counts.likes > 0 ? counts.likes : ''}
+            </button>
+            <button
+              onClick={() => handleReaction('dislike')}
+              disabled={reacting}
+              style={{ ...btn(reaction === 'dislike' ? 'danger' : 'ghost'), padding: '6px 14px', fontSize: 13 }}>
+              👎 {counts.dislikes > 0 ? counts.dislikes : ''}
+            </button>
+          </>
+        ) : (
+          <>
+            {counts.likes    > 0 && <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>👍 {counts.likes}</span>}
+            {counts.dislikes > 0 && <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>👎 {counts.dislikes}</span>}
+          </>
+        )}
+        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>by {arena.owner_name}</span>
+      </div>
+
+      {/* ── Lineage / variant tree ───────────────────────────────────────── */}
+      {showLineage && (
+        <ArenaLineageTree tree={lineageTree} currentId={init.id} onViewArena={onViewArena} />
+      )}
+
+      {/* ── Room overlay ─────────────────────────────────────────────────── */}
+      {roomOverlay && (
+        <GameSummaryScreen room={roomOverlay.room} initialRound={roomOverlay.initialRound} onClose={() => setRoomOverlay(null)} />
+      )}
+
+      {/* ── Update history timeline ──────────────────────────────────────── */}
+      {timeline.length > 0 && (
+        <div style={{ marginBottom: '1.5rem' }}>
+          <button onClick={() => setHistoryOpen(o => !o)}
+            style={{ ...btn('ghost'), width: '100%', textAlign: 'left', fontSize: 13, marginBottom: historyOpen ? 8 : 0,
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span>Update history ({timeline.length})</span>
+            <span>{historyOpen ? '↑' : '↓'}</span>
+          </button>
+          {historyOpen && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {timeline.map((entry, i) => (
+                <div key={i} style={{ padding: '8px 12px', background: 'var(--color-background-secondary)',
+                  borderRadius: 'var(--border-radius-md)', border: '0.5px solid var(--color-border-tertiary)', fontSize: 13 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
+                    <span style={{ color: 'var(--color-text-secondary)' }}>
+                      {entry.type === 'created' && 'Created'}
+                      {entry.type === 'edit'    && 'Description edited'}
+                      {entry.type === 'variant' && (
+                        <>
+                          Variant born: <strong style={{ color: 'var(--color-text-primary)' }}>{entry.childName}</strong>
+                          {entry.born_from?.gameCode && (
+                            <span style={{ marginLeft: 6, padding: '1px 5px', background: 'var(--color-background-tertiary)',
+                              border: '0.5px solid var(--color-border-secondary)', borderRadius: 4, fontSize: 11,
+                              color: 'var(--color-text-secondary)', letterSpacing: '0.03em' }}>
+                              {entry.born_from.gameCode} R{entry.born_from.roundNumber}
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', flexShrink: 0, marginLeft: 8 }}>
+                      {new Date(entry.at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                    </span>
+                  </div>
+                  <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: 0 }}>by {entry.by}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Appearances ──────────────────────────────────────────────────── */}
+      <div>
+        <button onClick={() => setAppearancesOpen(o => !o)}
+          style={{ ...btn('ghost'), width: '100%', textAlign: 'left', fontSize: 13, marginBottom: appearancesOpen ? 8 : 0,
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span>Appearances{appearances !== null ? ` (${appearances.length})` : ''}</span>
+          <span>{appearancesOpen ? '↑' : '↓'}</span>
+        </button>
+        {appearancesOpen && (
+          appearances === null
+            ? <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+            : appearances.length === 0
+              ? <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>No recorded appearances yet.</p>
+              : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {appearances.map((ap, i) => (
+                    <button key={i} onClick={() => setRoomOverlay({ room: ap.roomData, initialRound: ap.roundNumber })}
+                      style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                        padding: '8px 12px', background: 'var(--color-background-secondary)',
+                        border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)',
+                        cursor: 'pointer', textAlign: 'left' }}>
+                      <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>
+                        {ap.gameCode}
+                        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginLeft: 8 }}>
+                          Round {ap.roundNumber}
+                        </span>
+                      </span>
+                      <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>↗</span>
+                    </button>
+                  ))}
+                </div>
+              )
+        )}
+      </div>
+
+    </Screen>
+  )
+}

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -982,20 +982,121 @@ export async function listPublishedGroups({ query = '', tag = null } = {}) {
   } catch (e) { console.error('listPublishedGroups exception', e); return [] }
 }
 
-// Published arenas with pagination and optional name/bio search + tag filter.
-export async function listPublishedArenas({ query = '', tag = null, page = 0, pageSize = 20 } = {}) {
+// Published arenas with pagination and optional name/bio search + tag/pool filter.
+// Default sort: most recently played first (last_played_at desc nulls last), then newest created.
+// pool: 'standard' | 'wacky' | 'league' | 'weighted-liked' | null
+export async function listPublishedArenas({ query = '', tag = null, pool = null, page = 0, pageSize = 20 } = {}) {
   try {
     let q = supabase
       .from('arenas')
-      .select('id, name, bio, rules, tags, likes, dislikes, owner_name', { count: 'exact' })
+      .select('id, name, bio, rules, tags, pools, likes, dislikes, owner_name, last_played_at', { count: 'exact' })
       .eq('status', 'published')
     if (tag)          q = q.contains('tags', [tag])
+    if (pool && pool !== 'weighted-liked') q = q.contains('pools', [pool])
     if (query.trim()) q = q.or(`name.ilike.%${query.trim()}%,bio.ilike.%${query.trim()}%`)
-    q = q.order('name', { ascending: true }).range(page * pageSize, page * pageSize + pageSize - 1)
+    q = q
+      .order('last_played_at', { ascending: false, nullsFirst: false })
+      .order('created_at',     { ascending: false })
+      .range(page * pageSize, page * pageSize + pageSize - 1)
     const { data, count, error } = await q
     if (error) { console.error('listPublishedArenas error', error); return { items: [], total: 0 } }
-    return { items: data || [], total: count || 0 }
+    let items = data || []
+    // weighted-liked is computed: filter out arenas with dislikes > likes × 3
+    if (pool === 'weighted-liked') items = items.filter(a => (a.dislikes || 0) <= (a.likes || 0) * 3)
+    return { items, total: count || 0 }
   } catch (e) { console.error('listPublishedArenas exception', e); return { items: [], total: 0 } }
+}
+
+// Fetch a single published arena by id (full row for detail page).
+export async function getArena(id) {
+  try {
+    const { data, error } = await supabase
+      .from('arenas')
+      .select('id, name, bio, bio_history, rules, tags, pools, likes, dislikes, owner_id, owner_name, status, root_id, parent_id, generation, born_from, created_at, updated_at')
+      .eq('id', id)
+      .maybeSingle()
+    if (error) { console.error('getArena error', error); return null }
+    return data ?? null
+  } catch (e) { console.error('getArena exception', e); return null }
+}
+
+// Returns the full lineage tree for an arena: root + all variants, oldest first.
+// rootId: the root_id of the family (the original arena's id).
+export async function getArenaLineageTree(rootId) {
+  try {
+    const { data, error } = await supabase
+      .from('arenas')
+      .select('id, name, bio, rules, tags, pools, likes, dislikes, root_id, parent_id, generation, born_from, owner_id, owner_name, status, created_at')
+      .or(`id.eq.${rootId},root_id.eq.${rootId}`)
+      .order('created_at', { ascending: true })
+    if (error) { console.error('getArenaLineageTree error', error); return [] }
+    return data || []
+  } catch (e) { console.error('getArenaLineageTree exception', e); return [] }
+}
+
+// Get the current user's reaction ('like' | 'dislike') for an arena, or null if none.
+export async function getArenaReaction(arenaId, userId) {
+  if (!userId) return null
+  try {
+    const { data, error } = await supabase
+      .from('arena_reactions')
+      .select('reaction')
+      .eq('arena_id', arenaId)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) { console.error('getArenaReaction error', error); return null }
+    return data?.reaction ?? null
+  } catch (e) { console.error('getArenaReaction exception', e); return null }
+}
+
+// Set or change a reaction. Upserts on (arena_id, user_id).
+// Returns the updated {likes, dislikes} counts after the trigger fires.
+export async function upsertArenaReaction(arenaId, userId, reaction) {
+  try {
+    const { error } = await supabase
+      .from('arena_reactions')
+      .upsert({ arena_id: arenaId, user_id: userId, reaction }, { onConflict: 'arena_id,user_id' })
+    if (error) { console.error('upsertArenaReaction error', error); return null }
+    const { data } = await supabase.from('arenas').select('likes, dislikes').eq('id', arenaId).maybeSingle()
+    return data ? { likes: data.likes, dislikes: data.dislikes } : null
+  } catch (e) { console.error('upsertArenaReaction exception', e); return null }
+}
+
+// Clear a player's reaction for an arena.
+export async function deleteArenaReaction(arenaId, userId) {
+  try {
+    const { error } = await supabase
+      .from('arena_reactions')
+      .delete()
+      .eq('arena_id', arenaId)
+      .eq('user_id', userId)
+    if (error) { console.error('deleteArenaReaction error', error); return null }
+    const { data } = await supabase.from('arenas').select('likes, dislikes').eq('id', arenaId).maybeSingle()
+    return data ? { likes: data.likes, dislikes: data.dislikes } : null
+  } catch (e) { console.error('deleteArenaReaction exception', e); return null }
+}
+
+// Scan all rooms for rounds where the arena (or any of its variants) appeared.
+// arenaIds: array of arena IDs to search (include variants for full coverage).
+// Returns [{gameCode, roundNumber, roomData}] most-recent-room first.
+export async function getArenaAppearances(arenaIds) {
+  if (!arenaIds.length) return []
+  try {
+    const idSet = new Set(arenaIds)
+    const { data, error } = await supabase.from('rooms').select('data').order('updated_at', { ascending: false })
+    if (error) { console.error('getArenaAppearances error', error); return [] }
+    const appearances = []
+    for (const row of (data || [])) {
+      const r = row.data
+      if (!r || r.devMode) continue
+      for (const round of (r.rounds || [])) {
+        if (round.arena?.id && idSet.has(round.arena.id)) {
+          appearances.push({ gameCode: r.id, roundNumber: round.number, roomData: r })
+        }
+      }
+    }
+    return appearances
+  } catch (e) { console.error('getArenaAppearances exception', e); return [] }
 }
 
 // All distinct tags across published combatants, groups, and arenas.

--- a/supabase/migrations/20260429_arenas_last_played_at_pools.sql
+++ b/supabase/migrations/20260429_arenas_last_played_at_pools.sql
@@ -1,0 +1,19 @@
+-- Add last_played_at and pools to arenas table (issue #73)
+--
+-- last_played_at: updated when an arena snapshot is written to a round.
+--   Used for "most recently played" default sort in The Archive Arenas tab.
+--   Null means the arena has been created but not yet used in a game.
+--   The delivery-mode assignment code (issue #14) is responsible for setting this.
+--
+-- pools: curated pool membership, managed by Super Hosts (issue #74).
+--   Values: 'standard' | 'wacky' | 'league'
+--   'weighted-liked' is computed at read time from likes/dislikes — not stored here.
+--   An arena can belong to multiple curated pools simultaneously.
+
+alter table arenas
+  add column if not exists last_played_at timestamptz null,
+  add column if not exists pools text[] not null default '{}';
+
+create index if not exists arenas_last_played_at_idx
+  on arenas (last_played_at desc nulls last)
+  where status = 'published';


### PR DESCRIPTION
Closes #73

## What changed

- **`ArenaDetailScreen.jsx`** (new) — full arena detail page with:
  - Name, description, house rules, tags
  - Like/dislike counts + toggle buttons (gated on having a `playerId`)
  - Pool badges (Standard/Wacky/League/Popular) from `arenas.pools` + computed `weighted-liked`
  - Lineage/variant tree — shown when the tree has >1 node; clicking non-current nodes navigates to that variant
  - Update history timeline — creation, description edits (from `bio_history`), variant births — sorted chronologically
  - Appearances — lazy-loaded list of every round (across all variants) that used this arena, each tappable to open the GameSummaryScreen overlay

- **`ArchiveScreen.jsx`** — ArenasTab updated:
  - Cards now navigate to ArenaDetailScreen (inline expand removed)
  - Pool filter row added (Standard / Wacky / League / Popular)
  - Pool badges rendered on each card

- **`supabase.js`**:
  - `listPublishedArenas` sorts by `last_played_at` desc (nulls last) then `created_at` desc; accepts `pool` filter; returns `pools` column
  - New: `getArena`, `getArenaLineageTree`, `getArenaReaction`, `upsertArenaReaction`, `deleteArenaReaction`, `getArenaAppearances`

- **`App.jsx`** — `viewArena` state wired; `ArenaDetailScreen` in content chain; `ArchiveScreen` receives `onViewArena`

- **Migration** `20260429_arenas_last_played_at_pools.sql`:
  - `arenas.last_played_at` — set by delivery-mode assignment (issue #14); used for default sort
  - `arenas.pools text[]` — curated pool membership for Super Hosts (issue #74)

## Notes on dependencies

Pool curation (Standard/Wacky/League) requires #74 — column and UI are ready. `last_played_at` will be null until #14 delivery modes populate it; sort falls back to `created_at` desc.

## Test notes

- Archive → Arenas tab: arena cards shown, each taps into detail page
- Detail page: bio, rules, tags, likes/dislikes visible; reaction buttons work when logged in
- Pool filter buttons visible; all pools currently empty pending Super Host curation
- Update history and Appearances sections expand correctly; appearances empty until games with arenas are played
- Back button returns to Arenas tab