### PR TITLE
The Workshop: Create-a-Playlist

### DIFF
--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -3,7 +3,7 @@ import DevBanner from '../components/DevBanner.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant } from '../supabase.js'
+import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant, getPlaylistForDelivery } from '../supabase.js'
 import { uid, canUndoLastRound, undoRound, tallyReactions, normalizeRoomSettings } from '../gameLogic.js'
 
 // Inline form for evolving the current arena after a round resolves.
@@ -128,6 +128,11 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
         excludeIds = [...new Set([...excludeIds, ...seriesIds])]
       }
       arena = await getRandomArenaFromPool(arenaConfig?.pool || 'standard', excludeIds)
+    } else if (arenaMode === 'playlist' && arenaConfig?.playlistId) {
+      const playlistArenas = await getPlaylistForDelivery(arenaConfig.playlistId)
+      if (playlistArenas.length) {
+        arena = playlistArenas[(roundNum - 1) % playlistArenas.length]
+      }
     }
 
     const newRound = { id: uid(), number: roundNum, combatants: matchup, picks: {}, winner: null, createdAt: Date.now(), arena }

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
 import { btn, inp, lbl, tab } from '../styles.js'
-import { sset, getArenaPickerOptions } from '../supabase.js'
+import { sset, getArenaPickerOptions, getPlaylistPickerOptions } from '../supabase.js'
 import { playerColor, buildArenaSnapshot } from '../gameLogic.js'
 
 function SettingRow({ label, description, value, onToggle, indented }) {
@@ -52,7 +52,7 @@ const ARENA_MODES = [
   { value: 'none',        label: 'None' },
   { value: 'single',      label: 'Single' },
   { value: 'random-pool', label: 'Random pool' },
-  { value: 'playlist',    label: 'Playlist', disabled: true },
+  { value: 'playlist',    label: 'Playlist' },
 ]
 
 const POOL_OPTIONS = [
@@ -72,17 +72,34 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
   const [arenaSearch,  setArenaSearch]  = useState('')
   const [arenasLoaded, setArenasLoaded] = useState(false)
 
+  // Playlist picker state
+  const [playlists,       setPlaylists]       = useState([])
+  const [playlistSearch,  setPlaylistSearch]  = useState('')
+  const [playlistsLoaded, setPlaylistsLoaded] = useState(false)
+
   function toggle(key) { setSettings(s => ({ ...s, [key]: !s[key] })) }
 
   function selectArenaMode(mode) {
     setSettings(s => ({ ...s, arenaMode: mode, arenaConfig: null }))
     setArenaSearch('')
+    setPlaylistSearch('')
     if (mode === 'single' && !arenasLoaded) {
       getArenaPickerOptions(playerId).then(data => { setArenas(data); setArenasLoaded(true) })
     }
     if (mode === 'random-pool') {
       setSettings(s => ({ ...s, arenaMode: mode, arenaConfig: { pool: 'standard', excludeSeries: false } }))
     }
+    if (mode === 'playlist' && !playlistsLoaded) {
+      getPlaylistPickerOptions(playerId).then(data => { setPlaylists(data); setPlaylistsLoaded(true) })
+    }
+  }
+
+  function pickPlaylist(playlist) {
+    setSettings(s => ({ ...s, arenaConfig: { playlistId: playlist.id, playlistName: playlist.name } }))
+  }
+
+  function clearPlaylistSelection() {
+    setSettings(s => ({ ...s, arenaConfig: null }))
   }
 
   function pickArena(arena) {
@@ -122,7 +139,12 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
     ? arenas.filter(a => a.name.toLowerCase().includes(arenaSearch.trim().toLowerCase()) || (a.bio || '').toLowerCase().includes(arenaSearch.trim().toLowerCase()))
     : arenas
 
+  const filteredPlaylists = playlistSearch.trim()
+    ? playlists.filter(p => p.name.toLowerCase().includes(playlistSearch.trim().toLowerCase()))
+    : playlists
+
   const selectedArenaSnapshot = settings.arenaConfig?.arenaSnapshot || null
+  const selectedPlaylist = settings.arenaConfig?.playlistId ? { id: settings.arenaConfig.playlistId, name: settings.arenaConfig.playlistName } : null
 
   return (
     <Screen title="New room" onBack={onBack}>
@@ -284,11 +306,54 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
           </div>
         )}
 
-        {/* Playlist mode: gated */}
+        {/* Playlist mode: playlist search + select */}
         {settings.arenaMode === 'playlist' && (
-          <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
-            Playlist delivery coming soon.
-          </p>
+          <div>
+            {selectedPlaylist ? (
+              <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{selectedPlaylist.name}</div>
+                  </div>
+                  <button onClick={clearPlaylistSelection} style={{ ...btn('ghost'), padding: '3px 10px', fontSize: 12, flexShrink: 0 }}>Change</button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <input
+                  style={{ ...inp(), margin: '0 0 6px', fontSize: 14 }}
+                  value={playlistSearch}
+                  onChange={e => setPlaylistSearch(e.target.value)}
+                  placeholder="Search playlists…"
+                  autoFocus
+                />
+                {!playlistsLoaded ? (
+                  <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+                ) : filteredPlaylists.length === 0 ? (
+                  <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
+                    {playlists.length === 0 ? 'No playlists yet — create one in The Workshop first.' : 'No playlists match your search.'}
+                  </p>
+                ) : (
+                  <div style={{ border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden', maxHeight: 240, overflowY: 'auto' }}>
+                    {filteredPlaylists.map((playlist, i) => (
+                      <button
+                        key={playlist.id}
+                        onClick={() => pickPlaylist(playlist)}
+                        style={{ display: 'block', width: '100%', textAlign: 'left', padding: '10px 14px', background: i % 2 === 0 ? 'var(--color-background-secondary)' : 'var(--color-background-primary)', border: 'none', borderTop: i === 0 ? 'none' : '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                          <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>{playlist.name}</span>
+                          {playlist.status === 'stashed' && (
+                            <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>stashed</span>
+                          )}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
         )}
       </div>
 

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -58,7 +58,7 @@ function ArenaModeDisplay({ settings }) {
         )}
         {arenaMode === 'playlist' && (
           <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>
-            Playlist · {arenaConfig?.playlistId || 'not configured'}
+            Playlist · {arenaConfig?.playlistName || arenaConfig?.playlistId || 'not configured'}
           </span>
         )}
       </div>

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -6,7 +6,7 @@ import RoundChat from '../components/RoundChat.jsx'
 import EvolutionForm from '../components/EvolutionForm.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence, getArenaReaction, upsertArenaReaction, deleteArenaReaction } from '../supabase.js'
+import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, publishPlaylist, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence, getArenaReaction, upsertArenaReaction, deleteArenaReaction } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish, resolveAllAdvanceSelection } from '../gameLogic.js'
@@ -238,11 +238,12 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
         await incrementCombatantStats(c.id, { wins: isWin ? 1 : 0, losses: isWin ? 0 : 1, heart, angry, cry })
       }
       if (isFinalRound(r)) {
-        const { rosterSize } = normalizeRoomSettings(r.settings)
+        const { rosterSize, arenaMode, arenaConfig } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
         // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
         const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
         if (arenaIds.length) await publishArenas(arenaIds)
+        if (arenaMode === 'playlist' && arenaConfig?.playlistId) await publishPlaylist(arenaConfig.playlistId)
       }
     })()
   }
@@ -291,11 +292,12 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
         await incrementCombatantStats(c.id, { ...stat, heart, angry, cry })
       }
       if (isFinalRound(r)) {
-        const { rosterSize } = normalizeRoomSettings(r.settings)
+        const { rosterSize, arenaMode, arenaConfig } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
         // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
         const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
         if (arenaIds.length) await publishArenas(arenaIds)
+        if (arenaMode === 'playlist' && arenaConfig?.playlistId) await publishPlaylist(arenaConfig.playlistId)
       }
     })()
   }
@@ -439,11 +441,12 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
         await incrementCombatantStats(c.id, { wins: 1, heart, angry, cry })
       }
       if (isFinalRound(r)) {
-        const { rosterSize } = normalizeRoomSettings(r.settings)
+        const { rosterSize, arenaMode, arenaConfig } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(combatants, rounds, rosterSize))
         // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
         const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
         if (arenaIds.length) await publishArenas(arenaIds)
+        if (arenaMode === 'playlist' && arenaConfig?.playlistId) await publishPlaylist(arenaConfig.playlistId)
       }
     })()
   }
