### PR TITLE
Super Hosts role

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import ArenaDetailScreen from './screens/ArenaDetailScreen.jsx'
 import SpectateScreen from './screens/SpectateScreen.jsx'
 import GameSummaryScreen from './screens/GameSummaryScreen.jsx'
 import WorkshopScreen from './screens/WorkshopScreen.jsx'
+import SuperHostScreen from './screens/SuperHostScreen.jsx'
 import HelpModal from './components/HelpModal.jsx'
 
 function UserPill({ currentUser, isGuest, effectiveName, onLogout, onLogin }) {
@@ -139,6 +140,7 @@ export default function App() {
   const [viewPlayerProfile, setViewPlayerProfile] = useState(null)
   const [viewHelp, setViewHelp] = useState(false)
   const [viewWorkshop, setViewWorkshop] = useState(false)
+  const [viewSuperHost, setViewSuperHost] = useState(false)
   const [viewRoomSummary, setViewRoomSummary] = useState(null)
 
   async function openRoomSummary(roomId) {
@@ -247,8 +249,12 @@ export default function App() {
 
   function goHome() { setRoom(null); refreshLobbies(); nav('home') }
 
+  const isSuperHost = !!currentUser?.is_super_host
+
   let content = null
-  if (viewWorkshop)
+  if (viewSuperHost)
+    content = <SuperHostScreen currentUser={currentUser} onBack={() => setViewSuperHost(false)} />
+  else if (viewWorkshop)
     content = <WorkshopScreen currentUser={currentUser} onBack={() => setViewWorkshop(false)} onLogin={() => goAuth('home')} />
   else if (viewLobbies)
     content = <MyLobbiesScreen lobbies={openLobbies} playerId={playerId} onBack={() => { setViewLobbies(false); refreshLobbies() }} onEnter={r => { setRoom(r); setViewLobbies(false); nav(r.phase === 'lobby' ? 'lobby' : r.phase === 'draft' ? 'draft' : r.phase === 'vote' ? 'vote' : 'round') }} />
@@ -257,11 +263,11 @@ export default function App() {
   else if (viewPlayers)
     content = <PlayersScreen playerId={playerId} onBack={() => setViewPlayers(false)} onViewPlayer={id => setViewPlayerProfile(id)} />
   else if (viewGlobalCombatant)
-    content = <GlobalCombatantDetail key={viewGlobalCombatant?.id} combatant={viewGlobalCombatant} playerId={playerId} playerName={effectiveName} onBack={() => setViewGlobalCombatant(null)} onViewCombatant={setViewGlobalCombatant} />
+    content = <GlobalCombatantDetail key={viewGlobalCombatant?.id} combatant={viewGlobalCombatant} playerId={playerId} playerName={effectiveName} isSuperHost={isSuperHost} onBack={() => setViewGlobalCombatant(null)} onViewCombatant={setViewGlobalCombatant} />
   else if (viewArena)
-    content = <ArenaDetailScreen key={viewArena?.id} arena={viewArena} playerId={playerId} onBack={() => setViewArena(null)} onViewArena={setViewArena} />
+    content = <ArenaDetailScreen key={viewArena?.id} arena={viewArena} playerId={playerId} isSuperHost={isSuperHost} onBack={() => setViewArena(null)} onViewArena={setViewArena} />
   else if (viewArchive)
-    content = <ArchiveScreen playerId={playerId} onBack={() => setViewArchive(false)} onViewCombatant={c => setViewGlobalCombatant(c)} onViewArena={a => setViewArena(a)} />
+    content = <ArchiveScreen playerId={playerId} isSuperHost={isSuperHost} onBack={() => setViewArchive(false)} onViewCombatant={c => setViewGlobalCombatant(c)} onViewArena={a => setViewArena(a)} />
   else if (viewChronicles)
     content = <ChroniclesScreen onBack={() => setViewChronicles(false)} setViewCombatant={c => { setViewCombatant(c); setViewChronicles(false) }} playerId={playerId} onNextGame={r => { setViewChronicles(false); handleHostNextGame(r) }} />
   else if (viewCombatant)
@@ -271,7 +277,7 @@ export default function App() {
   else if (screen === 'admin')
     content = <AdminScreen onBack={() => nav('home')} />
   else if (screen === 'home')
-    content = <HomeScreen onCreate={() => nav('create')} onJoin={() => nav('join')} onChronicles={() => setViewChronicles(true)} onArchive={() => setViewArchive(true)} onPlayers={() => setViewPlayers(true)} onWorkshop={() => setViewWorkshop(true)} onDev={startDevMode} currentUser={currentUser} onLogin={() => nav('auth')} onLogout={logout} onAdmin={() => nav('admin')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} onHelp={() => setViewHelp(true)} />
+    content = <HomeScreen onCreate={() => nav('create')} onJoin={() => nav('join')} onChronicles={() => setViewChronicles(true)} onArchive={() => setViewArchive(true)} onPlayers={() => setViewPlayers(true)} onWorkshop={() => setViewWorkshop(true)} onSuperHost={() => setViewSuperHost(true)} onDev={startDevMode} currentUser={currentUser} onLogin={() => nav('auth')} onLogout={logout} onAdmin={() => nav('admin')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} onHelp={() => setViewHelp(true)} />
   else if (screen === 'create')
     content = <CreateRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} onLogin={() => goAuth('create')} onCreated={r => { addLobbyCode(r.id); setRoom(r); nav('lobby') }} onBack={() => nav('home')} />
   else if (screen === 'join')

--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import { btn, tab, inp } from '../styles.js'
-import { listCombatants, searchCast, listPublishedGroups, listPublishedArenas, listAllDistinctTags } from '../supabase.js'
+import { listCombatants, searchCast, listPublishedGroups, listPublishedArenas, listAllDistinctTags, superHostSetEntityTags } from '../supabase.js'
+import TagInput from '../components/TagInput.jsx'
 
 const PAGE_SIZE = 20
 
@@ -130,15 +131,25 @@ function CastTab({ query, activeTag, onFilterTag, onViewCombatant }) {
 
 // ─── Groups tab ───────────────────────────────────────────────────────────────
 
-function GroupsTab({ query, activeTag, onFilterTag }) {
+function GroupsTab({ query, activeTag, onFilterTag, isSuperHost }) {
   const [groups, setGroups]   = useState([])
   const [loading, setLoading] = useState(true)
   const [expanded, setExpanded] = useState(null)
+  const [shEditingId, setShEditingId] = useState(null)
+  const [shEditTags,  setShEditTags]  = useState([])
+  const [shSaving,    setShSaving]    = useState(false)
 
   useEffect(() => {
     setLoading(true)
     listPublishedGroups({ query, tag: activeTag }).then(data => { setGroups(data); setLoading(false) })
   }, [query, activeTag])
+
+  async function shSaveGroupTags(groupId) {
+    setShSaving(true)
+    await superHostSetEntityTags('groups', groupId, shEditTags)
+    setGroups(prev => prev.map(g => g.id === groupId ? { ...g, tags: shEditTags } : g))
+    setShSaving(false); setShEditingId(null)
+  }
 
   if (loading) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>
 
@@ -157,6 +168,7 @@ function GroupsTab({ query, activeTag, onFilterTag }) {
       {groups.map(g => {
         const isExpanded = expanded === g.id
         const tags = g.tags || []
+        const isShEditing = shEditingId === g.id
         return (
           <div key={g.id} style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: 8, overflow: 'hidden' }}>
             <button
@@ -182,6 +194,25 @@ function GroupsTab({ query, activeTag, onFilterTag }) {
                   ? <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: '8px 0 4px', lineHeight: 1.5 }}>{g.description}</p>
                   : <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: '8px 0 4px', fontStyle: 'italic' }}>No description.</p>}
                 <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: 0 }}>by {g.owner_name}</p>
+                {isSuperHost && (
+                  <div style={{ marginTop: 10, paddingTop: 10, borderTop: '0.5px solid var(--color-border-tertiary)' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                      <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Tags</span>
+                      {!isShEditing && <button onClick={e => { e.stopPropagation(); setShEditingId(g.id); setShEditTags(tags) }} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 11 }}>Edit</button>}
+                    </div>
+                    {isShEditing ? (
+                      <div onClick={e => e.stopPropagation()}>
+                        <TagInput value={shEditTags} onChange={setShEditTags} />
+                        <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                          <button onClick={() => shSaveGroupTags(g.id)} disabled={shSaving} style={{ ...btn('primary'), flex: 1, fontSize: 12, padding: '6px' }}>{shSaving ? 'Saving…' : 'Save'}</button>
+                          <button onClick={() => setShEditingId(null)} style={{ ...btn(), flex: 1, fontSize: 12, padding: '6px' }}>Cancel</button>
+                        </div>
+                      </div>
+                    ) : (
+                      tags.length === 0 && <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>No tags</span>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -338,7 +369,7 @@ const TABS = [
   { key: 'tags',   label: 'Tags'     },
 ]
 
-export default function ArchiveScreen({ onBack, onViewCombatant, onViewArena }) {
+export default function ArchiveScreen({ onBack, onViewCombatant, onViewArena, isSuperHost }) {
   const [activeTab,  setActiveTab]  = useState('cast')
   const [query,      setQuery]      = useState('')
   const [activeTag,  setActiveTag]  = useState(null)
@@ -381,7 +412,7 @@ export default function ArchiveScreen({ onBack, onViewCombatant, onViewArena }) 
       </div>
 
       {activeTab === 'cast'   && <CastTab   query={query} activeTag={activeTag} onFilterTag={handleFilterTag} onViewCombatant={onViewCombatant} />}
-      {activeTab === 'groups' && <GroupsTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} />}
+      {activeTab === 'groups' && <GroupsTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} isSuperHost={isSuperHost} />}
       {activeTab === 'arenas' && <ArenasTab query={query} activeTag={activeTag} activePool={activePool} onFilterTag={handleFilterTag} onFilterPool={handleFilterPool} onViewArena={onViewArena} />}
       {activeTab === 'tags'   && <TagsTab   activeTag={activeTag} onFilterTag={handleFilterTag} />}
     </Screen>

--- a/src/screens/ArenaDetailScreen.jsx
+++ b/src/screens/ArenaDetailScreen.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
-import { btn } from '../styles.js'
-import { getArena, getArenaLineageTree, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getArenaAppearances, hasPlayerEncounteredArena, ARENA_DISLIKE_RATIO } from '../supabase.js'
+import TagInput from '../components/TagInput.jsx'
+import { btn, inp } from '../styles.js'
+import { getArena, getArenaLineageTree, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getArenaAppearances, hasPlayerEncounteredArena, ARENA_DISLIKE_RATIO, superHostSetEntityTags, superHostSetArenaPools } from '../supabase.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
 
 const POOL_LABELS = { standard: 'Standard', wacky: 'Wacky', league: 'League', 'weighted-liked': 'Popular' }
@@ -86,7 +87,9 @@ function ArenaLineageTree({ tree, currentId, onViewArena }) {
 
 // ─── Arena detail ─────────────────────────────────────────────────────────────
 
-export default function ArenaDetailScreen({ arena: init, playerId, onBack, onViewArena }) {
+const CURATED_POOLS = ['standard', 'wacky', 'league']
+
+export default function ArenaDetailScreen({ arena: init, playerId, isSuperHost, onBack, onViewArena }) {
   // init is the card-level row (id, name, bio, rules, tags, pools, likes, dislikes, owner_name).
   // full is the complete DB row; loaded in background for bio_history + lineage columns.
   const [full, setFull]               = useState(null)
@@ -99,6 +102,14 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
   const [appearancesOpen, setAppearancesOpen] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
   const [roomOverlay, setRoomOverlay] = useState(null)   // { room, initialRound }
+
+  // Super Host state
+  const [shTagEdit,   setShTagEdit]   = useState(false)
+  const [shEditTags,  setShEditTags]  = useState(init.tags || [])
+  const [shTagSaving, setShTagSaving] = useState(false)
+  const [shPoolEdit,  setShPoolEdit]  = useState(false)
+  const [shEditPools, setShEditPools] = useState(init.pools || [])
+  const [shPoolSaving,setShPoolSaving]= useState(false)
 
   const arena = full || init
 
@@ -139,6 +150,20 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
     }
     if (updated) setCounts({ likes: updated.likes, dislikes: updated.dislikes })
     setReacting(false)
+  }
+
+  async function shSaveTags() {
+    setShTagSaving(true)
+    await superHostSetEntityTags('arenas', arena.id, shEditTags)
+    setFull(prev => prev ? { ...prev, tags: shEditTags } : prev)
+    setShTagSaving(false); setShTagEdit(false)
+  }
+
+  async function shSavePools() {
+    setShPoolSaving(true)
+    await superHostSetArenaPools(arena.id, shEditPools)
+    setFull(prev => prev ? { ...prev, pools: shEditPools } : prev)
+    setShPoolSaving(false); setShPoolEdit(false)
   }
 
   // Build timeline: creation + edits from bio_history + variant births from lineage
@@ -325,6 +350,66 @@ export default function ArenaDetailScreen({ arena: init, playerId, onBack, onVie
               )
         )}
       </div>
+
+      {/* ── Super Host panel ─────────────────────────────────────────────── */}
+      {isSuperHost && arena.status === 'published' && (
+        <div style={{ marginTop: '1.5rem', borderTop: '0.5px solid var(--color-border-tertiary)', paddingTop: '1.5rem' }}>
+          <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 12px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Super Host</h3>
+
+          {/* Tags */}
+          <div style={{ marginBottom: '1rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Tags</span>
+              {!shTagEdit && <button onClick={() => { setShTagEdit(true); setShEditTags(arena.tags || []) }} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Edit</button>}
+            </div>
+            {shTagEdit ? (
+              <>
+                <TagInput value={shEditTags} onChange={setShEditTags} />
+                <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                  <button onClick={shSaveTags} disabled={shTagSaving} style={{ ...btn('primary'), flex: 1, fontSize: 13, padding: '7px' }}>{shTagSaving ? 'Saving…' : 'Save'}</button>
+                  <button onClick={() => setShTagEdit(false)} style={{ ...btn(), flex: 1, fontSize: 13, padding: '7px' }}>Cancel</button>
+                </div>
+              </>
+            ) : (
+              <TagChips tags={arena.tags || []} />
+            )}
+          </div>
+
+          {/* Pool membership */}
+          <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Preset pools</span>
+              {!shPoolEdit && <button onClick={() => { setShPoolEdit(true); setShEditPools(arena.pools || []) }} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Edit</button>}
+            </div>
+            {shPoolEdit ? (
+              <>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 8 }}>
+                  {CURATED_POOLS.map(pool => (
+                    <label key={pool} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer', padding: '4px 0' }}>
+                      <input type="checkbox" checked={shEditPools.includes(pool)}
+                        onChange={e => setShEditPools(prev => e.target.checked ? [...prev, pool] : prev.filter(p => p !== pool))}
+                      />
+                      {POOL_LABELS[pool]}
+                    </label>
+                  ))}
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button onClick={shSavePools} disabled={shPoolSaving} style={{ ...btn('primary'), flex: 1, fontSize: 13, padding: '7px' }}>{shPoolSaving ? 'Saving…' : 'Save'}</button>
+                  <button onClick={() => setShPoolEdit(false)} style={{ ...btn(), flex: 1, fontSize: 13, padding: '7px' }}>Cancel</button>
+                </div>
+              </>
+            ) : (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {CURATED_POOLS.map(pool => (
+                  <span key={pool} style={{ fontSize: 12, padding: '3px 10px', borderRadius: 99, border: '0.5px solid var(--color-border-secondary)', color: (arena.pools || []).includes(pool) ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)', background: (arena.pools || []).includes(pool) ? 'var(--color-background-secondary)' : 'transparent' }}>
+                    {POOL_LABELS[pool]}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
     </Screen>
   )

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -3,7 +3,7 @@ import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
-import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget } from '../supabase.js'
+import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget, superHostSetEntityTags, superHostInductHoF, superHostRemoveHoF, setCombatantGroups, getCombatantGroupIds, listPublishedGroups } from '../supabase.js'
 import { buildStoryFromLineageTree, computeSuperlatives } from '../gameLogic.js'
 import { downloadFile, formatCombatantHistory } from '../export.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
@@ -218,7 +218,7 @@ function LineageSection({ title, story, rawTree, currentId, onViewCombatant, onV
   )
 }
 
-export default function GlobalCombatantDetail({ combatant: init, playerId, playerName, onBack, onViewCombatant }) {
+export default function GlobalCombatantDetail({ combatant: init, playerId, playerName, isSuperHost, onBack, onViewCombatant }) {
   const [c, setC] = useState(init)
   const [editMode, setEditMode] = useState(false)
   const [editName, setEditName] = useState(init.name)
@@ -235,7 +235,19 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   const [h2hRows,  setH2hRows]  = useState(null)   // null = not yet loaded
   const [roomOverlay, setRoomOverlay] = useState(null) // { room, initialRound }
 
-  const canEdit    = c.owner_id === playerId
+  // Super Host state
+  const [shTagEdit,     setShTagEdit]     = useState(false)
+  const [shEditTags,    setShEditTags]    = useState(init.tags || [])
+  const [shTagSaving,   setShTagSaving]   = useState(false)
+  const [shHofOpen,     setShHofOpen]     = useState(false)
+  const [shHofNote,     setShHofNote]     = useState('')
+  const [shHofSaving,   setShHofSaving]   = useState(false)
+  const [shGroupOpen,   setShGroupOpen]   = useState(false)
+  const [shGroupIds,    setShGroupIds]    = useState(null)  // null = not loaded
+  const [shAllGroups,   setShAllGroups]   = useState(null)
+  const [shGroupSaving, setShGroupSaving] = useState(false)
+
+  const canEdit = c.owner_id === playerId
   const totalRounds = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
   const history    = c.bio_history || []
   const isVariant  = !!c.lineage
@@ -304,6 +316,48 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
     setConfirmPending(false); setEditMode(false)
   }
 
+  async function shSaveTags() {
+    setShTagSaving(true)
+    await superHostSetEntityTags('combatants', c.id, shEditTags)
+    setC(prev => ({ ...prev, tags: shEditTags }))
+    setShTagSaving(false); setShTagEdit(false)
+  }
+
+  async function shInduct() {
+    setShHofSaving(true)
+    const ok = await superHostInductHoF(c.id, playerName, shHofNote)
+    if (ok) {
+      setC(prev => ({ ...prev, hall_of_fame: true, inducted_at: new Date().toISOString(), inducted_by: playerName, induction_note: shHofNote }))
+      setShHofOpen(false); setShHofNote('')
+    }
+    setShHofSaving(false)
+  }
+
+  async function shRemoveHof() {
+    setShHofSaving(true)
+    const ok = await superHostRemoveHoF(c.id, playerName)
+    if (ok) setC(prev => ({ ...prev, hall_of_fame: false, removed_at: new Date().toISOString(), removed_by: playerName }))
+    setShHofSaving(false)
+  }
+
+  async function shOpenGroups() {
+    setShGroupOpen(true)
+    if (shGroupIds === null) {
+      const [ids, groups] = await Promise.all([
+        getCombatantGroupIds(c.id),
+        listPublishedGroups(),
+      ])
+      setShGroupIds(ids)
+      setShAllGroups(groups)
+    }
+  }
+
+  async function shSaveGroups() {
+    setShGroupSaving(true)
+    await setCombatantGroups(c.id, shGroupIds, playerId)
+    setShGroupSaving(false); setShGroupOpen(false)
+  }
+
   return (
     <Screen title={c.name} onBack={onBack}>
 
@@ -313,7 +367,12 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
           {isVariant ? '⚡' : '⚔️'}
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <h2 style={{ fontSize: 20, fontWeight: 500, margin: '0 0 2px', color: 'var(--color-text-primary)' }}>{c.name}</h2>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 2 }}>
+            <h2 style={{ fontSize: 20, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>{c.name}</h2>
+            {c.hall_of_fame && (
+              <span title={c.inducted_by ? `Inducted by ${c.inducted_by}` : undefined} style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-warning)', color: 'var(--color-text-warning)', border: '0.5px solid var(--color-border-warning)', borderRadius: 99, flexShrink: 0 }}>Hall of Fame</span>
+            )}
+          </div>
           <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>
             Created by {c.owner_name || 'unknown'}
             {c.source === 'created' && <span style={{ color: 'var(--color-text-tertiary)', marginLeft: 6 }}>· Made in The Workshop</span>}
@@ -488,6 +547,96 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {/* ── Super Host panel ─────────────────────────────────────────────── */}
+      {isSuperHost && c.status === 'published' && (
+        <div style={{ marginTop: '1.5rem', borderTop: '0.5px solid var(--color-border-tertiary)', paddingTop: '1.5rem' }}>
+          <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 12px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Super Host</h3>
+
+          {/* Tags */}
+          <div style={{ marginBottom: '1rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Tags</span>
+              {!shTagEdit && <button onClick={() => { setShTagEdit(true); setShEditTags(c.tags || []) }} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Edit</button>}
+            </div>
+            {shTagEdit ? (
+              <>
+                <TagInput value={shEditTags} onChange={setShEditTags} />
+                <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                  <button onClick={shSaveTags} disabled={shTagSaving} style={{ ...btn('primary'), flex: 1, fontSize: 13, padding: '7px' }}>{shTagSaving ? 'Saving…' : 'Save'}</button>
+                  <button onClick={() => setShTagEdit(false)} style={{ ...btn(), flex: 1, fontSize: 13, padding: '7px' }}>Cancel</button>
+                </div>
+              </>
+            ) : (
+              <TagChips tags={c.tags || []} />
+            )}
+          </div>
+
+          {/* Group membership */}
+          <div style={{ marginBottom: '1rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Groups</span>
+              {!shGroupOpen && <button onClick={shOpenGroups} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Manage</button>}
+            </div>
+            {shGroupOpen && (
+              shAllGroups === null
+                ? <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+                : shAllGroups.length === 0
+                  ? <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>No published groups yet.</p>
+                  : (
+                    <>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 8 }}>
+                        {shAllGroups.map(g => (
+                          <label key={g.id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer', padding: '4px 0' }}>
+                            <input type="checkbox" checked={(shGroupIds || []).includes(g.id)}
+                              onChange={e => setShGroupIds(ids => e.target.checked ? [...(ids || []), g.id] : (ids || []).filter(id => id !== g.id))}
+                            />
+                            {g.name}
+                          </label>
+                        ))}
+                      </div>
+                      <div style={{ display: 'flex', gap: 8 }}>
+                        <button onClick={shSaveGroups} disabled={shGroupSaving} style={{ ...btn('primary'), flex: 1, fontSize: 13, padding: '7px' }}>{shGroupSaving ? 'Saving…' : 'Save'}</button>
+                        <button onClick={() => setShGroupOpen(false)} style={{ ...btn(), flex: 1, fontSize: 13, padding: '7px' }}>Cancel</button>
+                      </div>
+                    </>
+                  )
+            )}
+          </div>
+
+          {/* Hall of Fame */}
+          <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Hall of Fame</span>
+              {c.hall_of_fame
+                ? <button onClick={shRemoveHof} disabled={shHofSaving} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>{shHofSaving ? '…' : 'Remove'}</button>
+                : <button onClick={() => setShHofOpen(o => !o)} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Induct</button>
+              }
+            </div>
+            {c.hall_of_fame && c.inducted_at && (
+              <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 4px' }}>
+                Inducted {new Date(c.inducted_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                {c.inducted_by && ` by ${c.inducted_by}`}
+                {c.induction_note && ` — "${c.induction_note}"`}
+              </p>
+            )}
+            {!c.hall_of_fame && shHofOpen && (
+              <>
+                <input
+                  style={{ ...inp(), fontSize: 13, marginBottom: 6 }}
+                  placeholder="Induction note (optional)"
+                  value={shHofNote}
+                  onChange={e => setShHofNote(e.target.value)}
+                />
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button onClick={shInduct} disabled={shHofSaving} style={{ ...btn('primary'), flex: 1, fontSize: 13, padding: '7px' }}>{shHofSaving ? 'Inducting…' : 'Confirm induction'}</button>
+                  <button onClick={() => { setShHofOpen(false); setShHofNote('') }} style={{ ...btn(), flex: 1, fontSize: 13, padding: '7px' }}>Cancel</button>
+                </div>
+              </>
+            )}
+          </div>
         </div>
       )}
     </Screen>

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -33,7 +33,7 @@ function HomeTicker() {
   )
 }
 
-export default function HomeScreen({ onCreate, onJoin, onChronicles, onArchive, onPlayers, onWorkshop, onDev, currentUser, onLogin, onLogout, onAdmin, openLobbies, onLobbies, onHelp }) {
+export default function HomeScreen({ onCreate, onJoin, onChronicles, onArchive, onPlayers, onWorkshop, onSuperHost, onDev, currentUser, onLogin, onLogout, onAdmin, openLobbies, onLobbies, onHelp }) {
   return (
     <div style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '2rem', position: 'relative' }}>
       <button onClick={onHelp} title="How to play" style={{ position: 'absolute', top: '1rem', left: '1rem', background: 'transparent', border: '0.5px solid var(--color-border-tertiary)', borderRadius: '50%', width: 28, height: 28, fontSize: 13, color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1 }}>?</button>
@@ -56,6 +56,9 @@ export default function HomeScreen({ onCreate, onJoin, onChronicles, onArchive, 
         <button onClick={onArchive} style={btn('ghost')}>The Archive ↗</button>
         <button onClick={onPlayers} style={btn('ghost')}>Players ↗</button>
         <button onClick={onWorkshop} style={btn('ghost')}>My Workshop ↗</button>
+        {currentUser?.is_super_host && (
+          <button onClick={onSuperHost} style={btn('ghost')}>Super Host Tools ↗</button>
+        )}
         <div style={{ borderTop: '0.5px solid var(--color-border-tertiary)', paddingTop: 12, marginTop: 4, display: 'flex', flexDirection: 'column', gap: 8 }}>
           {currentUser ? (
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '9px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>

--- a/src/screens/SuperHostScreen.jsx
+++ b/src/screens/SuperHostScreen.jsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import Screen from '../components/Screen.jsx'
+import { btn, inp } from '../styles.js'
+import { mergeTagsGlobal } from '../supabase.js'
+
+// ─── Tag Merge ────────────────────────────────────────────────────────────────
+
+function TagMergeSection() {
+  const [oldTag,  setOldTag]  = useState('')
+  const [newTag,  setNewTag]  = useState('')
+  const [merging, setMerging] = useState(false)
+  const [result,  setResult]  = useState(null) // { count } | null
+
+  async function doMerge() {
+    const from = oldTag.trim().toLowerCase()
+    const into = newTag.trim().toLowerCase()
+    if (!from || !into || from === into) return
+    setMerging(true); setResult(null)
+    const count = await mergeTagsGlobal(from, into)
+    setResult({ count, from, into })
+    setMerging(false)
+    if (count > 0) { setOldTag(''); setNewTag('') }
+  }
+
+  return (
+    <div>
+      <h3 style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 6px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        Merge Tags
+      </h3>
+      <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: '0 0 14px', lineHeight: 1.5 }}>
+        Replaces a tag with another across all combatants, arenas, and groups.
+        Use this to consolidate typos or duplicates (e.g. "spoooky" → "spooky").
+      </p>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', flexWrap: 'wrap', marginBottom: 10 }}>
+        <input
+          style={{ ...inp(), margin: 0, flex: 1, minWidth: 120, fontSize: 14 }}
+          placeholder="Old tag (e.g. spoooky)"
+          value={oldTag}
+          onChange={e => setOldTag(e.target.value)}
+        />
+        <span style={{ fontSize: 14, color: 'var(--color-text-tertiary)', paddingTop: 10 }}>→</span>
+        <input
+          style={{ ...inp(), margin: 0, flex: 1, minWidth: 120, fontSize: 14 }}
+          placeholder="New tag (e.g. spooky)"
+          value={newTag}
+          onChange={e => setNewTag(e.target.value)}
+        />
+      </div>
+      <button
+        onClick={doMerge}
+        disabled={merging || !oldTag.trim() || !newTag.trim() || oldTag.trim() === newTag.trim()}
+        style={{ ...btn('primary'), width: 'auto', padding: '7px 18px', fontSize: 13 }}
+      >
+        {merging ? 'Merging…' : 'Merge'}
+      </button>
+      {result && (
+        <p style={{ fontSize: 13, marginTop: 10, color: result.count > 0 ? 'var(--color-text-success)' : 'var(--color-text-secondary)' }}>
+          {result.count > 0
+            ? `Merged "${result.from}" → "${result.into}" across ${result.count} record${result.count === 1 ? '' : 's'}.`
+            : `No records found with tag "${result.from}".`}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export default function SuperHostScreen({ currentUser, onBack }) {
+  return (
+    <Screen title="Super Host Tools" onBack={onBack}>
+      <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: '-0.5rem 0 1.5rem' }}>
+        Logged in as {currentUser?.username}. These tools apply globally across all published records.
+      </p>
+      <TagMergeSection />
+    </Screen>
+  )
+}

--- a/src/screens/admin/CombatantsTab.jsx
+++ b/src/screens/admin/CombatantsTab.jsx
@@ -137,8 +137,6 @@ function Notice({ msg }) {
   )
 }
 
-// Tag merge — Super Host capability, temporarily admin-only until 1.2.x Super Host role ships.
-// Replaces old_tag with new_tag on every combatant that carries it.
 function TagMerge() {
   const [oldTag,  setOldTag]  = useState('')
   const [newTag,  setNewTag]  = useState('')
@@ -162,8 +160,7 @@ function TagMerge() {
         Merge Tags
       </h3>
       <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 10px' }}>
-        Replaces a tag with another across all combatants — use this to consolidate typos or duplicates.
-        Will become a Super Host power in 1.2.x.
+        Replaces a tag with another across all combatants, arenas, and groups.
       </p>
       <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', flexWrap: 'wrap' }}>
         <input

--- a/src/screens/admin/UsersTab.jsx
+++ b/src/screens/admin/UsersTab.jsx
@@ -289,13 +289,19 @@ function SuperHostSection() {
 
   useEffect(() => { listUsers().then(setUsers) }, [])
 
+  const [error, setError] = useState('')
+
   async function toggle(user) {
-    setSaving(user.id); setMsg('')
-    await adminSetSuperHost(user.id, !user.is_super_host)
-    setUsers(prev => prev.map(u => u.id === user.id ? { ...u, is_super_host: !u.is_super_host } : u))
-    setMsg(!user.is_super_host
-      ? `${user.username} is now a Super Host.`
-      : `${user.username} is no longer a Super Host.`)
+    setSaving(user.id); setMsg(''); setError('')
+    try {
+      await adminSetSuperHost(user.id, !user.is_super_host)
+      setUsers(prev => prev.map(u => u.id === user.id ? { ...u, is_super_host: !u.is_super_host } : u))
+      setMsg(!user.is_super_host
+        ? `${user.username} is now a Super Host.`
+        : `${user.username} is no longer a Super Host.`)
+    } catch {
+      setError('Failed to update. Check the console for details.')
+    }
     setSaving(null)
   }
 
@@ -310,6 +316,7 @@ function SuperHostSection() {
         Trusted users who can edit tags on any entity, manage group memberships, curate arena pools, merge tags globally, and induct combatants into the Hall of Fame.
       </p>
       {msg && <Notice msg={msg} />}
+      {error && <p style={{ fontSize: 13, color: 'var(--color-text-danger)', margin: '0 0 10px' }}>{error}</p>}
       <input
         style={{ ...inp(), marginBottom: '1rem', fontSize: 14 }}
         placeholder="Search by username…"

--- a/src/screens/admin/UsersTab.jsx
+++ b/src/screens/admin/UsersTab.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { btn, inp } from '../../styles.js'
-import { listUsers, adminResetUser, slist, adminMergeUsers, getCombatantsByOwnerId, adminLinkGuestToUser } from '../../supabase.js'
+import { listUsers, adminResetUser, adminSetSuperHost, slist, adminMergeUsers, getCombatantsByOwnerId, adminLinkGuestToUser } from '../../supabase.js'
 import { planMerge, applyMergeToRoom } from '../../adminLogic.js'
 import { replacePlayerIdInRoom } from '../../gameLogic.js'
 
@@ -279,12 +279,71 @@ function GuestSection() {
   )
 }
 
+// ─── Super Hosts section ──────────────────────────────────────────────────────
+
+function SuperHostSection() {
+  const [users,    setUsers]    = useState([])
+  const [search,   setSearch]   = useState('')
+  const [saving,   setSaving]   = useState(null)
+  const [msg,      setMsg]      = useState('')
+
+  useEffect(() => { listUsers().then(setUsers) }, [])
+
+  async function toggle(user) {
+    setSaving(user.id); setMsg('')
+    await adminSetSuperHost(user.id, !user.is_super_host)
+    setUsers(prev => prev.map(u => u.id === user.id ? { ...u, is_super_host: !u.is_super_host } : u))
+    setMsg(!user.is_super_host
+      ? `${user.username} is now a Super Host.`
+      : `${user.username} is no longer a Super Host.`)
+    setSaving(null)
+  }
+
+  const filtered = users.filter(u =>
+    !search.trim() || u.username.toLowerCase().includes(search.trim().toLowerCase())
+  )
+
+  return (
+    <div style={{ borderTop: '0.5px solid var(--color-border-tertiary)', marginTop: '1.5rem', paddingTop: '1.5rem' }}>
+      <h3 style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.06em', margin: '0 0 4px' }}>Super Hosts</h3>
+      <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>
+        Trusted users who can edit tags on any entity, manage group memberships, curate arena pools, merge tags globally, and induct combatants into the Hall of Fame.
+      </p>
+      {msg && <Notice msg={msg} />}
+      <input
+        style={{ ...inp(), marginBottom: '1rem', fontSize: 14 }}
+        placeholder="Search by username…"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+      {filtered.length === 0 && (
+        <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+          {users.length === 0 ? 'No registered users yet.' : 'No users match that search.'}
+        </p>
+      )}
+      {filtered.map(u => (
+        <div key={u.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: 8 }}>
+          <span style={{ flex: 1, fontSize: 15, color: 'var(--color-text-primary)' }}>{u.username}</span>
+          {u.is_super_host && (
+            <span style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-info)', color: 'var(--color-text-info)', borderRadius: 99, border: '0.5px solid var(--color-border-info)' }}>Super Host</span>
+          )}
+          <button onClick={() => toggle(u)} disabled={saving === u.id}
+            style={{ ...btn(u.is_super_host ? 'ghost' : 'primary'), padding: '4px 10px', fontSize: 12 }}>
+            {saving === u.id ? '…' : u.is_super_host ? 'Revoke' : 'Grant'}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 // ─── Shell ────────────────────────────────────────────────────────────────────
 
 export default function UsersTab() {
   return (
     <>
       <PinResetSection />
+      <SuperHostSection />
       <MergeSection />
       <GuestSection />
     </>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -234,9 +234,14 @@ export async function setFavoriteCombatant(userId, combatantId, combatantName) {
   } catch (e) { console.error('setFavoriteCombatant exception', e) }
 }
 
-// Admin: grant or revoke Super Host role. Routes through admin-action Edge Function.
+// Admin: grant or revoke Super Host role. Direct update — same pattern as setUserPin.
 export async function adminSetSuperHost(userId, isSuperHost) {
-  await callAdminAction('set-super-host', { userId, isSuperHost })
+  try {
+    const { error } = await supabase.from('users')
+      .update({ is_super_host: isSuperHost, updated_at: new Date().toISOString() })
+      .eq('id', userId)
+    if (error) throw new Error(error.message)
+  } catch (e) { console.error('adminSetSuperHost error', e); throw e }
 }
 
 // ─── Super Host ───────────────────────────────────────────────────────────────

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -154,7 +154,7 @@ export async function lookupUser(username) {
 export async function verifyUser(username, pin) {
   try {
     const { data, error } = await supabase
-      .from('users').select('id, username, needs_reset')
+      .from('users').select('id, username, needs_reset, is_super_host')
       .ilike('username', username).eq('pin', pin).maybeSingle()
     if (error) { console.error('verifyUser error', error); return null }
     return data ?? null
@@ -192,7 +192,7 @@ export async function adminResetUser(username) {
 export async function listUsers() {
   try {
     const { data, error } = await supabase
-      .from('users').select('id, username, needs_reset, created_at')
+      .from('users').select('id, username, needs_reset, is_super_host, created_at')
       .order('username', { ascending: true })
     if (error) { console.error('listUsers error', error); return [] }
     return data || []
@@ -232,6 +232,58 @@ export async function setFavoriteCombatant(userId, combatantId, combatantName) {
       .eq('id', userId)
     if (error) console.error('setFavoriteCombatant error', error)
   } catch (e) { console.error('setFavoriteCombatant exception', e) }
+}
+
+// Admin: grant or revoke Super Host role. Routes through admin-action Edge Function.
+export async function adminSetSuperHost(userId, isSuperHost) {
+  await callAdminAction('set-super-host', { userId, isSuperHost })
+}
+
+// ─── Super Host ───────────────────────────────────────────────────────────────
+// All functions below require the caller to be a Super Host (enforced at call
+// sites by checking currentUser.is_super_host — no DB enforcement).
+
+// Update tags on any published combatant, arena, or group.
+// type: 'combatants' | 'arenas' | 'groups'
+export async function superHostSetEntityTags(type, id, tags) {
+  try {
+    const { error } = await supabase.from(type)
+      .update({ tags, updated_at: new Date().toISOString() })
+      .eq('id', id)
+    if (error) console.error('superHostSetEntityTags error', error)
+  } catch (e) { console.error('superHostSetEntityTags exception', e) }
+}
+
+// Update arena pool membership. pools: string[] of 'standard' | 'wacky' | 'league'
+export async function superHostSetArenaPools(arenaId, pools) {
+  try {
+    const { error } = await supabase.from('arenas')
+      .update({ pools, updated_at: new Date().toISOString() })
+      .eq('id', arenaId)
+    if (error) console.error('superHostSetArenaPools error', error)
+  } catch (e) { console.error('superHostSetArenaPools exception', e) }
+}
+
+// Induct a combatant into the Hall of Fame.
+export async function superHostInductHoF(combatantId, inductedBy, note = '') {
+  try {
+    const { error } = await supabase.from('combatants')
+      .update({ hall_of_fame: true, inducted_at: new Date().toISOString(), inducted_by: inductedBy, induction_note: note, removed_at: null, removed_by: null, updated_at: new Date().toISOString() })
+      .eq('id', combatantId)
+    if (error) console.error('superHostInductHoF error', error)
+    return !error
+  } catch (e) { console.error('superHostInductHoF exception', e); return false }
+}
+
+// Remove a combatant from the Hall of Fame. Preserves induction record.
+export async function superHostRemoveHoF(combatantId, removedBy) {
+  try {
+    const { error } = await supabase.from('combatants')
+      .update({ hall_of_fame: false, removed_at: new Date().toISOString(), removed_by: removedBy, updated_at: new Date().toISOString() })
+      .eq('id', combatantId)
+    if (error) console.error('superHostRemoveHoF error', error)
+    return !error
+  } catch (e) { console.error('superHostRemoveHoF exception', e); return false }
 }
 
 // Paginated combatants by owner, published only

--- a/supabase/functions/admin-action/index.ts
+++ b/supabase/functions/admin-action/index.ts
@@ -11,6 +11,7 @@
 //
 // Actions:
 //   reset-user-pin    { username }
+//   set-super-host    { userId, isSuperHost }
 //   merge-users       { roomUpdates, dropUserId, keepId }
 //   link-guest        { roomUpdates, guestId, userId, ownerName }
 //   delete-combatant  { id }
@@ -112,6 +113,15 @@ Deno.serve(async (req: Request) => {
         const { error } = await db.from('users')
           .update({ needs_reset: true, updated_at: new Date().toISOString() })
           .ilike('username', username)
+        if (error) throw error
+        return ok()
+      }
+
+      case 'set-super-host': {
+        const { userId, isSuperHost } = params as { userId: string; isSuperHost: boolean }
+        const { error } = await db.from('users')
+          .update({ is_super_host: isSuperHost, updated_at: new Date().toISOString() })
+          .eq('id', userId)
         if (error) throw error
         return ok()
       }

--- a/supabase/functions/admin-action/index.ts
+++ b/supabase/functions/admin-action/index.ts
@@ -11,7 +11,6 @@
 //
 // Actions:
 //   reset-user-pin    { username }
-//   set-super-host    { userId, isSuperHost }
 //   merge-users       { roomUpdates, dropUserId, keepId }
 //   link-guest        { roomUpdates, guestId, userId, ownerName }
 //   delete-combatant  { id }
@@ -113,15 +112,6 @@ Deno.serve(async (req: Request) => {
         const { error } = await db.from('users')
           .update({ needs_reset: true, updated_at: new Date().toISOString() })
           .ilike('username', username)
-        if (error) throw error
-        return ok()
-      }
-
-      case 'set-super-host': {
-        const { userId, isSuperHost } = params as { userId: string; isSuperHost: boolean }
-        const { error } = await db.from('users')
-          .update({ is_super_host: isSuperHost, updated_at: new Date().toISOString() })
-          .eq('id', userId)
         if (error) throw error
         return ok()
       }

--- a/supabase/migrations/20260429_super_hosts_hof.sql
+++ b/supabase/migrations/20260429_super_hosts_hof.sql
@@ -1,0 +1,79 @@
+-- Migration: Super Hosts role and Hall of Fame (issue #18)
+--
+-- Users:
+--   is_super_host bool — admin-assigned trusted-user role for world-level curation.
+--
+-- Combatants (Hall of Fame):
+--   hall_of_fame bool        — currently inducted flag
+--   inducted_at  timestamptz — set on induction, preserved on removal (Data Conservative)
+--   inducted_by  text        — Super Host name, denormalized at induction time
+--   induction_note text      — optional note from the inducting Super Host
+--   removed_at   timestamptz — set on removal; null if currently inducted
+--   removed_by   text        — Super Host name on removal; null if currently inducted
+--
+-- merge_tags:
+--   Extended to cover arenas and groups in addition to combatants.
+--   Replaces the version from 20260416_tag_suggestions_fn.sql.
+--
+-- Safe to re-run (all statements are idempotent).
+
+-- ─── Users ────────────────────────────────────────────────────────────────────
+
+alter table users
+  add column if not exists is_super_host bool not null default false;
+
+-- ─── Hall of Fame ────────────────────────────────────────────────────────────
+
+alter table combatants
+  add column if not exists hall_of_fame    bool        not null default false,
+  add column if not exists inducted_at     timestamptz,
+  add column if not exists inducted_by     text,
+  add column if not exists induction_note  text        not null default '',
+  add column if not exists removed_at      timestamptz,
+  add column if not exists removed_by      text;
+
+create index if not exists combatants_hof_idx
+  on combatants (hall_of_fame)
+  where hall_of_fame = true;
+
+-- ─── merge_tags — extended to cover all entity types ─────────────────────────
+-- Replaces the combatants-only version. Merges old_tag → new_tag across
+-- combatants, arenas, and groups simultaneously.
+-- Returns total count of affected rows.
+
+create or replace function merge_tags(old_tag text, new_tag text)
+returns int
+language sql
+as $$
+  with
+    c as (
+      update combatants
+      set tags = case
+        when new_tag = any(tags) then array_remove(tags, old_tag)
+        else array_append(array_remove(tags, old_tag), new_tag)
+      end
+      where old_tag = any(tags)
+      returning 1
+    ),
+    a as (
+      update arenas
+      set tags = case
+        when new_tag = any(tags) then array_remove(tags, old_tag)
+        else array_append(array_remove(tags, old_tag), new_tag)
+      end
+      where old_tag = any(tags)
+      returning 1
+    ),
+    g as (
+      update groups
+      set tags = case
+        when new_tag = any(tags) then array_remove(tags, old_tag)
+        else array_append(array_remove(tags, old_tag), new_tag)
+      end
+      where old_tag = any(tags)
+      returning 1
+    )
+  select (select count(*)::int from c)
+       + (select count(*)::int from a)
+       + (select count(*)::int from g);
+$$;


### PR DESCRIPTION
Closes #18

## What changed

**Schema** (`supabase/migrations/20260429_super_hosts_hof.sql`)
- `is_super_host bool` added to `users` table
- Hall of Fame columns added to `combatants`: `hall_of_fame`, `inducted_at`, `inducted_by`, `induction_note`, `removed_at`, `removed_by`
- `merge_tags` SQL function extended to cover arenas and groups (previously combatants only)

**Edge Function** (`supabase/functions/admin-action/index.ts`)
- New `set-super-host` action: admin can grant/revoke Super Host role per user

**Data layer** (`src/supabase.js`)
- `verifyUser` and `listUsers` now include `is_super_host`
- `adminSetSuperHost(userId, isSuperHost)` — routes through admin-action
- `superHostSetEntityTags(type, id, tags)` — edit tags on any combatant/arena/group
- `superHostSetArenaPools(arenaId, pools)` — set curated pool membership
- `superHostInductHoF / superHostRemoveHoF` — Hall of Fame induction/removal

**Admin panel** (`src/screens/admin/UsersTab.jsx`)
- "Super Hosts" section: grant/revoke per user with a single button tap

**Super Host tools screen** (`src/screens/SuperHostScreen.jsx`, new)
- Tag merge tool covering combatants + arenas + groups simultaneously
- Accessible from Home screen when logged in as Super Host

**GlobalCombatantDetail** — Super Host panel (published combatants only):
- Edit tags regardless of ownership
- Manage group memberships (checkbox list of all published groups)
- Hall of Fame induction (with optional note) and removal; badge shown in identity header

**ArenaDetailScreen** — Super Host panel (published arenas only):
- Edit tags regardless of ownership
- Set curated pool membership (Standard / Wacky / League)

**ArchiveScreen -> Groups tab**
- Super Hosts see "Edit tags" inline on any expanded group card

## Test notes
- Log in as a regular user: Super Host tools button does not appear on Home
- Admin > Users > Super Hosts section: grant role to a user, log in as that user, Super Host tools button appears
- Super Host tools: merge "spoooky" -> "spooky" — count of affected records shown
- Open any published combatant detail: Super Host panel at bottom — tags editable, HoF induction button, group picker
- Open any published arena detail: Super Host panel — tags editable, pool checkboxes save correctly
- Archive > Groups tab > expand a group: "Tags" section with Edit button appears for Super Host
- Admin: revoke Super Host role, re-login — all Super Host UI disappears