### PR TITLE
Super Host: arena preset pool curation

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -957,14 +957,14 @@ export async function publishArenas(ids) {
 // Returns a random arena snapshot for random-pool delivery mode.
 // pool: 'standard' | 'wacky' | 'league' | 'weighted-liked'
 // excludeArenaIds: arena IDs to exclude (e.g. already played in the series)
-// Pool-specific curation (standard/wacky/league) deferred to Super Host #74 —
-// all published arenas are eligible across those pools for now.
 export async function getRandomArenaFromPool(pool, excludeArenaIds = []) {
   try {
-    const { data, error } = await supabase
+    let q = supabase
       .from('arenas')
       .select('id, name, bio, rules, tags, likes, dislikes')
       .eq('status', 'published')
+    if (pool !== 'weighted-liked') q = q.contains('pools', [pool])
+    const { data, error } = await q
     if (error || !data?.length) return null
 
     let eligible = data


### PR DESCRIPTION
Closes #74

## What changed

Most of the work for this issue landed in the Super Hosts role PR (#82): the `pools text[]` migration, `superHostSetArenaPools`, pool badges on the arena detail page, the Super Host edit panel with standard/wacky/league checkboxes, and `weighted-liked` filtering in `listPublishedArenas`.

This PR completes the one remaining gap: `getRandomArenaFromPool` was not yet filtering by pool membership for standard/wacky/league pools (a deferred comment marked it for this issue). It now uses `.contains('pools', [pool])` at the query level, consistent with `listPublishedArenas`.

**Acceptance criteria:**
- `pools text[]` column: migration `20260429_arenas_last_played_at_pools.sql`
- Arena detail page: read-only pool badges visible to all; Super Host edit panel with standard/wacky/league checkboxes gated on `isSuperHost`
- `superHostSetArenaPools` writes to the `pools` column
- `weighted-liked` computed from like/dislike ratio via `ARENA_DISLIKE_RATIO` constant — not stored, not manually managed
- Suppression threshold: `ARENA_DISLIKE_RATIO = 3` named export — not a magic number
- Random draws from standard/wacky/league pools now correctly return only curated arenas
- Non-Super Hosts see pool badges read-only; edit UI is gated on `isSuperHost`

## Test notes

- As Super Host on an arena detail page: a "Preset pools" section appears under Super Host Tools; checkboxes for Standard / Wacky / League toggle pool membership immediately on Save
- Pool badges (Standard, Wacky, League, Popular) appear at the top of the detail page for any user when the arena is in those pools; Popular is computed from likes/dislikes
- In lobby with random-pool delivery mode: selecting Standard/Wacky/League only draws from arenas curated to that pool; selecting Popular draws from arenas passing the dislike-ratio threshold