@@ -547,9 +550,12 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
         await incrementCombatantStats(c.id, { wins: isWin ? 1 : 0, losses: isWin ? 0 : 1, heart, angry, cry })
       }
       if (isFinalRound(r)) {
-        const { rosterSize } = normalizeRoomSettings(r.settings)
+        const { rosterSize, arenaMode, arenaConfig } = normalizeRoomSettings(r.settings)
         await publishCombatants(getCombatantsToPublish(finalCombatants, rounds, rosterSize))
-        if (r.settings?.arena?.id) await publishArenas([r.settings.arena.id])
+        // Publish every arena snapshotted into a round (handles single, random-pool, playlist modes)
+        const arenaIds = [...new Set(rounds.filter(rd => rd.arena?.id).map(rd => rd.arena.id))]
+        if (arenaIds.length) await publishArenas(arenaIds)
+        if (arenaMode === 'playlist' && arenaConfig?.playlistId) await publishPlaylist(arenaConfig.playlistId)
       }
     })()
   }

--- a/src/screens/WorkshopScreen.jsx
+++ b/src/screens/WorkshopScreen.jsx
@@ -18,6 +18,14 @@ import {
   updateWorkshopArena,
   setWorkshopArenaStatus,
   deleteWorkshopArena,
+  getWorkshopPlaylists,
+  createWorkshopPlaylist,
+  updateWorkshopPlaylist,
+  setWorkshopPlaylistStatus,
+  deleteWorkshopPlaylist,
+  getPlaylistWithSlots,
+  setPlaylistSlots,
+  getArenaPickerOptions,
 } from '../supabase.js'
 
 // ─── Guest gate ───────────────────────────────────────────────────────────────
