### PR TITLE
Arenas: core feature

### DIFF
--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -134,6 +134,19 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
                     : <span style={{ fontSize: 13, color: 'var(--color-text-tertiary)' }}>No result recorded</span>}
               </div>
 
+              {rd.arena && (
+                <div style={{ marginBottom: 12, padding: '8px 12px', background: 'var(--color-background-tertiary)', borderRadius: 'var(--border-radius-md)', border: '0.5px solid var(--color-border-tertiary)' }}>
+                  <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Arena</div>
+                  <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary)' }}>{rd.arena.name}</div>
+                  {rd.arena.description && (
+                    <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0', lineHeight: 1.5 }}>{rd.arena.description}</p>
+                  )}
+                  {rd.arena.houseRules && (
+                    <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0', fontStyle: 'italic' }}>Rules: {rd.arena.houseRules}</p>
+                  )}
+                </div>
+              )}
+
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
                 {(rd.combatants || []).map(c => {
                   const isWinner = rd.winner?.id === c.id

--- a/src/screens/GameSummaryScreen.jsx
+++ b/src/screens/GameSummaryScreen.jsx
@@ -144,6 +144,20 @@ function RoundCard({ round, playerById }) {
         })}
       </div>
 
+      {/* Arena context */}
+      {round.arena && (
+        <div style={{ padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+          <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>Arena</div>
+          <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary)' }}>{round.arena.name}</div>
+          {round.arena.description && (
+            <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0', lineHeight: 1.5 }}>{round.arena.description}</p>
+          )}
+          {round.arena.houseRules && (
+            <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '4px 0 0', fontStyle: 'italic' }}>Rules: {round.arena.houseRules}</p>
+          )}
+        </div>
+      )}
+
       {/* Vote breakdown — only show if there are any picks */}
       {Object.values(picks).length > 0 && (
         <div style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>


### PR DESCRIPTION
Closes #14

## What changed

All arena acceptance criteria were already implemented across the sub-PRs (#68–#74, #77). The one gap was that `round.arena` — snapshotted at round-start time by all three delivery modes — was never rendered in the two post-game read-back screens:

- **GameSummaryScreen** (`RoundCard`): arena name, description, and house rules now appear between the Matchup card and the Votes card
- **ChroniclesScreen** (`ChroniclesRoomDetail`): same arena card appears above the combatant list for each round

Both screens already had per-round access to the snapshot; they just weren't displaying it.

## Test notes

- Play a game with an arena (any delivery mode: single, random-pool, or playlist)
- After the game, open Chronicles — each round should show the arena that was active
- Open an arena's detail page → Appearances → tap a game → verify the arena card appears in the round view
- Rounds with no arena (`round.arena === null`) show no arena section — no regression for pre-arena games