### PR TITLE
Groups: core feature

### DIFF
--- a/src/components/CombatantSheet.jsx
+++ b/src/components/CombatantSheet.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { btn, inp, lbl } from '../styles.js'
-import { getCombatant, updateGlobalCombatant, getLineageTree, getCombatantRoundHistory } from '../supabase.js'
+import { getCombatant, updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, getGroupsForCombatants } from '../supabase.js'
 import { buildStoryFromLineageTree } from '../gameLogic.js'
 
 /**
@@ -203,12 +203,17 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
   const [ownChainTree,  setOwnChainTree]  = useState([])
   const [h2hOpen,  setH2hOpen]  = useState(false)
   const [h2hRows,  setH2hRows]  = useState(null)
+  const [groups,   setGroups]   = useState([])
 
   // Reset all state when combatant changes (sheet back-stack navigation)
   useEffect(() => {
     setC(init); setEditMode(false); setEditName(init.name); setEditBio(init.bio || '')
     setLineageStory([]); setLineageTree([]); setOwnChainStory([]); setOwnChainTree([])
-    setH2hOpen(false); setH2hRows(null)
+    setH2hOpen(false); setH2hRows(null); setGroups([])
+  }, [init.id])
+
+  useEffect(() => {
+    getGroupsForCombatants([init.id]).then(map => setGroups(map[init.id] || []))
   }, [init.id])
 
   const canEdit    = c.owner_id === playerId
@@ -285,6 +290,17 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
             <div key={icon} style={{ padding: '4px 10px', background: 'var(--color-background-secondary)', borderRadius: 99, border: '0.5px solid var(--color-border-tertiary)', fontSize: 13, color: 'var(--color-text-secondary)' }}>
               {icon} {count}
             </div>
+          ))}
+        </div>
+      )}
+
+      {/* Groups */}
+      {groups.length > 0 && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: '1rem' }}>
+          {groups.map(g => (
+            <span key={g.id} style={{ fontSize: 12, padding: '3px 9px', background: 'var(--color-background-tertiary)', color: 'var(--color-text-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 99 }}>
+              {g.name}
+            </span>
           ))}
         </div>
       )}

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -6,7 +6,7 @@ import RoundChat from '../components/RoundChat.jsx'
 import EvolutionForm from '../components/EvolutionForm.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, publishPlaylist, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence, getArenaReaction, upsertArenaReaction, deleteArenaReaction } from '../supabase.js'
+import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, publishPlaylist, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getGroupsForCombatants, getCombatantGroupIds, setCombatantGroups } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish, resolveAllAdvanceSelection } from '../gameLogic.js'
@@ -131,6 +131,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
   const [voteNudgeDone,    setVoteNudgeDone]    = useState(false)  // one-time guest nudge after first pick
   const [arenaReaction,    setArenaReaction]    = useState(null)   // 'like' | 'dislike' | null
   const [arenaReacting,    setArenaReacting]    = useState(false)
+  const [combatantGroups,  setCombatantGroupsState] = useState({})  // { [combatantId]: [{ id, name }] }
 
   // Draw / merge flow state machine.
   // null                                                           — no flow in progress
@@ -172,6 +173,12 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
     if (!arenaId || !playerId) { setArenaReaction(null); return }
     getArenaReaction(arenaId, playerId).then(setArenaReaction)
   }, [arenaId, playerId])
+
+  useEffect(() => {
+    if (!round?.combatants?.length) return
+    const ids = round.combatants.map(c => c.id)
+    getGroupsForCombatants(ids).then(setCombatantGroupsState)
+  }, [round?.id])
 
   async function handleArenaReaction(value) {
     if (!arenaId || !playerId || arenaReacting) return
@@ -403,6 +410,11 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       ownerId: primaryParent.ownerId, ownerName: primaryParent.ownerName, lineage,
     })
 
+    // Inherit the union of all parents' group memberships.
+    const allGroupIds = (await Promise.all(parents.map(c => getCombatantGroupIds(c.id)))).flat()
+    const uniqueGroupIds = [...new Set(allGroupIds)]
+    if (uniqueGroupIds.length) await setCombatantGroups(newId, uniqueGroupIds, primaryParent.ownerId)
+
     const merge = {
       fromIds,
       fromNames:        parents.map(c => c.name),
@@ -523,6 +535,10 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       id: newId, name: newName, bio: variantBio,
       ownerId, ownerName: winner.ownerName, lineage,
     })
+
+    // Inherit parent's group memberships — variant continues the same group affiliations.
+    const parentGroupIds = await getCombatantGroupIds(winner.id)
+    if (parentGroupIds.length) await setCombatantGroups(newId, parentGroupIds, ownerId)
 
     // Apply win/loss to the original. The draft roster is immutable — the variant
     // does not replace the original in any future round of this game. It enters
@@ -655,6 +671,18 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
     return null
   })()
 