@@ -564,12 +572,324 @@ function ArenaCard({ arena, onEdit, onPublish, onUnpublish, onDelete }) {
   )
 }
 
+// ─── Playlist slot list ───────────────────────────────────────────────────────
+
+function SlotList({ slots, onRemove, onMoveUp, onMoveDown }) {
+  if (!slots.length) {
+    return (
+      <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>
+        No arenas added yet. Search above to add slots.
+      </p>
+    )
+  }
+  return (
+    <div style={{ marginBottom: 12 }}>
+      {slots.map((slot, i) => (
+        <div key={`${slot.arena_id}-${i}`} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 10px', marginBottom: 4, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', minWidth: 18, textAlign: 'right', flexShrink: 0 }}>{i + 1}.</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>{slot.arenaName}</span>
+            {slot.arenaStatus === 'stashed' && (
+              <span style={{ fontSize: 10, marginLeft: 6, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>stashed</span>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+            <button onClick={() => onMoveUp(i)} disabled={i === 0} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12, opacity: i === 0 ? 0.3 : 1 }}>↑</button>
+            <button onClick={() => onMoveDown(i)} disabled={i === slots.length - 1} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12, opacity: i === slots.length - 1 ? 0.3 : 1 }}>↓</button>
+            <button onClick={() => onRemove(i)} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12, color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }}>×</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Playlist form ────────────────────────────────────────────────────────────
+
+function PlaylistForm({ existing, onSave, onCancel, currentUser }) {
+  const isEdit      = !!existing
+  const isPublished = existing?.status === 'published'
+
+  const [name,        setName]        = useState(existing?.name   || '')
+  const [tags,        setTags]        = useState(existing?.tags   || [])
+  const [slots,       setSlots]       = useState([])         // [{ arena_id, arenaName, arenaBio, arenaStatus }]
+  const [slotsLoaded, setSlotsLoaded] = useState(!isEdit)    // new form has nothing to load
+  const [status,      setStatus]      = useState(existing?.status || 'stashed')
+  const [saving,      setSaving]      = useState(false)
+  const [confirm,     setConfirm]     = useState(false)
+  const [error,       setError]       = useState('')
+
+  // Arena picker state
+  const [arenaSearch,  setArenaSearch]  = useState('')
+  const [arenas,       setArenas]       = useState([])
+  const [arenasLoaded, setArenasLoaded] = useState(false)
+  const [showPicker,   setShowPicker]   = useState(false)
+
+  const initialSlotIdsRef = useRef(null)
+
+  // Load arena picker options
+  useEffect(() => {
+    getArenaPickerOptions(currentUser.id).then(data => { setArenas(data); setArenasLoaded(true) })
+  }, [currentUser.id])
+
+  // Load existing slots when editing
+  useEffect(() => {
+    if (!existing?.id) return
+    getPlaylistWithSlots(existing.id).then(full => {
+      if (!full) return
+      const loaded = full.slots || []
+      setSlots(loaded)
+      initialSlotIdsRef.current = loaded.map(s => s.arena_id)
+      setSlotsLoaded(true)
+    })
+  }, [existing?.id])
+
+  const initialSlotIds = initialSlotIdsRef.current || []
+  const currentSlotIds = slots.map(s => s.arena_id)
+
+  const hasChanges = !isEdit || (
+    name.trim() !== existing.name.trim() ||
+    JSON.stringify(tags) !== JSON.stringify(existing.tags || []) ||
+    JSON.stringify(currentSlotIds) !== JSON.stringify(initialSlotIds)
+  )
+
+  const filteredArenas = (arenaSearch.trim()
+    ? arenas.filter(a => a.name.toLowerCase().includes(arenaSearch.toLowerCase()) || (a.bio || '').toLowerCase().includes(arenaSearch.toLowerCase()))
+    : arenas
+  ).filter(a => !slots.find(s => s.arena_id === a.id))
+
+  function addSlot(arena) {
+    setSlots(prev => [...prev, { arena_id: arena.id, arenaName: arena.name, arenaBio: arena.bio || '', arenaStatus: arena.status }])
+    setArenaSearch('')
+    setShowPicker(false)
+  }
+
+  function removeSlot(idx)  { setSlots(prev => prev.filter((_, i) => i !== idx)) }
+
+  function moveUp(idx) {
+    if (idx === 0) return
+    setSlots(prev => { const next = [...prev]; [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]]; return next })
+  }
+
+  function moveDown(idx) {
+    setSlots(prev => {
+      if (idx >= prev.length - 1) return prev
+      const next = [...prev]; [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]]; return next
+    })
+  }
+
+  function validate() {
+    if (!name.trim()) { setError('Name is required.'); return false }
+    return true
+  }
+
+  async function handleSave() {
+    if (!validate()) return
+    if (isEdit && isPublished && !confirm) { setConfirm(true); return }
+    setSaving(true); setError('')
+    const arenaIds = slots.map(s => s.arena_id)
+    if (isEdit) {
+      const ok = await updateWorkshopPlaylist(existing.id, { name: name.trim(), tags })
+      if (!ok) { setError('Save failed. Try again.'); setSaving(false); return }
+      const slotsOk = await setPlaylistSlots(existing.id, arenaIds)
+      if (!slotsOk) { setError('Save failed. Try again.'); setSaving(false); return }
+      onSave({ ...existing, name: name.trim(), tags, slot_count: slots.length })
+    } else {
+      const id = await createWorkshopPlaylist({ name: name.trim(), tags, ownerId: currentUser.id, ownerName: currentUser.username, status })
+      if (!id) { setError('Save failed. Try again.'); setSaving(false); return }
+      if (arenaIds.length) await setPlaylistSlots(id, arenaIds)
+      onSave({ id, name: name.trim(), tags, status, slot_count: arenaIds.length, owner_id: currentUser.id, owner_name: currentUser.username })
+    }
+    setSaving(false)
+  }
+
+  return (
+    <div>
+      <h3 style={{ fontSize: 17, fontWeight: 500, margin: '0 0 1.25rem', color: 'var(--color-text-primary)' }}>
+        {isEdit ? 'Edit playlist' : 'New playlist'}
+      </h3>
+
+      <label style={lbl}>Name *</label>
+      <input
+        style={inp()}
+        placeholder="What is this playlist called?"
+        value={name}
+        onChange={e => { setName(e.target.value); setError('') }}
+        maxLength={80}
+        autoFocus={!isEdit}
+      />
+
+      <label style={lbl}>Arena slots</label>
+      {isEdit && !slotsLoaded ? (
+        <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>Loading slots…</p>
+      ) : (
+        <SlotList slots={slots} onRemove={removeSlot} onMoveUp={moveUp} onMoveDown={moveDown} />
+      )}
+
+      {/* Arena picker */}
+      {showPicker ? (
+        <div style={{ marginBottom: 12 }}>
+          <input
+            style={{ ...inp(), margin: '0 0 6px', fontSize: 14 }}
+            value={arenaSearch}
+            onChange={e => setArenaSearch(e.target.value)}
+            placeholder="Search arenas…"
+            autoFocus
+          />
+          {!arenasLoaded ? (
+            <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+          ) : filteredArenas.length === 0 ? (
+            <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
+              {arenas.length === 0 ? 'No arenas yet — create one in the Arenas tab first.' : 'No arenas match.'}
+            </p>
+          ) : (
+            <div style={{ border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden', maxHeight: 200, overflowY: 'auto' }}>
+              {filteredArenas.map((arena, i) => (
+                <button
+                  key={arena.id}
+                  onClick={() => addSlot(arena)}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: i % 2 === 0 ? 'var(--color-background-secondary)' : 'var(--color-background-primary)', border: 'none', borderTop: i === 0 ? 'none' : '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary)' }}>{arena.name}</span>
+                    {arena.status === 'stashed' && (
+                      <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>stashed</span>
+                    )}
+                  </div>
+                  {arena.bio && (
+                    <p style={{ fontSize: 11, color: 'var(--color-text-secondary)', margin: '1px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{arena.bio}</p>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+          <button onClick={() => { setShowPicker(false); setArenaSearch('') }} style={{ ...btn('ghost'), marginTop: 6, padding: '4px 12px', fontSize: 12 }}>
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button onClick={() => setShowPicker(true)} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13, marginBottom: 12 }}>
+          + Add arena slot
+        </button>
+      )}
+
+      <label style={lbl}>Tags</label>
+      <div style={{ marginBottom: 12 }}>
+        <TagInput value={tags} onChange={setTags} />
+      </div>
+
+      {!isEdit && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ ...lbl, marginBottom: 8 }}>Visibility</label>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={() => setStatus('stashed')} style={{ ...tab(status === 'stashed'), fontSize: 13, padding: '6px 14px' }}>
+              Stash (private)
+            </button>
+            <button onClick={() => setStatus('published')} style={{ ...tab(status === 'published'), fontSize: 13, padding: '6px 14px' }}>
+              Publish now
+            </button>
+          </div>
+          {status === 'stashed' && (
+            <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '6px 0 0' }}>
+              Only you can see this until you publish it.
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && <p style={{ color: 'var(--color-text-danger)', fontSize: 13, margin: '0 0 12px' }}>{error}</p>}
+
+      {confirm && (
+        <div style={{ background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', padding: '12px 14px', marginBottom: 12 }}>
+          <p style={{ margin: '0 0 8px', fontSize: 13, color: 'var(--color-text-primary)' }}>
+            This playlist is published — your edits will be public. Continue?
+          </p>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={handleSave} disabled={saving} style={{ ...btn('primary'), padding: '7px 14px', fontSize: 13, width: 'auto' }}>
+              {saving ? 'Saving…' : 'Yes, save'}
+            </button>
+            <button onClick={() => setConfirm(false)} style={{ ...btn(), padding: '7px 14px', fontSize: 13, width: 'auto' }}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!confirm && (
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={handleSave} disabled={saving || !hasChanges || (isEdit && !slotsLoaded)} style={{ ...btn('primary'), width: 'auto', padding: '9px 18px', fontSize: 14 }}>
+            {saving ? 'Saving…' : isEdit ? 'Save' : status === 'published' ? 'Create & publish' : 'Add to stash'}
+          </button>
+          <button onClick={onCancel} style={{ ...btn(), width: 'auto', padding: '9px 18px', fontSize: 14 }}>
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Playlist Workshop card ───────────────────────────────────────────────────
+
+function PlaylistCard({ playlist, onEdit, onPublish, onUnpublish, onDelete }) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const isStashed   = playlist.status === 'stashed'
+  const isPublished = playlist.status === 'published'
+
+  return (
+    <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '12px 14px', marginBottom: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{playlist.name}</span>
+        {isStashed && (
+          <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>
+            🔒 stashed
+          </span>
+        )}
+        {isPublished && (
+          <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-success)', border: '0.5px solid var(--color-border-success)', color: 'var(--color-text-success)' }}>
+            published
+          </span>
+        )}
+      </div>
+      <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '3px 0 0' }}>
+        {playlist.slot_count} {playlist.slot_count === 1 ? 'arena' : 'arenas'}
+      </p>
+      {playlist.tags?.length > 0 && (
+        <div style={{ marginTop: 5 }}>
+          <TagChips tags={playlist.tags} />
+        </div>
+      )}
+
+      {confirmDelete ? (
+        <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>Delete permanently?</span>
+          <button onClick={() => onDelete(playlist)} style={{ ...btn(), padding: '4px 12px', fontSize: 12, width: 'auto', color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }}>Delete</button>
+          <button onClick={() => setConfirmDelete(false)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Keep</button>
+        </div>
+      ) : (
+        <div style={{ marginTop: 10, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <button onClick={() => onEdit(playlist)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Edit</button>
+          {isStashed && (
+            <button onClick={() => onPublish(playlist)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12, color: 'var(--color-text-success)', borderColor: 'var(--color-border-success)' }}>Publish</button>
+          )}
+          {isPublished && (
+            <button onClick={() => onUnpublish(playlist)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Move to stash</button>
+          )}
+          {isStashed && (
+            <button onClick={() => setConfirmDelete(true)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12, color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }}>Delete</button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── Main screen ──────────────────────────────────────────────────────────────
 
 export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
   if (!currentUser) return <GuestGate onLogin={onLogin} />
 
-  const [section,    setSection]    = useState('combatants')  // 'combatants' | 'arenas' | 'groups'
+  const [section,    setSection]    = useState('combatants')  // 'combatants' | 'arenas' | 'playlists' | 'groups'
   const [view,       setView]       = useState('library')     // 'library' | 'create' | 'edit'
   const [editTarget, setEditTarget] = useState(null)
   const [filter,     setFilter]     = useState('all')         // 'all' | 'stashed' | 'published'
@@ -584,6 +904,13 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
   const [arenaLoading,    setArenaLoading]    = useState(false)
   const [arenaLoaded,     setArenaLoaded]     = useState(false)
   const [arenaEditTarget, setArenaEditTarget] = useState(null)
+
+  // Playlist section state
+  const [playlistItems,      setPlaylistItems]      = useState([])
+  const [playlistFilter,     setPlaylistFilter]     = useState('all')
+  const [playlistLoading,    setPlaylistLoading]    = useState(false)
+  const [playlistLoaded,     setPlaylistLoaded]     = useState(false)
+  const [playlistEditTarget, setPlaylistEditTarget] = useState(null)
 
   useEffect(() => {
     setLoading(true)
@@ -600,6 +927,15 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
       setArenaItems(data); setArenaLoading(false); setArenaLoaded(true)
     })
   }, [section, arenaLoaded, currentUser.id])
+
+  // Lazy-load playlists on first visit to that section
+  useEffect(() => {
+    if (section !== 'playlists' || playlistLoaded) return
+    setPlaylistLoading(true)
+    getWorkshopPlaylists(currentUser.id).then(data => {
+      setPlaylistItems(data); setPlaylistLoading(false); setPlaylistLoaded(true)
+    })
+  }, [section, playlistLoaded, currentUser.id])
 
   // ── Combatant handlers ──────────────────────────────────────────────────────
 
@@ -657,10 +993,39 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
     if (ok) setArenaItems(prev => prev.filter(a => a.id !== arena.id))
   }
 
+  // ── Playlist handlers ──────────────────────────────────────────────────────
+
+  function handlePlaylistSaved(playlist) {
+    if (view === 'create') {
+      setPlaylistItems(prev => [playlist, ...prev])
+    } else if (view === 'edit') {
+      setPlaylistItems(prev => prev.map(p => p.id === playlist.id ? playlist : p))
+    }
+    setView('library')
+    setPlaylistEditTarget(null)
+  }
+
+  async function handlePlaylistPublish(playlist) {
+    const ok = await setWorkshopPlaylistStatus(playlist.id, 'published')
+    if (ok) setPlaylistItems(prev => prev.map(p => p.id === playlist.id ? { ...p, status: 'published' } : p))
+  }
+
+  async function handlePlaylistUnpublish(playlist) {
+    const ok = await setWorkshopPlaylistStatus(playlist.id, 'stashed')
+    if (ok) setPlaylistItems(prev => prev.map(p => p.id === playlist.id ? { ...p, status: 'stashed' } : p))
+  }
+
+  async function handlePlaylistDelete(playlist) {
+    if (playlist.status !== 'stashed') return
+    const ok = await deleteWorkshopPlaylist(playlist.id)
+    if (ok) setPlaylistItems(prev => prev.filter(p => p.id !== playlist.id))
+  }
+
   function cancelForm() {
     setView('library')
     setEditTarget(null)
     setArenaEditTarget(null)
+    setPlaylistEditTarget(null)
   }
 
   // ── Derived values ──────────────────────────────────────────────────────────
@@ -672,9 +1037,13 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
   const stashedCount   = items.filter(c => c.status === 'stashed').length
   const publishedCount = items.filter(c => c.status === 'published').length
 
-  const arenaVisible       = arenaFilter === 'all' ? arenaItems : arenaItems.filter(a => a.status === arenaFilter)
-  const arenaStashedCount  = arenaItems.filter(a => a.status === 'stashed').length
+  const arenaVisible        = arenaFilter === 'all' ? arenaItems : arenaItems.filter(a => a.status === arenaFilter)
+  const arenaStashedCount   = arenaItems.filter(a => a.status === 'stashed').length
   const arenaPublishedCount = arenaItems.filter(a => a.status === 'published').length
+
+  const playlistVisible        = playlistFilter === 'all' ? playlistItems : playlistItems.filter(p => p.status === playlistFilter)
+  const playlistStashedCount   = playlistItems.filter(p => p.status === 'stashed').length
+  const playlistPublishedCount = playlistItems.filter(p => p.status === 'published').length
 
   // ── Form view (shared across sections) ─────────────────────────────────────
 
@@ -697,6 +1066,14 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
             currentUser={currentUser}
           />
         )}
+        {section === 'playlists' && (
+          <PlaylistForm
+            existing={view === 'edit' ? playlistEditTarget : null}
+            onSave={handlePlaylistSaved}
+            onCancel={cancelForm}
+            currentUser={currentUser}
+          />
+        )}
       </Screen>
     )
   }
@@ -707,10 +1084,11 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
         Your bench. Everything stashed here is private until you publish it.
       </p>
 
-      {/* ── Section tabs: Combatants / Arenas / Groups ── */}
+      {/* ── Section tabs: Combatants / Arenas / Playlists / Groups ── */}
       <div style={{ display: 'flex', gap: 6, marginBottom: '1.25rem', flexWrap: 'wrap' }}>
         <button onClick={() => setSection('combatants')} style={tab(section === 'combatants')}>Combatants</button>
         <button onClick={() => setSection('arenas')}     style={tab(section === 'arenas')}>Arenas</button>
+        <button onClick={() => setSection('playlists')}  style={tab(section === 'playlists')}>Playlists</button>
         <button onClick={() => setSection('groups')}     style={tab(section === 'groups')}>Groups</button>
       </div>
 
@@ -806,6 +1184,51 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
               onPublish={handleArenaPublish}
               onUnpublish={handleArenaUnpublish}
               onDelete={handleArenaDelete}
+            />
+          ))}
+        </>
+      )}
+
+      {/* ── Playlists section ── */}
+      {section === 'playlists' && (
+        <>
+          <button
+            onClick={() => setView('create')}
+            style={{ ...btn('primary'), marginBottom: '1.25rem' }}
+          >
+            + New playlist
+          </button>
+
+          {playlistItems.length > 0 && (
+            <div style={{ display: 'flex', gap: 6, marginBottom: '1rem', flexWrap: 'wrap' }}>
+              <button onClick={() => setPlaylistFilter('all')}       style={tab(playlistFilter === 'all')}>All ({playlistItems.length})</button>
+              <button onClick={() => setPlaylistFilter('stashed')}   style={tab(playlistFilter === 'stashed')}>Stashed ({playlistStashedCount})</button>
+              <button onClick={() => setPlaylistFilter('published')} style={tab(playlistFilter === 'published')}>Published ({playlistPublishedCount})</button>
+            </div>
+          )}
+
+          {playlistLoading && <p style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>Loading…</p>}
+
+          {!playlistLoading && playlistItems.length === 0 && (
+            <div style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+              Nothing here yet. Create your first playlist above.
+            </div>
+          )}
+
+          {!playlistLoading && playlistItems.length > 0 && playlistVisible.length === 0 && (
+            <p style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+              Nothing in this filter yet.
+            </p>
+          )}
+
+          {playlistVisible.map(playlist => (
+            <PlaylistCard
+              key={playlist.id}
+              playlist={playlist}
+              onEdit={p => { setPlaylistEditTarget(p); setView('edit') }}
+              onPublish={handlePlaylistPublish}
+              onUnpublish={handlePlaylistUnpublish}
+              onDelete={handlePlaylistDelete}
             />
           ))}
         </>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1020,6 +1020,155 @@ export async function getArenaPickerOptions(ownerId) {
   } catch (e) { console.error('getArenaPickerOptions exception', e); return [] }
 }
 
+// ─── Playlist Workshop operations ─────────────────────────────────────────────
+
+// Returns the new playlist id, or null on failure.
+export async function createWorkshopPlaylist({ name, tags = [], ownerId, ownerName, status = 'stashed' }) {
+  try {
+    const { data, error } = await supabase.from('arena_playlists').insert({
+      name, tags, owner_id: ownerId, owner_name: ownerName,
+      status, updated_at: new Date().toISOString(),
+    }).select('id').single()
+    if (error) console.error('createWorkshopPlaylist error', error)
+    return data?.id || null
+  } catch (e) { console.error('createWorkshopPlaylist exception', e); return null }
+}
+
+// Returns playlists owned by ownerId, each with a slot_count field.
+export async function getWorkshopPlaylists(ownerId) {
+  try {
+    const { data, error } = await supabase
+      .from('arena_playlists')
+      .select('id, name, tags, status, owner_id, owner_name, created_at, updated_at')
+      .eq('owner_id', ownerId)
+      .order('updated_at', { ascending: false })
+    if (error) { console.error('getWorkshopPlaylists error', error); return [] }
+    const rows = data || []
+    if (!rows.length) return rows
+    const ids = rows.map(p => p.id)
+    const { data: slots } = await supabase.from('arena_playlist_slots').select('playlist_id').in('playlist_id', ids)
+    const countMap = {}
+    for (const s of (slots || [])) countMap[s.playlist_id] = (countMap[s.playlist_id] || 0) + 1
+    return rows.map(p => ({ ...p, slot_count: countMap[p.id] || 0 }))
+  } catch (e) { console.error('getWorkshopPlaylists exception', e); return [] }
+}
+
+export async function updateWorkshopPlaylist(id, { name, tags }) {
+  try {
+    const { error } = await supabase.from('arena_playlists')
+      .update({ name, tags, updated_at: new Date().toISOString() }).eq('id', id)
+    if (error) console.error('updateWorkshopPlaylist error', error)
+    return !error
+  } catch (e) { console.error('updateWorkshopPlaylist exception', e); return false }
+}
+
+export async function setWorkshopPlaylistStatus(id, status) {
+  try {
+    const { error } = await supabase.from('arena_playlists')
+      .update({ status, updated_at: new Date().toISOString() }).eq('id', id)
+    if (error) console.error('setWorkshopPlaylistStatus error', error)
+    return !error
+  } catch (e) { console.error('setWorkshopPlaylistStatus exception', e); return false }
+}
+
+// Only valid for stashed playlists — callers must verify status === 'stashed'.
+// Deletes slots first (no cascade in schema).
+export async function deleteWorkshopPlaylist(id) {
+  try {
+    await supabase.from('arena_playlist_slots').delete().eq('playlist_id', id)
+    const { error } = await supabase.from('arena_playlists').delete().eq('id', id)
+    if (error) console.error('deleteWorkshopPlaylist error', error)
+    return !error
+  } catch (e) { console.error('deleteWorkshopPlaylist exception', e); return false }
+}
+
+// Returns a playlist row with its slots joined to arena metadata for the edit form.
+// slots: [{ id, position, arena_id, arenaName, arenaBio, arenaStatus }] ordered by position.
+export async function getPlaylistWithSlots(playlistId) {
+  try {
+    const [playlistRes, slotsRes] = await Promise.all([
+      supabase.from('arena_playlists').select('*').eq('id', playlistId).single(),
+      supabase.from('arena_playlist_slots').select('id, position, arena_id').eq('playlist_id', playlistId).order('position'),
+    ])
+    if (playlistRes.error) { console.error('getPlaylistWithSlots error', playlistRes.error); return null }
+    const slots = slotsRes.data || []
+    if (!slots.length) return { ...playlistRes.data, slots: [] }
+    const { data: arenas } = await supabase.from('arenas').select('id, name, bio, status').in('id', slots.map(s => s.arena_id))
+    const arenaMap = Object.fromEntries((arenas || []).map(a => [a.id, a]))
+    return {
+      ...playlistRes.data,
+      slots: slots.map(s => ({
+        id:          s.id,
+        position:    s.position,
+        arena_id:    s.arena_id,
+        arenaName:   arenaMap[s.arena_id]?.name   || 'Unknown arena',
+        arenaBio:    arenaMap[s.arena_id]?.bio     || '',
+        arenaStatus: arenaMap[s.arena_id]?.status  || 'published',
+      })),
+    }
+  } catch (e) { console.error('getPlaylistWithSlots exception', e); return null }
+}
+
+// Replaces all slots for a playlist with the given ordered arenaIds (1-based positions).
+export async function setPlaylistSlots(playlistId, arenaIds) {
+  try {
+    await supabase.from('arena_playlist_slots').delete().eq('playlist_id', playlistId)
+    if (!arenaIds.length) return true
+    const rows = arenaIds.map((arenaId, i) => ({ playlist_id: playlistId, arena_id: arenaId, position: i + 1 }))
+    const { error } = await supabase.from('arena_playlist_slots').insert(rows)
+    if (error) console.error('setPlaylistSlots error', error)
+    return !error
+  } catch (e) { console.error('setPlaylistSlots exception', e); return false }
+}
+
+// Returns published + owner's stashed playlists for the lobby picker.
+export async function getPlaylistPickerOptions(ownerId) {
+  try {
+    const { data, error } = await supabase
+      .from('arena_playlists')
+      .select('id, name, tags, status, owner_id')
+      .or(`status.eq.published,owner_id.eq.${ownerId}`)
+      .order('name', { ascending: true })
+    if (error) { console.error('getPlaylistPickerOptions error', error); return [] }
+    const seen = new Set()
+    return (data || []).filter(p => { if (seen.has(p.id)) return false; seen.add(p.id); return true })
+  } catch (e) { console.error('getPlaylistPickerOptions exception', e); return [] }
+}
+
+// Returns ordered arena snapshots for playlist delivery at round-open time.
+// Shape matches round.arena: { id, name, description, houseRules, tags }.
+export async function getPlaylistForDelivery(playlistId) {
+  try {
+    const { data: slots, error } = await supabase
+      .from('arena_playlist_slots')
+      .select('position, arena_id')
+      .eq('playlist_id', playlistId)
+      .order('position')
+    if (error || !slots?.length) return []
+    const { data: arenas } = await supabase
+      .from('arenas')
+      .select('id, name, bio, rules, tags')
+      .in('id', slots.map(s => s.arena_id))
+    const arenaMap = Object.fromEntries((arenas || []).map(a => [a.id, a]))
+    return slots.map(s => {
+      const a = arenaMap[s.arena_id]
+      if (!a) return null
+      return { id: a.id, name: a.name, description: a.bio || '', houseRules: a.rules || null, tags: a.tags || [] }
+    }).filter(Boolean)
+  } catch (e) { console.error('getPlaylistForDelivery exception', e); return [] }
+}
+
+// Called on game completion for the playlist used in the finished game.
+// Idempotent — safe to call on an already-published playlist.
+export async function publishPlaylist(id) {
+  if (!id) return
+  try {
+    const { error } = await supabase.from('arena_playlists')
+      .update({ status: 'published', updated_at: new Date().toISOString() }).eq('id', id)
+    if (error) console.error('publishPlaylist error', error)
+  } catch (e) { console.error('publishPlaylist exception', e) }
+}
+
 // ─── Archive listing functions ────────────────────────────────────────────────
 
 // Published groups with aggregated member count, combined W/L, and most-decorated


### PR DESCRIPTION
Closes #72

## What changed

**supabase.js** — 10 new playlist functions covering the full lifecycle:
- `createWorkshopPlaylist`, `getWorkshopPlaylists`, `updateWorkshopPlaylist`, `setWorkshopPlaylistStatus`, `deleteWorkshopPlaylist`
- `getPlaylistWithSlots` — fetches playlist + slots joined to arena metadata (used by edit form)
- `setPlaylistSlots` — delete-and-reinsert to replace all slots for a playlist
- `getPlaylistPickerOptions` — published + owner's stashed playlists for the lobby picker
- `getPlaylistForDelivery` — ordered arena snapshots for round-open delivery
- `publishPlaylist` — idempotent publish on game completion

**WorkshopScreen.jsx** — Playlists tab with full create/edit/stash/publish/delete:
- `PlaylistForm`: name, ordered slot manager (search/select, up/down reorder, remove), tags, stash/publish toggle; published playlists require one-step confirm on any edit
- `PlaylistCard`: slot count, status badge, all lifecycle actions
- Slots loaded lazily via `getPlaylistWithSlots` when editing (mirrors combatant group-id pattern)

**CreateRoom.jsx** — Playlist delivery mode enabled:
- Removed `disabled: true` from the Playlist ARENA_MODES entry
- Playlist search/select UI matching single-arena picker pattern
- `arenaConfig` stores `{ playlistId, playlistName }` — name snapshotted so lobby display does not need a fetch

**BattleScreen.jsx** — Playlist delivery at round-open:
- `(roundNum - 1) % playlistArenas.length` cycling via `getPlaylistForDelivery`
- `arenaEvolutionOverride` already takes precedence (existing logic unchanged)

**LobbyScreen.jsx** — Shows `playlistName` instead of raw ID in arena mode display

**VoteScreen.jsx** — `publishPlaylist` added to all four game-completion fire-and-forget blocks; also fixed a vestigial `r.settings?.arena?.id` pattern in the evolution path to use the correct round-scan approach

## Test notes
- Create a playlist in My Workshop → Playlists tab; verify it appears under Stashed
- Publish it; verify confirm prompt fires
- Create a room with Arena → Playlist mode; select the playlist; start rounds and verify arenas cycle in slot order
- Create a room with a shorter playlist than round count; verify cycling back to slot 1
- Complete a game with a stashed playlist; verify it auto-publishes on room close
- Stashed playlist not visible to other hosts in lobby picker