### PR TITLE
Arena likes and dislikes

### DIFF
--- a/src/screens/ArenaDetailScreen.jsx
+++ b/src/screens/ArenaDetailScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import { btn } from '../styles.js'
-import { getArena, getArenaLineageTree, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getArenaAppearances } from '../supabase.js'
+import { getArena, getArenaLineageTree, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getArenaAppearances, hasPlayerEncounteredArena, ARENA_DISLIKE_RATIO } from '../supabase.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
 
 const POOL_LABELS = { standard: 'Standard', wacky: 'Wacky', league: 'League', 'weighted-liked': 'Popular' }
@@ -92,6 +92,7 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
   const [full, setFull]               = useState(null)
   const [lineageTree, setLineageTree] = useState([])
   const [reaction, setReaction]       = useState(null)   // 'like' | 'dislike' | null
+  const [encountered, setEncountered] = useState(null)   // null = loading, true/false = resolved
   const [reacting, setReacting]       = useState(false)
   const [counts, setCounts]           = useState({ likes: init.likes || 0, dislikes: init.dislikes || 0 })
   const [appearances, setAppearances] = useState(null)   // null = not yet loaded
@@ -109,7 +110,12 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
       const rootId = row.root_id || row.id
       getArenaLineageTree(rootId).then(setLineageTree)
     })
-    if (playerId) getArenaReaction(init.id, playerId).then(setReaction)
+    if (playerId) {
+      getArenaReaction(init.id, playerId).then(setReaction)
+      hasPlayerEncounteredArena(init.id, playerId).then(setEncountered)
+    } else {
+      setEncountered(false)
+    }
   }, [init.id, playerId])
 
   // Lazy-load appearances when section is opened
@@ -154,7 +160,7 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
   const showLineage = lineageTree.length > 1
 
   const curated = (arena.pools || []).filter(p => p !== 'weighted-liked')
-  const isPopular = (counts.dislikes || 0) <= (counts.likes || 0) * 3 && counts.likes > 0
+  const isPopular = (counts.dislikes || 0) <= (counts.likes || 0) * ARENA_DISLIKE_RATIO && counts.likes > 0
   const allPools = isPopular ? [...curated, 'weighted-liked'] : curated
 
   const hasRules = !!arena.rules?.trim()
@@ -200,29 +206,36 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
       )}
 
       {/* ��─ Likes / dislikes + reaction ──────────────────────────────────── */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: '1.5rem' }}>
-        {playerId ? (
-          <>
-            <button
-              onClick={() => handleReaction('like')}
-              disabled={reacting}
-              style={{ ...btn(reaction === 'like' ? 'primary' : 'ghost'), padding: '6px 14px', fontSize: 13 }}>
-              👍 {counts.likes > 0 ? counts.likes : ''}
-            </button>
-            <button
-              onClick={() => handleReaction('dislike')}
-              disabled={reacting}
-              style={{ ...btn(reaction === 'dislike' ? 'danger' : 'ghost'), padding: '6px 14px', fontSize: 13 }}>
-              👎 {counts.dislikes > 0 ? counts.dislikes : ''}
-            </button>
-          </>
-        ) : (
-          <>
-            {counts.likes    > 0 && <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>👍 {counts.likes}</span>}
-            {counts.dislikes > 0 && <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>👎 {counts.dislikes}</span>}
-          </>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {encountered === true ? (
+            <>
+              <button
+                onClick={() => handleReaction('like')}
+                disabled={reacting}
+                style={{ ...btn(reaction === 'like' ? 'primary' : 'ghost'), padding: '6px 14px', fontSize: 13 }}>
+                👍 {counts.likes > 0 ? counts.likes : ''}
+              </button>
+              <button
+                onClick={() => handleReaction('dislike')}
+                disabled={reacting}
+                style={{ ...btn(reaction === 'dislike' ? 'danger' : 'ghost'), padding: '6px 14px', fontSize: 13 }}>
+                👎 {counts.dislikes > 0 ? counts.dislikes : ''}
+              </button>
+            </>
+          ) : (
+            <>
+              {counts.likes    > 0 && <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>👍 {counts.likes}</span>}
+              {counts.dislikes > 0 && <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>👎 {counts.dislikes}</span>}
+            </>
+          )}
+          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>by {arena.owner_name}</span>
+        </div>
+        {playerId && encountered === false && (
+          <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '6px 0 0', fontStyle: 'italic' }}>
+            Play in a game with this arena to rate it.
+          </p>
         )}