+  // Groups shared by two or more combatants in this round — signals a civil war.
+  const civilWarGroups = (() => {
+    const tally = {}
+    for (const c of round.combatants) {
+      for (const g of combatantGroups[c.id] || []) {
+        if (!tally[g.id]) tally[g.id] = { name: g.name, combatantNames: [] }
+        tally[g.id].combatantNames.push(c.name)
+      }
+    }
+    return Object.values(tally).filter(x => x.combatantNames.length >= 2)
+  })()
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (<>
@@ -736,6 +764,15 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
         </div>
       )}
 
+      {civilWarGroups.length > 0 && (
+        <div style={{ marginBottom: '1rem', padding: '10px 14px', background: 'var(--color-background-warning)', border: '0.5px solid var(--color-border-warning)', borderRadius: 'var(--border-radius-md)', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 16 }}>⚔️</span>
+          <span style={{ fontSize: 13, color: 'var(--color-text-warning)', fontWeight: 500 }}>
+            Civil war — {civilWarGroups.map(g => g.name).join(', ')}
+          </span>
+        </div>
+      )}
+
       {/* ── Combatant cards ─────────────────────────────────────────────── */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: '1.5rem' }}>
         {round.combatants.map(c => {
@@ -788,6 +825,15 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
                       )
                       return null
                     })}
+                  </div>
+                )}
+                {(combatantGroups[c.id] || []).length > 0 && (
+                  <div style={{ display: 'flex', gap: 5, marginTop: 8, flexWrap: 'wrap' }}>
+                    {(combatantGroups[c.id] || []).map(g => (
+                      <span key={g.id} style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-tertiary)', color: 'var(--color-text-tertiary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 99 }}>
+                        {g.name}
+                      </span>
+                    ))}
                   </div>
                 )}
               </div>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -795,6 +795,36 @@ export async function setCombatantGroups(combatantId, groupIds, addedBy) {
   } catch (e) { console.error('setCombatantGroups exception', e); return false }
 }
 
+// Fetch published group memberships for multiple combatants at once.
+// Returns { [combatantId]: [{ id, name }] } — only published groups are included.
+// Stashed groups owned by others are invisible; only published groups appear here.
+export async function getGroupsForCombatants(combatantIds) {
+  if (!combatantIds?.length) return {}
+  try {
+    const { data: memberships, error: mErr } = await supabase
+      .from('combatant_groups')
+      .select('combatant_id, group_id')
+      .in('combatant_id', combatantIds)
+    if (mErr) { console.error('getGroupsForCombatants memberships error', mErr); return {} }
+    const groupIds = [...new Set((memberships || []).map(m => m.group_id))]
+    if (!groupIds.length) return {}
+    const { data: groups, error: gErr } = await supabase
+      .from('groups')
+      .select('id, name')
+      .in('id', groupIds)
+      .eq('status', 'published')
+    if (gErr) { console.error('getGroupsForCombatants groups error', gErr); return {} }
+    const groupMap = Object.fromEntries((groups || []).map(g => [g.id, g]))
+    const result = {}
+    for (const m of memberships || []) {
+      if (!groupMap[m.group_id]) continue
+      if (!result[m.combatant_id]) result[m.combatant_id] = []
+      result[m.combatant_id].push(groupMap[m.group_id])
+    }
+    return result
+  } catch (e) { console.error('getGroupsForCombatants exception', e); return {} }
+}
+
 // Create a new combatant from The Workshop.
 // Status defaults to 'stashed' unless the caller explicitly passes 'published'.
 export async function createWorkshopCombatant({ id, name, bio, tags = [], ownerId, ownerName, status = 'stashed' }) {


### PR DESCRIPTION
Closes #16

## What changed

Most of the groups infrastructure (schema, supabase helpers, ArchiveScreen groups tab, Workshop group picker) was already in place. This PR fills the three remaining gaps:

**`getGroupsForCombatants()` (supabase.js)**
New batch helper that fetches published group memberships for a set of combatant IDs in two queries. Only published groups are returned — stashed groups owned by others stay invisible.

**Group badges on combatant cards + civil war flag (VoteScreen)**
- Fetches groups for the current round's combatants on each round load
- Renders group name pills on each combatant card (same badge row as ephemeral badges)
- Derives `civilWarGroups`: any group shared by 2+ combatants in the round
- Renders a "Civil war — [Group Name]" banner above the combatant cards when triggered

**Group display on combatant detail page (CombatantSheet)**
- GlobalView fetches published groups for the combatant on load / navigation
- Renders group badges between the reactions row and the bio section

**Evolution and merge inheritance**
- After `createVariantCombatant` in `handleEvolution`: copies parent's `combatant_groups` rows to the variant via `setCombatantGroups`
- After `createVariantCombatant` in `handleMerge`: copies the union of all parents' group IDs to the merge variant

## Test notes
- Create a group in Workshop, publish it, assign it to two combatants in the same draft — verify civil war banner appears on their round
- Open a combatant's detail sheet — group badges should appear if they belong to any published groups
- Confirm an evolution — open the variant's detail sheet and verify it inherited the parent's groups