### PR TITLE
The Workshop: Create-a-Group

### DIFF
--- a/src/screens/WorkshopScreen.jsx
+++ b/src/screens/WorkshopScreen.jsx
@@ -26,6 +26,14 @@ import {
   getPlaylistWithSlots,
   setPlaylistSlots,
   getArenaPickerOptions,
+  createWorkshopGroup,
+  getWorkshopGroups,
+  updateWorkshopGroup,
+  setWorkshopGroupStatus,
+  deleteWorkshopGroup,
+  setGroupCombatants,
+  getGroupCombatantIds,
+  getCombatantPickerOptions,
 } from '../supabase.js'
 
 // ─── Guest gate ───────────────────────────────────────────────────────────────
@@ -884,6 +892,335 @@ function PlaylistCard({ playlist, onEdit, onPublish, onUnpublish, onDelete }) {
   )
 }
 
+// ─── Group member list ────────────────────────────────────────────────────────
+
+function MemberList({ members, onRemove }) {
+  if (!members.length) {
+    return (
+      <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>
+        No members yet. Search below to add combatants.
+      </p>
+    )
+  }
+  return (
+    <div style={{ marginBottom: 8 }}>
+      {members.map(m => (
+        <div key={m.combatant_id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 10px', marginBottom: 4, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+          <div style={{ flex: 1 }}>
+            <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>{m.combatantName}</span>
+            {m.combatantStatus === 'stashed' && (
+              <span style={{ fontSize: 10, marginLeft: 6, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>stashed</span>
+            )}
+          </div>
+          <button onClick={() => onRemove(m.combatant_id)} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12, color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }}>×</button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── Group form ───────────────────────────────────────────────────────────────
+
+function GroupForm({ existing, onSave, onCancel, currentUser }) {
+  const isEdit      = !!existing
+  const isPublished = existing?.status === 'published'
+
+  const [name,          setName]          = useState(existing?.name        || '')
+  const [description,   setDescription]   = useState(existing?.description || '')
+  const [tags,          setTags]          = useState(existing?.tags        || [])
+  const [members,       setMembers]       = useState([])   // [{ combatant_id, combatantName, combatantStatus }]
+  const [membersLoaded, setMembersLoaded] = useState(!isEdit)
+  const [status,        setStatus]        = useState(existing?.status || 'stashed')
+  const [saving,        setSaving]        = useState(false)
+  const [confirm,       setConfirm]       = useState(false)
+  const [error,         setError]         = useState('')
+
+  const [combatants,       setCombatants]       = useState([])
+  const [combatantsLoaded, setCombatantsLoaded] = useState(false)
+  const [combatantSearch,  setCombatantSearch]  = useState('')
+  const [showPicker,       setShowPicker]       = useState(false)
+  const [initMemberIds,    setInitMemberIds]    = useState(null)  // null = still loading
+
+  // Load picker options on mount
+  useEffect(() => {
+    getCombatantPickerOptions(currentUser.id).then(data => { setCombatants(data); setCombatantsLoaded(true) })
+  }, [currentUser.id])
+
+  // Load existing member IDs when editing
+  useEffect(() => {
+    if (!existing?.id) return
+    getGroupCombatantIds(existing.id).then(setInitMemberIds)
+  }, [existing?.id])
+
+  // Build member display list once both data sets are ready
+  useEffect(() => {
+    if (!isEdit || !combatantsLoaded || initMemberIds === null || membersLoaded) return
+    const combatantMap = Object.fromEntries(combatants.map(c => [c.id, c]))
+    setMembers(initMemberIds.map(id => ({
+      combatant_id:     id,
+      combatantName:    combatantMap[id]?.name   || 'Unknown',
+      combatantStatus:  combatantMap[id]?.status || 'published',
+    })))
+    setMembersLoaded(true)
+  }, [isEdit, combatantsLoaded, initMemberIds, membersLoaded, combatants])
+
+  const currentMemberIds = members.map(m => m.combatant_id)
+  const nameChanged      = isEdit && name.trim()        !== existing.name.trim()
+  const descChanged      = isEdit && description.trim() !== (existing.description || '').trim()
+  const tagsChanged      = isEdit && JSON.stringify(tags) !== JSON.stringify(existing.tags || [])
+  const membersChanged   = isEdit && membersLoaded && initMemberIds !== null &&
+    JSON.stringify([...currentMemberIds].sort()) !== JSON.stringify([...initMemberIds].sort())
+  const hasChanges       = !isEdit || nameChanged || descChanged || tagsChanged || membersChanged
+
+  const filteredCombatants = (combatantSearch.trim()
+    ? combatants.filter(c => c.name.toLowerCase().includes(combatantSearch.toLowerCase()))
+    : combatants
+  ).filter(c => !members.find(m => m.combatant_id === c.id))
+
+  function addMember(combatant) {
+    setMembers(prev => [...prev, { combatant_id: combatant.id, combatantName: combatant.name, combatantStatus: combatant.status }])
+    setCombatantSearch('')
+    setShowPicker(false)
+  }
+
+  function removeMember(combatantId) {
+    setMembers(prev => prev.filter(m => m.combatant_id !== combatantId))
+  }
+
+  function validate() {
+    if (!name.trim())        { setError('Name is required.');        return false }
+    if (!description.trim()) { setError('Description is required.'); return false }
+    return true
+  }
+
+  async function handleSave() {
+    if (!validate()) return
+    if (isEdit && isPublished && descChanged && !confirm) {
+      setConfirm(true); return
+    }
+    setSaving(true); setError('')
+    const memberIds = members.map(m => m.combatant_id)
+    if (isEdit) {
+      const [ok] = await Promise.all([
+        updateWorkshopGroup(existing.id, { name: name.trim(), description: description.trim(), tags }),
+        setGroupCombatants(existing.id, memberIds, currentUser.id),
+      ])
+      if (!ok) { setError('Save failed. Try again.'); setSaving(false); return }
+      onSave({ ...existing, name: name.trim(), description: description.trim(), tags, member_count: memberIds.length })
+    } else {
+      const id = uid()
+      const ok = await createWorkshopGroup({
+        id, name: name.trim(), description: description.trim(), tags,
+        ownerId: currentUser.id, ownerName: currentUser.username,
+        status,
+      })
+      if (!ok) { setError('Save failed. Try again.'); setSaving(false); return }
+      if (memberIds.length) await setGroupCombatants(id, memberIds, currentUser.id)
+      onSave({ id, name: name.trim(), description: description.trim(), tags, status, member_count: memberIds.length, owner_id: currentUser.id, owner_name: currentUser.username })
+    }
+    setSaving(false)
+  }
+
+  return (
+    <div>
+      <h3 style={{ fontSize: 17, fontWeight: 500, margin: '0 0 1.25rem', color: 'var(--color-text-primary)' }}>
+        {isEdit ? 'Edit group' : 'New group'}
+      </h3>
+
+      <label style={lbl}>Name *</label>
+      <input
+        style={inp()}
+        placeholder="What is this group called?"
+        value={name}
+        onChange={e => { setName(e.target.value); setError('') }}
+        maxLength={80}
+        autoFocus={!isEdit}
+      />
+
+      <label style={lbl}>Description *</label>
+      <textarea
+        style={{ ...inp(), minHeight: 80, resize: 'vertical', fontFamily: 'var(--font-sans)' }}
+        placeholder="What's the joke? What's the theme? What do these fighters have in common?"
+        value={description}
+        onChange={e => { setDescription(e.target.value); setError(''); setConfirm(false) }}
+        maxLength={500}
+      />
+
+      <label style={lbl}>Members</label>
+      {isEdit && !membersLoaded ? (
+        <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 12px' }}>Loading members…</p>
+      ) : (
+        <MemberList members={members} onRemove={removeMember} />
+      )}
+
+      {showPicker ? (
+        <div style={{ marginBottom: 12 }}>
+          <input
+            style={{ ...inp(), margin: '0 0 6px', fontSize: 14 }}
+            value={combatantSearch}
+            onChange={e => setCombatantSearch(e.target.value)}
+            placeholder="Search combatants…"
+            autoFocus
+          />
+          {!combatantsLoaded ? (
+            <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+          ) : filteredCombatants.length === 0 ? (
+            <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>
+              {combatants.length === 0 ? 'No combatants yet.' : 'No combatants match.'}
+            </p>
+          ) : (
+            <div style={{ border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden', maxHeight: 200, overflowY: 'auto' }}>
+              {filteredCombatants.map((c, i) => (
+                <button
+                  key={c.id}
+                  onClick={() => addMember(c)}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: i % 2 === 0 ? 'var(--color-background-secondary)' : 'var(--color-background-primary)', border: 'none', borderTop: i === 0 ? 'none' : '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary)' }}>{c.name}</span>
+                    {c.status === 'stashed' && (
+                      <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>stashed</span>
+                    )}
+                  </div>
+                  {c.bio && (
+                    <p style={{ fontSize: 11, color: 'var(--color-text-secondary)', margin: '1px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.bio}</p>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+          <button onClick={() => { setShowPicker(false); setCombatantSearch('') }} style={{ ...btn('ghost'), marginTop: 6, padding: '4px 12px', fontSize: 12 }}>
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button onClick={() => setShowPicker(true)} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13, marginBottom: 12 }}>
+          + Add member
+        </button>
+      )}
+
+      <label style={lbl}>Tags</label>
+      <div style={{ marginBottom: 12 }}>
+        <TagInput value={tags} onChange={setTags} />
+      </div>
+
+      {!isEdit && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ ...lbl, marginBottom: 8 }}>Visibility</label>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              onClick={() => setStatus('stashed')}
+              style={{ ...tab(status === 'stashed'), fontSize: 13, padding: '6px 14px' }}
+            >
+              Stash (private)
+            </button>
+            <button
+              onClick={() => setStatus('published')}
+              style={{ ...tab(status === 'published'), fontSize: 13, padding: '6px 14px' }}
+            >
+              Publish now
+            </button>
+          </div>
+          {status === 'stashed' && (
+            <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '6px 0 0' }}>
+              Only you can see this until you publish it.
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && <p style={{ color: 'var(--color-text-danger)', fontSize: 13, margin: '0 0 12px' }}>{error}</p>}
+
+      {confirm && (
+        <div style={{ background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', borderRadius: 'var(--border-radius-md)', padding: '12px 14px', marginBottom: 12 }}>
+          <p style={{ margin: '0 0 8px', fontSize: 13, color: 'var(--color-text-primary)' }}>
+            This group is published — your description edit will be public. Continue?
+          </p>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={handleSave} disabled={saving} style={{ ...btn('primary'), padding: '7px 14px', fontSize: 13, width: 'auto' }}>
+              {saving ? 'Saving…' : 'Yes, save'}
+            </button>
+            <button onClick={() => setConfirm(false)} style={{ ...btn(), padding: '7px 14px', fontSize: 13, width: 'auto' }}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!confirm && (
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={handleSave} disabled={saving || !hasChanges || (isEdit && !membersLoaded)} style={{ ...btn('primary'), width: 'auto', padding: '9px 18px', fontSize: 14 }}>
+            {saving ? 'Saving…' : isEdit ? 'Save' : status === 'published' ? 'Create & publish' : 'Add to stash'}
+          </button>
+          <button onClick={onCancel} style={{ ...btn(), width: 'auto', padding: '9px 18px', fontSize: 14 }}>
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Group Workshop card ──────────────────────────────────────────────────────
+
+function GroupCard({ group, onEdit, onPublish, onUnpublish, onDelete }) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const isStashed   = group.status === 'stashed'
+  const isPublished = group.status === 'published'
+
+  return (
+    <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '12px 14px', marginBottom: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{group.name}</span>
+        {isStashed && (
+          <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-tertiary)' }}>
+            🔒 stashed
+          </span>
+        )}
+        {isPublished && (
+          <span style={{ fontSize: 10, padding: '1px 7px', borderRadius: 99, background: 'var(--color-background-success)', border: '0.5px solid var(--color-border-success)', color: 'var(--color-text-success)' }}>
+            published
+          </span>
+        )}
+      </div>
+      {group.description && (
+        <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '3px 0 0', overflow: 'hidden', textOverflow: 'ellipsis', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+          {group.description}
+        </p>
+      )}
+      <p style={{ fontSize: 11, color: 'var(--color-text-tertiary)', margin: '3px 0 0' }}>
+        {group.member_count} {group.member_count === 1 ? 'member' : 'members'}
+      </p>
+      {group.tags?.length > 0 && (
+        <div style={{ marginTop: 5 }}>
+          <TagChips tags={group.tags} />
+        </div>
+      )}
+
+      {confirmDelete ? (
+        <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>Delete permanently?</span>
+          <button onClick={() => onDelete(group)} style={{ ...btn(), padding: '4px 12px', fontSize: 12, width: 'auto', color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }}>Delete</button>
+          <button onClick={() => setConfirmDelete(false)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Keep</button>
+        </div>
+      ) : (
+        <div style={{ marginTop: 10, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <button onClick={() => onEdit(group)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Edit</button>
+          {isStashed && (
+            <button onClick={() => onPublish(group)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12, color: 'var(--color-text-success)', borderColor: 'var(--color-border-success)' }}>Publish</button>
+          )}
+          {isPublished && (
+            <button onClick={() => onUnpublish(group)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12 }}>Move to stash</button>
+          )}
+          {isStashed && (
+            <button onClick={() => setConfirmDelete(true)} style={{ ...btn('ghost'), padding: '4px 12px', fontSize: 12, color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }}>Delete</button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── Main screen ──────────────────────────────────────────────────────────────
 
 export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
@@ -912,6 +1249,13 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
   const [playlistLoaded,     setPlaylistLoaded]     = useState(false)
   const [playlistEditTarget, setPlaylistEditTarget] = useState(null)
 
+  // Group section state
+  const [groupItems,      setGroupItems]      = useState([])
+  const [groupFilter,     setGroupFilter]     = useState('all')
+  const [groupLoading,    setGroupLoading]    = useState(false)
+  const [groupLoaded,     setGroupLoaded]     = useState(false)
+  const [groupEditTarget, setGroupEditTarget] = useState(null)
+
   useEffect(() => {
     setLoading(true)
     getWorkshopCombatants(currentUser.id).then(data => {
@@ -936,6 +1280,15 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
       setPlaylistItems(data); setPlaylistLoading(false); setPlaylistLoaded(true)
     })
   }, [section, playlistLoaded, currentUser.id])
+
+  // Lazy-load groups on first visit to that section
+  useEffect(() => {
+    if (section !== 'groups' || groupLoaded) return
+    setGroupLoading(true)
+    getWorkshopGroups(currentUser.id).then(data => {
+      setGroupItems(data); setGroupLoading(false); setGroupLoaded(true)
+    })
+  }, [section, groupLoaded, currentUser.id])
 
   // ── Combatant handlers ──────────────────────────────────────────────────────
 
@@ -1021,11 +1374,40 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
     if (ok) setPlaylistItems(prev => prev.filter(p => p.id !== playlist.id))
   }
 
+  // ── Group handlers ──────────────────────────────────────────────────────────
+
+  function handleGroupSaved(group) {
+    if (view === 'create') {
+      setGroupItems(prev => [group, ...prev])
+    } else if (view === 'edit') {
+      setGroupItems(prev => prev.map(g => g.id === group.id ? group : g))
+    }
+    setView('library')
+    setGroupEditTarget(null)
+  }
+
+  async function handleGroupPublish(group) {
+    const ok = await setWorkshopGroupStatus(group.id, 'published')
+    if (ok) setGroupItems(prev => prev.map(g => g.id === group.id ? { ...g, status: 'published' } : g))
+  }
+
+  async function handleGroupUnpublish(group) {
+    const ok = await setWorkshopGroupStatus(group.id, 'stashed')
+    if (ok) setGroupItems(prev => prev.map(g => g.id === group.id ? { ...g, status: 'stashed' } : g))
+  }
+
+  async function handleGroupDelete(group) {
+    if (group.status !== 'stashed') return
+    const ok = await deleteWorkshopGroup(group.id)
+    if (ok) setGroupItems(prev => prev.filter(g => g.id !== group.id))
+  }
+
   function cancelForm() {
     setView('library')
     setEditTarget(null)
     setArenaEditTarget(null)
     setPlaylistEditTarget(null)
+    setGroupEditTarget(null)
   }
 
   // ── Derived values ──────────────────────────────────────────────────────────
@@ -1044,6 +1426,10 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
   const playlistVisible        = playlistFilter === 'all' ? playlistItems : playlistItems.filter(p => p.status === playlistFilter)
   const playlistStashedCount   = playlistItems.filter(p => p.status === 'stashed').length
   const playlistPublishedCount = playlistItems.filter(p => p.status === 'published').length
+
+  const groupVisible        = groupFilter === 'all' ? groupItems : groupItems.filter(g => g.status === groupFilter)
+  const groupStashedCount   = groupItems.filter(g => g.status === 'stashed').length
+  const groupPublishedCount = groupItems.filter(g => g.status === 'published').length
 
   // ── Form view (shared across sections) ─────────────────────────────────────
 
@@ -1074,6 +1460,14 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
             currentUser={currentUser}
           />
         )}
+        {section === 'groups' && (
+          <GroupForm
+            existing={view === 'edit' ? groupEditTarget : null}
+            onSave={handleGroupSaved}
+            onCancel={cancelForm}
+            currentUser={currentUser}
+          />
+        )}
       </Screen>
     )
   }
@@ -1092,11 +1486,49 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
         <button onClick={() => setSection('groups')}     style={tab(section === 'groups')}>Groups</button>
       </div>
 
-      {/* ── Groups placeholder ── */}
+      {/* ── Groups section ── */}
       {section === 'groups' && (
-        <div style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--color-text-tertiary)', fontSize: 13 }}>
-          Group creation coming soon.
-        </div>
+        <>
+          <button
+            onClick={() => setView('create')}
+            style={{ ...btn('primary'), marginBottom: '1.25rem' }}
+          >
+            + New group
+          </button>
+
+          {groupItems.length > 0 && (
+            <div style={{ display: 'flex', gap: 6, marginBottom: '1rem', flexWrap: 'wrap' }}>
+              <button onClick={() => setGroupFilter('all')}       style={tab(groupFilter === 'all')}>All ({groupItems.length})</button>
+              <button onClick={() => setGroupFilter('stashed')}   style={tab(groupFilter === 'stashed')}>Stashed ({groupStashedCount})</button>
+              <button onClick={() => setGroupFilter('published')} style={tab(groupFilter === 'published')}>Published ({groupPublishedCount})</button>
+            </div>
+          )}
+
+          {groupLoading && <p style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>Loading…</p>}
+
+          {!groupLoading && groupItems.length === 0 && (
+            <div style={{ textAlign: 'center', padding: '2rem 0', color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+              Nothing here yet. Create your first group above.
+            </div>
+          )}
+
+          {!groupLoading && groupItems.length > 0 && groupVisible.length === 0 && (
+            <p style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+              Nothing in this filter yet.
+            </p>
+          )}
+
+          {groupVisible.map(group => (
+            <GroupCard
+              key={group.id}
+              group={group}
+              onEdit={g => { setGroupEditTarget(g); setView('edit') }}
+              onPublish={handleGroupPublish}
+              onUnpublish={handleGroupUnpublish}
+              onDelete={handleGroupDelete}
+            />
+          ))}
+        </>
       )}
 
       {/* ── Combatants section ── */}

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -825,6 +825,110 @@ export async function getGroupsForCombatants(combatantIds) {
   } catch (e) { console.error('getGroupsForCombatants exception', e); return {} }
 }
 
+// ─── Group Workshop operations ────────────────────────────────────────────────
+
+export async function createWorkshopGroup({ id, name, description, tags = [], ownerId, ownerName, status = 'stashed' }) {
+  try {
+    const { error } = await supabase.from('groups').insert({
+      id, name, description: description || '', tags,
+      owner_id: ownerId, owner_name: ownerName,
+      status, updated_at: new Date().toISOString(),
+    })
+    if (error) console.error('createWorkshopGroup error', error)
+    return !error
+  } catch (e) { console.error('createWorkshopGroup exception', e); return false }
+}
+
+// Fetch all groups for a Workshop owner — stashed and published — with member_count.
+export async function getWorkshopGroups(ownerId) {
+  try {
+    const { data, error } = await supabase
+      .from('groups')
+      .select('id, name, description, tags, status, owner_id, owner_name, created_at, updated_at')
+      .eq('owner_id', ownerId)
+      .order('updated_at', { ascending: false })
+    if (error) { console.error('getWorkshopGroups error', error); return [] }
+    const rows = data || []
+    if (!rows.length) return rows
+    const ids = rows.map(g => g.id)
+    const { data: memberships } = await supabase.from('combatant_groups').select('group_id').in('group_id', ids)
+    const countMap = {}
+    for (const m of (memberships || [])) countMap[m.group_id] = (countMap[m.group_id] || 0) + 1
+    return rows.map(g => ({ ...g, member_count: countMap[g.id] || 0 }))
+  } catch (e) { console.error('getWorkshopGroups exception', e); return [] }
+}
+
+export async function updateWorkshopGroup(id, { name, description, tags }) {
+  try {
+    const { error } = await supabase.from('groups').update({
+      name, description: description || '', tags,
+      updated_at: new Date().toISOString(),
+    }).eq('id', id)
+    if (error) console.error('updateWorkshopGroup error', error)
+    return !error
+  } catch (e) { console.error('updateWorkshopGroup exception', e); return false }
+}
+
+export async function setWorkshopGroupStatus(id, status) {
+  try {
+    const { error } = await supabase.from('groups')
+      .update({ status, updated_at: new Date().toISOString() }).eq('id', id)
+    if (error) console.error('setWorkshopGroupStatus error', error)
+    return !error
+  } catch (e) { console.error('setWorkshopGroupStatus exception', e); return false }
+}
+
+// Only valid for stashed groups. Removes combatant_groups rows for this group first.
+export async function deleteWorkshopGroup(id) {
+  try {
+    await supabase.from('combatant_groups').delete().eq('group_id', id)
+    const { error } = await supabase.from('groups').delete().eq('id', id)
+    if (error) console.error('deleteWorkshopGroup error', error)
+    return !error
+  } catch (e) { console.error('deleteWorkshopGroup exception', e); return false }
+}
+
+// Replace all combatant memberships for a group (from the group side).
+// Mirrors setCombatantGroups but keyed on group_id instead of combatant_id.
+export async function setGroupCombatants(groupId, combatantIds, addedBy) {
+  try {
+    const { error: delErr } = await supabase.from('combatant_groups').delete().eq('group_id', groupId)
+    if (delErr) { console.error('setGroupCombatants delete error', delErr); return false }
+    if (!combatantIds.length) return true
+    const rows = combatantIds.map(combatant_id => ({ combatant_id, group_id: groupId, added_by: addedBy }))
+    const { error: insErr } = await supabase.from('combatant_groups').insert(rows)
+    if (insErr) console.error('setGroupCombatants insert error', insErr)
+    return !insErr
+  } catch (e) { console.error('setGroupCombatants exception', e); return false }
+}
+
+// Fetch combatant IDs belonging to a group — used when opening the group edit form.
+export async function getGroupCombatantIds(groupId) {
+  try {
+    const { data, error } = await supabase
+      .from('combatant_groups')
+      .select('combatant_id')
+      .eq('group_id', groupId)
+    if (error) { console.error('getGroupCombatantIds error', error); return [] }
+    return (data || []).map(r => r.combatant_id)
+  } catch (e) { console.error('getGroupCombatantIds exception', e); return [] }
+}
+
+// Returns combatants available to add to a group: the owner's own combatants (any status)
+// plus all published combatants from any owner. Deduped and sorted by name.
+export async function getCombatantPickerOptions(ownerId) {
+  try {
+    const { data, error } = await supabase
+      .from('combatants')
+      .select('id, name, bio, status, owner_id')
+      .or(`owner_id.eq.${ownerId},status.eq.published`)
+      .order('name', { ascending: true })
+    if (error) { console.error('getCombatantPickerOptions error', error); return [] }
+    const seen = new Set()
+    return (data || []).filter(c => { if (seen.has(c.id)) return false; seen.add(c.id); return true })
+  } catch (e) { console.error('getCombatantPickerOptions exception', e); return [] }
+}
+
 // Create a new combatant from The Workshop.
 // Status defaults to 'stashed' unless the caller explicitly passes 'published'.
 export async function createWorkshopCombatant({ id, name, bio, tags = [], ownerId, ownerName, status = 'stashed' }) {


### PR DESCRIPTION
Closes #17

## What changed

**supabase.js** — 8 new group Workshop functions:
- `createWorkshopGroup`, `getWorkshopGroups` (with member_count), `updateWorkshopGroup`, `setWorkshopGroupStatus`, `deleteWorkshopGroup`
- `setGroupCombatants` — replace all members for a group (mirrors `setCombatantGroups` but keyed on group_id)
- `getGroupCombatantIds` — load existing members when opening the edit form
- `getCombatantPickerOptions` — owner's own combatants (any status) + all published combatants, deduped by id

**WorkshopScreen.jsx** — full Groups section implementation:
- `MemberList` — current members with × remove button
- `GroupForm` — name (required), description (required), searchable combatant picker for member management, tags, stash/publish toggle on create; published-description confirm dialog on edit
- `GroupCard` — name, status badge, description excerpt, member count, tags, edit/publish/stash/delete actions
- Lazy-load on first tab visit, filter tabs (All/Stashed/Published), same lifecycle as combatants/arenas/playlists
- Replaces the "Group creation coming soon" placeholder

## Test notes
- Create a group: name + description required; description blank should block save
- Add/remove members from the picker; stashed combatants show a badge in the picker list
- Stash/publish toggle on create; "Move to stash" and "Publish" on the card
- Delete only appears for stashed groups; confirm step before delete fires
- Edit a published group, change description → confirm dialog appears before saving
- Member edits (add/remove) on a published group save without the confirm dialog
- Groups tab in the combatant form now shows any group created here