-        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>by {arena.owner_name}</span>
       </div>
 
       {/* ── Lineage / variant tree ───────────────────────────────────────── */}

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -6,7 +6,7 @@ import RoundChat from '../components/RoundChat.jsx'
 import EvolutionForm from '../components/EvolutionForm.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence } from '../supabase.js'
+import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence, getArenaReaction, upsertArenaReaction, deleteArenaReaction } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish, resolveAllAdvanceSelection } from '../gameLogic.js'
@@ -129,6 +129,8 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
   const [hostOnline,       setHostOnline]       = useState(null)   // null = not yet synced; false = host absent
   const [presentIds,       setPresentIds]       = useState([])
   const [voteNudgeDone,    setVoteNudgeDone]    = useState(false)  // one-time guest nudge after first pick
+  const [arenaReaction,    setArenaReaction]    = useState(null)   // 'like' | 'dislike' | null
+  const [arenaReacting,    setArenaReacting]    = useState(false)
 
   // Draw / merge flow state machine.
   // null                                                           — no flow in progress
@@ -163,6 +165,26 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       onPresenceChange:   setPresentIds,
     })
   }, [room.id])
+
+  const arenaId = round?.arena?.id
+
+  useEffect(() => {
+    if (!arenaId || !playerId) { setArenaReaction(null); return }
+    getArenaReaction(arenaId, playerId).then(setArenaReaction)
+  }, [arenaId, playerId])
+
+  async function handleArenaReaction(value) {
+    if (!arenaId || !playerId || arenaReacting) return
+    setArenaReacting(true)
+    if (arenaReaction === value) {
+      await deleteArenaReaction(arenaId, playerId)
+      setArenaReaction(null)
+    } else {
+      await upsertArenaReaction(arenaId, playerId, value)
+      setArenaReaction(value)
+    }
+    setArenaReacting(false)
+  }
 
   // ── Voting ────────────────────────────────────────────────────────────────
 
@@ -674,6 +696,22 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
           )}
           {round.arena.houseRules && (
             <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0', fontStyle: 'italic' }}>Rules: {round.arena.houseRules}</p>
+          )}
+          {playerId && (
+            <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+              <button
+                onClick={() => handleArenaReaction('like')}
+                disabled={arenaReacting}
+                style={{ background: arenaReaction === 'like' ? 'var(--color-background-info)' : 'var(--color-background-tertiary)', border: arenaReaction === 'like' ? '1px solid var(--color-border-info)' : '0.5px solid var(--color-border-tertiary)', borderRadius: 99, padding: '5px 10px', fontSize: 13, cursor: 'pointer' }}>
+                👍
+              </button>
+              <button
+                onClick={() => handleArenaReaction('dislike')}
+                disabled={arenaReacting}
+                style={{ background: arenaReaction === 'dislike' ? 'var(--color-background-danger)' : 'var(--color-background-tertiary)', border: arenaReaction === 'dislike' ? '1px solid var(--color-border-danger)' : '0.5px solid var(--color-border-tertiary)', borderRadius: 99, padding: '5px 10px', fontSize: 13, cursor: 'pointer' }}>
+                👎
+              </button>
+            </div>
           )}
         </div>
       )}

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -817,6 +817,14 @@ export async function publishCombatants(ids) {
   } catch (e) { console.error('publishCombatants exception', e) }
 }
 
