### PR TITLE
[1.2.x] Hall of Fame

### DIFF
--- a/src/screens/ArchiveScreen.jsx
+++ b/src/screens/ArchiveScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import { btn, tab, inp } from '../styles.js'
-import { listCombatants, searchCast, listPublishedGroups, listPublishedArenas, listAllDistinctTags, superHostSetEntityTags } from '../supabase.js'
+import { listCombatants, searchCast, listPublishedGroups, listPublishedArenas, listAllDistinctTags, superHostSetEntityTags, listHofCombatants } from '../supabase.js'
 import TagInput from '../components/TagInput.jsx'
 
 const PAGE_SIZE = 20
@@ -78,6 +78,9 @@ function CastTab({ query, activeTag, onFilterTag, onViewCombatant }) {
               <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', minWidth: 24 }}>#{page * PAGE_SIZE + idx + 1}</span>
                 <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)' }}>{c.name}</span>
+                {c.hall_of_fame && (
+                  <span style={{ fontSize: 11, padding: '2px 6px', background: 'var(--color-background-warning)', color: 'var(--color-text-warning)', border: '0.5px solid var(--color-border-warning)', borderRadius: 99, whiteSpace: 'nowrap' }}>Hall of Fame</span>
+                )}
                 {isVariant && (
                   <span style={{ fontSize: 11, padding: '2px 6px', background: 'var(--color-background-info)', color: 'var(--color-text-info)', border: '0.5px solid var(--color-border-info)', borderRadius: 99, whiteSpace: 'nowrap' }}>
                     ⚡ gen {c.lineage.generation}
@@ -321,6 +324,71 @@ function ArenasTab({ query, activeTag, activePool, onFilterTag, onFilterPool, on
   )
 }
 
+// ─── Hall of Fame tab ─────────────────────────────────────────────────────────
+
+function HofTab({ onViewCombatant }) {
+  const [items, setItems]     = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    listHofCombatants().then(data => { setItems(data); setLoading(false) })
+  }, [])
+
+  if (loading) return <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>
+
+  if (!items.length) return (
+    <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+      No combatants have been inducted yet.
+    </p>
+  )
+
+  return (
+    <>
+      <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '0 0 1.25rem' }}>
+        Inducted by Super Hosts. A permanent honour — the record lives on even if the badge is removed.
+      </p>
+      {items.map((c, idx) => {
+        const isVariant = !!c.lineage
+        return (
+          <button key={c.id} onClick={() => onViewCombatant(c)}
+            style={{ display: 'block', width: '100%', textAlign: 'left', padding: '14px 16px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-warning)', borderRadius: 'var(--border-radius-md)', marginBottom: 10, cursor: 'pointer' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 3 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', minWidth: 20 }}>#{idx + 1}</span>
+                <span style={{ fontSize: 16, fontWeight: 500, color: 'var(--color-text-primary)' }}>{c.name}</span>
+                <span style={{ fontSize: 11, padding: '2px 7px', background: 'var(--color-background-warning)', color: 'var(--color-text-warning)', border: '0.5px solid var(--color-border-warning)', borderRadius: 99, flexShrink: 0 }}>Hall of Fame</span>
+                {isVariant && (
+                  <span style={{ fontSize: 11, padding: '2px 6px', background: 'var(--color-background-info)', color: 'var(--color-text-info)', border: '0.5px solid var(--color-border-info)', borderRadius: 99 }}>
+                    ⚡ gen {c.lineage.generation}
+                  </span>
+                )}
+              </div>
+              <span style={{ fontSize: 12, color: 'var(--color-text-secondary)', flexShrink: 0, marginLeft: 8 }}>{c.wins}W – {c.losses}L</span>
+            </div>
+            <div style={{ paddingLeft: 28 }}>
+              <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+                by {c.owner_name || 'unknown'}
+              </span>
+              {c.inducted_at && (
+                <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginLeft: 8 }}>
+                  · inducted {new Date(c.inducted_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                  {c.inducted_by && ` by ${c.inducted_by}`}
+                </span>
+              )}
+            </div>
+            {c.induction_note && (
+              <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '4px 0 0 28px', lineHeight: 1.4, fontStyle: 'italic' }}>"{c.induction_note}"</p>
+            )}
+            {c.bio && (
+              <p style={{ fontSize: 12, color: 'var(--color-text-secondary)', margin: '4px 0 0 28px', lineHeight: 1.4 }}>{c.bio.length > 100 ? c.bio.slice(0, 100) + '…' : c.bio}</p>
+            )}
+          </button>
+        )
+      })}
+    </>
+  )
+}
+
 // ─── Tags tab ─────────────────────────────────────────────────────────────────
 
 function TagsTab({ activeTag, onFilterTag }) {
@@ -363,10 +431,11 @@ function TagsTab({ activeTag, onFilterTag }) {
 // ─── Archive screen ───────────────────────────────────────────────────────────
 
 const TABS = [
-  { key: 'cast',   label: 'The Cast' },
-  { key: 'groups', label: 'Groups'   },
-  { key: 'arenas', label: 'Arenas'   },
-  { key: 'tags',   label: 'Tags'     },
+  { key: 'cast',   label: 'The Cast'     },
+  { key: 'hof',    label: 'Hall of Fame' },
+  { key: 'groups', label: 'Groups'       },
+  { key: 'arenas', label: 'Arenas'       },
+  { key: 'tags',   label: 'Tags'         },
 ]
 
 export default function ArchiveScreen({ onBack, onViewCombatant, onViewArena, isSuperHost }) {
@@ -412,6 +481,7 @@ export default function ArchiveScreen({ onBack, onViewCombatant, onViewArena, is
       </div>
 
       {activeTab === 'cast'   && <CastTab   query={query} activeTag={activeTag} onFilterTag={handleFilterTag} onViewCombatant={onViewCombatant} />}
+      {activeTab === 'hof'    && <HofTab    onViewCombatant={onViewCombatant} />}
       {activeTab === 'groups' && <GroupsTab query={query} activeTag={activeTag} onFilterTag={handleFilterTag} isSuperHost={isSuperHost} />}
       {activeTab === 'arenas' && <ArenasTab query={query} activeTag={activeTag} activePool={activePool} onFilterTag={handleFilterTag} onFilterPool={handleFilterPool} onViewArena={onViewArena} />}
       {activeTab === 'tags'   && <TagsTab   activeTag={activeTag} onFilterTag={handleFilterTag} />}

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -3,7 +3,7 @@ import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
-import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget, superHostSetEntityTags, superHostInductHoF, superHostRemoveHoF, setCombatantGroups, getCombatantGroupIds, listPublishedGroups } from '../supabase.js'
+import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget, superHostSetEntityTags, superHostInductHoF, superHostRemoveHoF, superHostEditHofNote, setCombatantGroups, getCombatantGroupIds, listPublishedGroups } from '../supabase.js'
 import { buildStoryFromLineageTree, computeSuperlatives } from '../gameLogic.js'
 import { downloadFile, formatCombatantHistory } from '../export.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
@@ -242,6 +242,8 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   const [shHofOpen,     setShHofOpen]     = useState(false)
   const [shHofNote,     setShHofNote]     = useState('')
   const [shHofSaving,   setShHofSaving]   = useState(false)
+  const [shNoteEdit,    setShNoteEdit]    = useState(false)
+  const [shNoteVal,     setShNoteVal]     = useState('')
   const [shGroupOpen,   setShGroupOpen]   = useState(false)
   const [shGroupIds,    setShGroupIds]    = useState(null)  // null = not loaded
   const [shAllGroups,   setShAllGroups]   = useState(null)
@@ -338,6 +340,13 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
     const ok = await superHostRemoveHoF(c.id, playerName)
     if (ok) setC(prev => ({ ...prev, hall_of_fame: false, removed_at: new Date().toISOString(), removed_by: playerName }))
     setShHofSaving(false)
+  }
+
+  async function shSaveNote() {
+    setShHofSaving(true)
+    const ok = await superHostEditHofNote(c.id, shNoteVal)
+    if (ok) setC(prev => ({ ...prev, induction_note: shNoteVal }))
+    setShHofSaving(false); setShNoteEdit(false)
   }
 
   async function shOpenGroups() {
@@ -610,17 +619,45 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
           <div>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
               <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Hall of Fame</span>
-              {c.hall_of_fame
-                ? <button onClick={shRemoveHof} disabled={shHofSaving} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>{shHofSaving ? '…' : 'Remove'}</button>
-                : <button onClick={() => setShHofOpen(o => !o)} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Induct</button>
-              }
+              <div style={{ display: 'flex', gap: 6 }}>
+                {c.hall_of_fame && !shNoteEdit && (
+                  <button onClick={() => { setShNoteEdit(true); setShNoteVal(c.induction_note || '') }} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Edit note</button>
+                )}
+                {c.hall_of_fame
+                  ? <button onClick={shRemoveHof} disabled={shHofSaving} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>{shHofSaving ? '…' : 'Remove'}</button>
+                  : !shHofOpen && <button onClick={() => setShHofOpen(true)} style={{ ...btn('ghost'), padding: '2px 8px', fontSize: 12 }}>Induct</button>
+                }
+              </div>
             </div>
-            {c.hall_of_fame && c.inducted_at && (
+            {/* Induction record — visible whether currently inducted or previously removed */}
+            {c.inducted_at && !shNoteEdit && (
               <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '0 0 4px' }}>
-                Inducted {new Date(c.inducted_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                {c.hall_of_fame ? 'Inducted' : 'Previously inducted'}{' '}
+                {new Date(c.inducted_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
                 {c.inducted_by && ` by ${c.inducted_by}`}
                 {c.induction_note && ` — "${c.induction_note}"`}
+                {!c.hall_of_fame && c.removed_at && (
+                  <span>
+                    {' · Removed '}
+                    {new Date(c.removed_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                    {c.removed_by && ` by ${c.removed_by}`}
+                  </span>
+                )}
               </p>
+            )}
+            {shNoteEdit && (
+              <>
+                <input
+                  style={{ ...inp(), fontSize: 13, marginBottom: 6 }}
+                  placeholder="Induction note (optional)"
+                  value={shNoteVal}
+                  onChange={e => setShNoteVal(e.target.value)}
+                />
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button onClick={shSaveNote} disabled={shHofSaving} style={{ ...btn('primary'), flex: 1, fontSize: 13, padding: '7px' }}>{shHofSaving ? 'Saving…' : 'Save note'}</button>
+                  <button onClick={() => setShNoteEdit(false)} style={{ ...btn(), flex: 1, fontSize: 13, padding: '7px' }}>Cancel</button>
+                </div>
+              </>
             )}
             {!c.hall_of_fame && shHofOpen && (
               <>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -291,6 +291,30 @@ export async function superHostRemoveHoF(combatantId, removedBy) {
   } catch (e) { console.error('superHostRemoveHoF exception', e); return false }
 }
 
+// Update the induction note only — does not alter inducted_at, inducted_by, or hall_of_fame status.
+export async function superHostEditHofNote(combatantId, note) {
+  try {
+    const { error } = await supabase.from('combatants')
+      .update({ induction_note: note, updated_at: new Date().toISOString() })
+      .eq('id', combatantId)
+    if (error) console.error('superHostEditHofNote error', error)
+    return !error
+  } catch (e) { console.error('superHostEditHofNote exception', e); return false }
+}
+
+// All currently inducted Hall of Fame combatants, sorted by inducted_at desc.
+export async function listHofCombatants() {
+  try {
+    const { data, error } = await supabase.from('combatants')
+      .select('id, name, bio, owner_name, wins, losses, draws, reactions_heart, reactions_angry, reactions_cry, lineage, tags, inducted_at, inducted_by, induction_note')
+      .eq('status', 'published')
+      .eq('hall_of_fame', true)
+      .order('inducted_at', { ascending: false })
+    if (error) { console.error('listHofCombatants error', error); return [] }
+    return data || []
+  } catch (e) { console.error('listHofCombatants exception', e); return [] }
+}
+
 // Paginated combatants by owner, published only
 export async function getPlayerCombatants({ ownerId, query = '', sort = 'wins', ascending = false, page = 0, pageSize = 20 } = {}) {
   try {


### PR DESCRIPTION
Closes #19

## What changed

- **`supabase.js`**: Added `listHofCombatants()` (fetches all currently inducted combatants, sorted by induction date desc) and `superHostEditHofNote()` (updates the induction note without touching inducted_at / inducted_by / hall_of_fame status).

- **`ArchiveScreen.jsx`**: Added "Hall of Fame" tab (second tab after The Cast) showing all inducted combatants with their induction date, Super Host name, and optional note. Added Hall of Fame badge to Cast entry cards so inducted combatants are visually flagged inline.

- **`GlobalCombatantDetail.jsx`**: Induction record is now visible even after removal (badge hidden, record preserved — shows "Previously inducted…· Removed…"). Added "Edit note" button in the Super Host panel so the induction note can be updated without triggering a removal/re-induction cycle.

Schema migration (`20260429_super_hosts_hof.sql`) and the induct/remove supabase functions were already in place from issue #18.

## Test notes

- As a Super Host, open a published combatant → Super Host panel → Induct into Hall of Fame (with and without a note). Verify badge appears in the detail header and on the Cast entry card.
- Edit the induction note via "Edit note" — confirm inducted_at and inducted_by are unchanged.
- Remove the combatant from the Hall of Fame — badge disappears, but "Previously inducted…· Removed…" record is still visible in the Super Host panel.
- In The Archive → Hall of Fame tab: inducted combatants appear with their induction metadata. Tap one to navigate to their detail page.
- Non-inducted combatants do not appear in the Hall of Fame tab.