### PR TITLE
Open Lobbies

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -32,6 +32,7 @@ export function normalizeRoomSettings(settings) {
     arenaMode:            'none',
     arenaConfig:          null,
     arenaEvolutionEnabled: false,
+    isPublic:             false,
     ...settings,
   }
 }

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -1185,6 +1185,11 @@ describe('normalizeRoomSettings', () => {
     expect(normalizeRoomSettings({ allowMerges: false }).allowMerges).toBe(false)
   })
 
+  it('isPublic defaults to false, can be set true', () => {
+    expect(normalizeRoomSettings({}).isPublic).toBe(false)
+    expect(normalizeRoomSettings({ isPublic: true }).isPublic).toBe(true)
+  })
+
   it('is non-destructive — does not mutate the input', () => {
     const input = { rosterSize: 6 }
     const result = normalizeRoomSettings(input)

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -40,6 +40,7 @@ function RosterSizeRow({ value, onChange }) {
 }
 
 const SETTINGS = [
+  ['isPublic',               'Open lobby',              'Anyone can browse and join without an invite code'],
   ['spectatorsAllowed',      'Allow spectators',        'Let others watch without playing'],
   ['anonymousCombatants',    'Anonymous combatants',    'Hide owner names during voting'],
   ['blindVoting',            'Blind voting',            'Hide votes until everyone has picked'],
@@ -65,7 +66,7 @@ const POOL_OPTIONS = [
 export default function CreateRoom({ playerId, playerName, setPlayerName, lockedName, isGuest, onLogin, onCreated, onBack }) {
   const [name, setName] = useState(playerName)
   const [loading, setLoading] = useState(false)
-  const [settings, setSettings] = useState({ rosterSize: 8, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false, allowEvolutions: true, allowDraws: true, allowMerges: true, arenaMode: 'none', arenaConfig: null, arenaEvolutionEnabled: false })
+  const [settings, setSettings] = useState({ rosterSize: 8, isPublic: false, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false, allowEvolutions: true, allowDraws: true, allowMerges: true, arenaMode: 'none', arenaConfig: null, arenaEvolutionEnabled: false })
 
   // Arena picker state for single mode
   const [arenas,       setArenas]       = useState([])

--- a/src/screens/JoinRoom.jsx
+++ b/src/screens/JoinRoom.jsx
@@ -1,8 +1,31 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
 import { btn, inp, lbl } from '../styles.js'
-import { sget, sset } from '../supabase.js'
+import { sget, sset, getPublicLobbies } from '../supabase.js'
 import { playerColor } from '../gameLogic.js'
+
+const SORTS = [
+  { key: 'familiar', label: 'Familiar' },
+  { key: 'players',  label: 'Players'  },
+  { key: 'newest',   label: 'Newest'   },
+]
+
+function sortLobbies(lobbies, sort) {
+  const copy = [...lobbies]
+  if (sort === 'players') return copy.sort((a, b) => b.playerCount - a.playerCount || b.createdAt - a.createdAt)
+  if (sort === 'newest')  return copy.sort((a, b) => b.createdAt - a.createdAt)
+  // 'familiar': already pre-sorted by getPublicLobbies (timesPlayedWithHost desc, players desc, newest)
+  return copy
+}
+
+function timeAgo(ts) {
+  const mins = Math.floor((Date.now() - ts) / 60000)
+  if (mins < 1)  return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24)  return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
 
 export default function JoinRoom({ playerId, playerName, setPlayerName, lockedName, isGuest, initialCode = '', spectateMode = false, onJoined, onSpectated, onBack, onLogin, openLobbies = [], onLobbies }) {
   const [name, setName] = useState(playerName)
@@ -11,6 +34,19 @@ export default function JoinRoom({ playerId, playerName, setPlayerName, lockedNa
   const [loading, setLoading] = useState(false)
   // 'idle' | 'can_spectate' — shown when game is in progress and player isn't in it
   const [spectateRoom, setSpectateRoom] = useState(null)
+
+  const [publicLobbies, setPublicLobbies] = useState([])
+  const [lobbiesLoading, setLobbiesLoading] = useState(true)
+  const [sort, setSort] = useState('familiar')
+
+  useEffect(() => {
+    getPublicLobbies(playerId).then(data => {
+      setPublicLobbies(data)
+      setLobbiesLoading(false)
+    })
+  }, [playerId])
+
+  const sortedLobbies = sortLobbies(publicLobbies, sort)
 
   async function join() {
     if (!name.trim() || !code.trim()) return
@@ -73,6 +109,12 @@ export default function JoinRoom({ playerId, playerName, setPlayerName, lockedNa
     setLoading(false); onSpectated(room)
   }
 
+  function pickLobby(lobbyCode) {
+    setCode(lobbyCode)
+    setError('')
+    setSpectateRoom(null)
+  }
+
   return (
     <Screen title="Join room" onBack={onBack}>
       <label style={lbl}>Your name</label>
@@ -108,6 +150,60 @@ export default function JoinRoom({ playerId, playerName, setPlayerName, lockedNa
           {loading ? 'Joining…' : 'Join room'}
         </button>
       )}
+
+      {/* ── Open lobbies ──────────────────────────────────────────────────── */}
+      <div style={{ marginTop: 28 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+          <h3 style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.06em', margin: 0 }}>Open lobbies</h3>
+          {sortedLobbies.length > 1 && (
+            <div style={{ display: 'flex', gap: 4 }}>
+              {SORTS.map(({ key, label }) => (
+                <button
+                  key={key}
+                  onClick={() => setSort(key)}
+                  style={{ fontSize: 11, padding: '2px 8px', borderRadius: 99, border: sort === key ? 'none' : '0.5px solid var(--color-border-secondary)', background: sort === key ? 'var(--color-text-info)' : 'var(--color-background-tertiary)', color: sort === key ? '#fff' : 'var(--color-text-secondary)', cursor: 'pointer' }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {lobbiesLoading ? (
+          <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Loading…</p>
+        ) : sortedLobbies.length === 0 ? (
+          <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>No open lobbies right now.</p>
+        ) : (
+          <div style={{ border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden' }}>
+            {sortedLobbies.map((lobby, i) => (
+              <button
+                key={lobby.code}
+                onClick={() => pickLobby(lobby.code)}
+                style={{ display: 'block', width: '100%', textAlign: 'left', padding: '10px 14px', background: code === lobby.code ? 'var(--color-background-selected, var(--color-background-secondary))' : i % 2 === 0 ? 'var(--color-background-secondary)' : 'var(--color-background-primary)', border: 'none', borderTop: i === 0 ? 'none' : '0.5px solid var(--color-border-tertiary)', cursor: 'pointer' }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+                      {lobby.hostName}
+                      {lobby.timesPlayedWithHost > 0 && (
+                        <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--color-text-tertiary)', marginLeft: 6 }}>
+                          played together {lobby.timesPlayedWithHost}×
+                        </span>
+                      )}
+                    </div>
+                    <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 1 }}>
+                      {lobby.playerCount} {lobby.playerCount === 1 ? 'player' : 'players'} waiting · {timeAgo(lobby.createdAt)}
+                      {lobby.arenaMode !== 'none' && ` · ${lobby.arenaMode}`}
+                    </div>
+                  </div>
+                  <span style={{ fontSize: 13, fontWeight: 600, letterSpacing: 2, color: 'var(--color-text-secondary)', flexShrink: 0 }}>{lobby.code}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </Screen>
   )
 }

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -74,6 +74,43 @@ export async function getActiveRoomsForPlayer(playerId) {
   } catch (e) { console.error('getActiveRoomsForPlayer exception', e); return [] }
 }
 
+// Public lobbies for the join screen browser.
+// One table scan: collects open public rooms and (if playerId given) computes
+// how many completed games the current player has had with each host, used for
+// the default "familiar" sort order.
+export async function getPublicLobbies(playerId = null) {
+  try {
+    const { data, error } = await supabase.from('rooms').select('data').order('updated_at', { ascending: false })
+    if (error) { console.error('getPublicLobbies error', error); return [] }
+    const hostFrequency = {}
+    const publicLobbies = []
+    for (const row of (data || [])) {
+      const r = row.data
+      if (!r || r.devMode) continue
+      if (playerId && r.phase === 'ended' && (r.players || []).some(p => p.id === playerId && !p.isBot)) {
+        hostFrequency[r.host] = (hostFrequency[r.host] || 0) + 1
+      }
+      if (r.phase === 'lobby' && r.settings?.isPublic && !r.nextRoomId) {
+        publicLobbies.push({
+          code:        r.id,
+          hostId:      r.host,
+          hostName:    (r.players || []).find(p => p.id === r.host)?.name || 'Unknown',
+          playerCount: (r.players || []).filter(p => !p.isBot).length,
+          createdAt:   r.createdAt,
+          arenaMode:   r.settings?.arenaMode || 'none',
+        })
+      }
+    }
+    return publicLobbies
+      .map(lobby => ({ ...lobby, timesPlayedWithHost: hostFrequency[lobby.hostId] || 0 }))
+      .sort((a, b) =>
+        b.timesPlayedWithHost - a.timesPlayedWithHost ||
+        b.playerCount - a.playerCount ||
+        b.createdAt - a.createdAt
+      )
+  } catch (e) { console.error('getPublicLobbies exception', e); return [] }
+}
+
 // ─── Realtime ────────────────────────────────────────────────────────────────
 
 // Subscribe to live updates for a single room row.


### PR DESCRIPTION
Closes #22

## What changed

- **`settings.isPublic`** — new boolean (default `false`) added to `normalizeRoomSettings` and CreateRoom initial state. Stored on the room record at creation time.
- **CreateRoom**: "Open lobby" toggle is the first setting in the list. Off by default. When on, the room is discoverable without an invite code.
- **`getPublicLobbies(playerId)`** in `supabase.js` — single table scan that collects all public lobby-phase rooms and, for logged-in users, computes "times played with host" from completed games in the same pass. Returns lobbies sorted: familiarity → player count → newest.
- **JoinRoom**: public lobby browser appears below the code entry. Shows host name, player count, time since created, and arena mode. Tapping a row pre-fills the room code. Sort controls (Familiar / Players / Newest) appear when there's more than one lobby. "Familiar" is the default — lobbies where the player has history with the host float to the top.

## Test notes

- Create a room with "Open lobby" toggled on → verify it appears in another browser's join screen lobby browser
- Join via the browser (tap a row, then "Join room") → verify it follows the normal join flow
- Create a closed room (default) → verify it does not appear in the browser
- Sort controls: only shown when 2+ lobbies exist; each re-orders the list client-side
- `normalizeRoomSettings({}).isPublic` → `false` (covered by new unit test, all 621 tests pass)