+// ─── Arena config ─────────────────────────────────────────────────────────────
+
+// Arena suppression threshold: an arena is excluded from the weighted-liked pool
+// when its dislike count exceeds its like count by this ratio.
+// Applies in: listPublishedArenas (pool filter), getRandomArenaFromPool,
+// and the computed pool badge in ArenaDetailScreen.
+export const ARENA_DISLIKE_RATIO = 3
+
 // ─── Arena Workshop operations ────────────────────────────────────────────────
 
 export async function createWorkshopArena({ id, name, bio, rules, tags = [], ownerId, ownerName, status = 'stashed' }) {
@@ -904,7 +912,7 @@ export async function getRandomArenaFromPool(pool, excludeArenaIds = []) {
 
     let eligible = data
     if (pool === 'weighted-liked') {
-      eligible = eligible.filter(a => (a.likes || 0) >= (a.dislikes || 0))
+      eligible = eligible.filter(a => (a.dislikes || 0) <= (a.likes || 0) * ARENA_DISLIKE_RATIO)
     }
     if (excludeArenaIds.length) {
       const filtered = eligible.filter(a => !excludeArenaIds.includes(a.id))
@@ -1001,8 +1009,8 @@ export async function listPublishedArenas({ query = '', tag = null, pool = null,
     const { data, count, error } = await q
     if (error) { console.error('listPublishedArenas error', error); return { items: [], total: 0 } }
     let items = data || []
-    // weighted-liked is computed: filter out arenas with dislikes > likes × 3
-    if (pool === 'weighted-liked') items = items.filter(a => (a.dislikes || 0) <= (a.likes || 0) * 3)
+    // weighted-liked is computed: filter out arenas with dislikes > likes × ARENA_DISLIKE_RATIO
+    if (pool === 'weighted-liked') items = items.filter(a => (a.dislikes || 0) <= (a.likes || 0) * ARENA_DISLIKE_RATIO)
     return { items, total: count || 0 }
   } catch (e) { console.error('listPublishedArenas exception', e); return { items: [], total: 0 } }
 }
@@ -1097,6 +1105,22 @@ export async function getArenaAppearances(arenaIds) {
     }
     return appearances
   } catch (e) { console.error('getArenaAppearances exception', e); return [] }
+}
+
+// Returns true if the given player participated in any game that used this arena.
+// Used to gate the like/dislike action on the arena detail page in The Archive.
+export async function hasPlayerEncounteredArena(arenaId, playerId) {
+  if (!arenaId || !playerId) return false
+  try {
+    const { data, error } = await supabase.from('rooms').select('data').order('updated_at', { ascending: false })
+    if (error || !data?.length) return false
+    return data.some(row => {
+      const r = row.data
+      if (!r || r.devMode) return false
+      if (!(r.players || []).some(p => p.id === playerId)) return false
+      return (r.rounds || []).some(rd => rd.arena?.id === arenaId)
+    })
+  } catch (e) { console.error('hasPlayerEncounteredArena exception', e); return false }
 }
 
 // All distinct tags across published combatants, groups, and arenas.


### PR DESCRIPTION
Closes #70

## What changed

- **VoteScreen**: Like/dislike buttons added to the arena context card during a round. Players can rate the arena from the moment it's revealed. Reaction state persists — toggling the same value clears it, switching flips it.
- **ArenaDetailScreen**: Rating is now gated on encounter. Players who haven't played in a game with that arena see the counts but can't react; a hint explains why. The existing reaction UI is unchanged for players who have played with the arena.
- **supabase.js**:
  - `ARENA_DISLIKE_RATIO = 3` exported as a named constant — replaces every hardcoded `3` in suppression logic and the detail page's computed pool badge.
  - `getRandomArenaFromPool` weighted-liked filter corrected to `dislikes <= likes × ARENA_DISLIKE_RATIO` (was `likes >= dislikes`, a stricter threshold that didn't match the spec).
  - `hasPlayerEncounteredArena(arenaId, playerId)` added — scans rooms to check whether a player was in any game that used this arena.
- No new migration needed — `arena_reactions` table and trigger were created in the #68 migration; `likes`/`dislikes` columns on `arenas` are already in place.

## Test notes

- Play a game with an arena (any delivery mode). After the round starts, confirm 👍/👎 buttons appear in the arena card on VoteScreen and that reacting persists correctly (tap again to clear, tap the other to switch).
- Navigate to The Archive → Arenas tab → open the arena you just played. Rating buttons should be active (you've encountered it).
- Open a different arena you've never played. Buttons should be absent; "Play in a game with this arena to rate it." hint should appear (logged-in players only).
- Verify running totals on the arena detail page update immediately after reacting.
- In BattleScreen delivery mode random-pool with pool weighted-liked, an arena with dislikes > likes × 3 should be excluded from the draw pool.