### PR TITLE
Host can kick players in lobby and draft screens

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -1108,6 +1108,38 @@ export function replacePlayerIdInRoom(room, oldId, newId) {
   }
 }
 
+// ─── Host kick ────────────────────────────────────────────────────────────────
+
+/**
+ * Removes a player from the room. Returns the updated room and any combatants
+ * the player had already submitted, so the caller can stash or discard them.
+ *
+ * Touches: players[], combatants map, drafts map.
+ * prevWinners is preserved — it is a historical record from a prior game.
+ */
+export function kickPlayerFromRoom(room, kickedId) {
+  if (!room || !kickedId) return { room, submittedCombatants: [] }
+  if (!(room.players || []).some(p => p.id === kickedId)) return { room, submittedCombatants: [] }
+
+  const players = (room.players || []).filter(p => p.id !== kickedId)
+  const submittedCombatants = room.combatants?.[kickedId] || []
+
+  const { [kickedId]: _c, ...remainingCombatants } = room.combatants || {}
+
+  const drafts = room.drafts ? { ...room.drafts } : undefined
+  if (drafts) delete drafts[kickedId]
+
+  return {
+    room: {
+      ...room,
+      players,
+      combatants: remainingCombatants,
+      ...(drafts !== undefined ? { drafts } : {}),
+    },
+    submittedCombatants,
+  }
+}
+
 // ─── Series standings ─────────────────────────────────────────────────────────
 
 /**

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -31,6 +31,7 @@ import {
   getEphemeralBadges,
   computeSuperlatives,
   getCombatantsToPublish,
+  kickPlayerFromRoom,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -2432,6 +2433,80 @@ describe('replacePlayerIdInRoom', () => {
     const original = JSON.parse(JSON.stringify(room))
     replacePlayerIdInRoom(room, OLD, NEW)
     expect(room).toEqual(original)
+  })
+})
+
+// ─── kickPlayerFromRoom ───────────────────────────────────────────────────────
+
+describe('kickPlayerFromRoom', () => {
+  function makeKickRoom() {
+    return {
+      id: 'ROOM1', code: 'ROOM1', host: 'p1', phase: 'draft',
+      players: [
+        { id: 'p1', name: 'Alice', color: '#fff', isBot: false },
+        { id: 'p2', name: 'Bob',   color: '#000', isBot: false },
+        { id: 'p3', name: 'Carol', color: '#aaa', isBot: false },
+      ],
+      combatants: {
+        p1: [{ id: 'c1', name: 'Fighter', ownerId: 'p1' }],
+        p2: [{ id: 'c2', name: 'Brawler', ownerId: 'p2' }],
+      },
+      drafts: { p3: { names: ['Draft'], bios: [''], globalIds: [null] } },
+    }
+  }
+
+  it('removes kicked player from players array', () => {
+    const { room } = kickPlayerFromRoom(makeKickRoom(), 'p2')
+    expect(room.players.map(p => p.id)).toEqual(['p1', 'p3'])
+  })
+
+  it('removes kicked player combatants from combatants map', () => {
+    const { room } = kickPlayerFromRoom(makeKickRoom(), 'p2')
+    expect(room.combatants).not.toHaveProperty('p2')
+    expect(room.combatants).toHaveProperty('p1')
+  })
+
+  it('returns submitted combatants for stashing', () => {
+    const { submittedCombatants } = kickPlayerFromRoom(makeKickRoom(), 'p2')
+    expect(submittedCombatants).toHaveLength(1)
+    expect(submittedCombatants[0].id).toBe('c2')
+  })
+
+  it('returns empty submittedCombatants when player has not submitted', () => {
+    const { submittedCombatants } = kickPlayerFromRoom(makeKickRoom(), 'p3')
+    expect(submittedCombatants).toEqual([])
+  })
+
+  it('removes kicked player draft from drafts map', () => {
+    const { room } = kickPlayerFromRoom(makeKickRoom(), 'p3')
+    expect(room.drafts).not.toHaveProperty('p3')
+  })
+
+  it('preserves other players drafts when kicking', () => {
+    const base = makeKickRoom()
+    base.drafts.p2 = { names: ['Kick'], bios: [''], globalIds: [null] }
+    const { room } = kickPlayerFromRoom(base, 'p3')
+    expect(room.drafts).toHaveProperty('p2')
+  })
+
+  it('preserves prevWinners (historical record)', () => {
+    const base = makeKickRoom()
+    base.prevWinners = { p2: [{ id: 'pw1', name: 'Legend' }] }
+    const { room } = kickPlayerFromRoom(base, 'p2')
+    expect(room.prevWinners).toHaveProperty('p2')
+  })
+
+  it('returns unchanged room when player not found', () => {
+    const base = makeKickRoom()
+    const { room } = kickPlayerFromRoom(base, 'ghost')
+    expect(room).toEqual(base)
+  })
+
+  it('does not mutate the input', () => {
+    const base = makeKickRoom()
+    const original = JSON.parse(JSON.stringify(base))
+    kickPlayerFromRoom(base, 'p2')
+    expect(base).toEqual(original)
   })
 })
 

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -125,7 +125,7 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
     const roomCode = Math.random().toString(36).slice(2, 6).toUpperCase()
     const room = {
       id: roomCode, code: roomCode, host: playerId, phase: 'lobby',
-      players: [{ id: playerId, name: name.trim(), color: playerColor(0), ready: false }],
+      players: [{ id: playerId, name: name.trim(), color: playerColor(0), ready: false, isGuest }],
       combatants: {}, rounds: [], currentRound: 0, createdAt: Date.now(),
       settings,
     }

--- a/src/screens/DraftScreen.jsx
+++ b/src/screens/DraftScreen.jsx
@@ -6,12 +6,12 @@ import DevBanner from '../components/DevBanner.jsx'
 import FighterAutocomplete from '../components/FighterAutocomplete.jsx'
 import CombatantStatsPill from '../components/CombatantStatsPill.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, upsertGlobalCombatant, subscribeToRoom, getHeritageChain, getCombatantsByIds, getPlayerStashedCombatants, createWorkshopCombatant } from '../supabase.js'
+import { sget, sset, upsertGlobalCombatant, subscribeToRoom, getHeritageChain, getCombatantsByIds, getPlayerStashedCombatants, createWorkshopCombatant, stashKickedCombatants } from '../supabase.js'
 import {
   uid, ownerLabel, slotMatchesPrevWinner, areAllPrevWinnersPlaced,
   getUnplacedWinners, buildCombatantFromDraft, isDraftComplete,
   getReadyPlayerCount, canForceStart, DEV_ROSTER_NAMES, DEV_ROSTER_BIOS,
-  normalizeRoomSettings, buildActiveFormMap,
+  normalizeRoomSettings, buildActiveFormMap, kickPlayerFromRoom,
 } from '../gameLogic.js'
 
 export default function DraftScreen({ room: init, playerId, setRoom, onDone, isGuest, onLogin, onBack, onEndSeries }) {
@@ -38,6 +38,8 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
   const [submitted, setSubmitted] = useState(existing.length === rosterSize)
   const [forceStarting, setForceStarting] = useState(false)
   const [confirmCancel, setConfirmCancel] = useState(false)
+  // playerId being confirmed for kick, or null
+  const [confirmKick, setConfirmKick] = useState(null)
   const isHost = room.host === playerId
   const isSeries = !!room.prevRoomId
   const cancelLabel = isSeries ? 'End series' : 'Cancel game'
@@ -75,6 +77,10 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
 
   useEffect(() => {
     return subscribeToRoom(room.id, r => {
+      if (!(r.players || []).some(p => p.id === playerId)) {
+        localStorage.setItem('eights_kicked', JSON.stringify({ code: r.code, at: Date.now() }))
+        onBack(); return
+      }
       setLocal(r); setRoom(r)
       if (r.phase === 'battle') onDone()
     })
@@ -177,6 +183,16 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
     setLocal(updated); setRoom(updated); setForceStarting(false); onDone()
   }
 
+  async function kickPlayer(kickedId) {
+    const kickedPlayer = room.players.find(p => p.id === kickedId)
+    const { room: updated, submittedCombatants } = kickPlayerFromRoom(room, kickedId)
+    if (submittedCombatants.length > 0 && kickedPlayer && !kickedPlayer.isGuest) {
+      await stashKickedCombatants(submittedCombatants)
+    }
+    await sset('room:' + room.id, updated)
+    setLocal(updated); setRoom(updated); setConfirmKick(null)
+  }
+
   if (submitted) {
     const realPlayers = room.players.filter(p => !p.isBot)
     const readyCount  = getReadyPlayerCount(room.players, room.combatants, rosterSize)
@@ -196,11 +212,29 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
           {room.players.map(p => {
             const done = p.isBot || (room.combatants[p.id] || []).length === rosterSize
             return (
-              <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)' }}>
-                <AvatarWithHover player={p} onViewProfile={null} />
-                <span style={{ color: 'var(--color-text-primary)', fontSize: 14 }}>{p.name}</span>
-                {p.isBot && <Pill>bot</Pill>}
-                <span style={{ marginLeft: 'auto', fontSize: 13 }}>{done ? '✓' : '…'}</span>
+              <div key={p.id} style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: confirmKick === p.id ? 'var(--border-radius-md) var(--border-radius-md) 0 0' : 'var(--border-radius-md)' }}>
+                  <AvatarWithHover player={p} onViewProfile={null} />
+                  <span style={{ color: 'var(--color-text-primary)', fontSize: 14 }}>{p.name}</span>
+                  {p.isBot && <Pill>bot</Pill>}
+                  {confirmKick !== p.id && <span style={{ marginLeft: 'auto', fontSize: 13 }}>{done ? '✓' : '…'}</span>}
+                  {isHost && !p.isBot && p.id !== playerId && confirmKick !== p.id && (
+                    <button
+                      onClick={() => setConfirmKick(p.id)}
+                      style={{ background: 'transparent', border: 'none', fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer', padding: '4px 6px' }}
+                      title="Remove player"
+                    >✕</button>
+                  )}
+                  {isHost && confirmKick === p.id && (
+                    <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--color-text-danger)' }}>Remove?</span>
+                  )}
+                </div>
+                {isHost && confirmKick === p.id && (
+                  <div style={{ display: 'flex', gap: 0, background: 'var(--color-background-danger)', border: '0.5px solid var(--color-border-danger)', borderTop: 'none', borderRadius: '0 0 var(--border-radius-md) var(--border-radius-md)', overflow: 'hidden' }}>
+                    <button onClick={() => kickPlayer(p.id)} style={{ flex: 1, padding: '8px', background: 'transparent', border: 'none', borderRight: '0.5px solid var(--color-border-danger)', fontSize: 13, color: 'var(--color-text-danger)', cursor: 'pointer' }}>Yes, remove</button>
+                    <button onClick={() => setConfirmKick(null)} style={{ flex: 1, padding: '8px', background: 'transparent', border: 'none', fontSize: 13, color: 'var(--color-text-secondary)', cursor: 'pointer' }}>Never mind</button>
+                  </div>
+                )}
               </div>
             )
           })}

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { btn } from '../styles.js'
 import { slist } from '../supabase.js'
 import { buildTickerMessages } from '../gameLogic.js'
@@ -34,9 +34,26 @@ function HomeTicker() {
 }
 
 export default function HomeScreen({ onCreate, onJoin, onChronicles, onArchive, onPlayers, onWorkshop, onSuperHost, onDev, currentUser, onLogin, onLogout, onAdmin, openLobbies, onLobbies, onHelp }) {
+  const [kickedNotice, setKickedNotice] = useState(() => {
+    try { return JSON.parse(localStorage.getItem('eights_kicked') || 'null') } catch { return null }
+  })
+
+  const dismissKick = useCallback(() => {
+    localStorage.removeItem('eights_kicked')
+    setKickedNotice(null)
+  }, [])
+
   return (
     <div style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '2rem', position: 'relative' }}>
       <button onClick={onHelp} title="How to play" style={{ position: 'absolute', top: '1rem', left: '1rem', background: 'transparent', border: '0.5px solid var(--color-border-tertiary)', borderRadius: '50%', width: 28, height: 28, fontSize: 13, color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1 }}>?</button>
+      {kickedNotice && (
+        <div style={{ position: 'absolute', top: '1rem', left: '50%', transform: 'translateX(-50%)', width: 'calc(100% - 2rem)', maxWidth: 320, display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'var(--color-background-warning)', border: '0.5px solid var(--color-border-warning)', borderRadius: 'var(--border-radius-md)', zIndex: 10 }}>
+          <span style={{ flex: 1, fontSize: 13, color: 'var(--color-text-warning)' }}>
+            You were removed from game {kickedNotice.code} by the host.
+          </span>
+          <button onClick={dismissKick} style={{ background: 'transparent', border: 'none', fontSize: 16, color: 'var(--color-text-warning)', cursor: 'pointer', padding: '2px 4px', lineHeight: 1, flexShrink: 0 }}>✕</button>
+        </div>
+      )}
       <div style={{ textAlign: 'center', marginBottom: '3rem' }}>
         <HomeTicker />
         <div style={{ fontSize: 56, marginBottom: '0.5rem' }}>⚔️</div>

--- a/src/screens/JoinRoom.jsx
+++ b/src/screens/JoinRoom.jsx
@@ -86,7 +86,7 @@ export default function JoinRoom({ playerId, playerName, setPlayerName, lockedNa
     }
 
     // Join as player
-    room.players.push({ id: playerId, name: name.trim(), color: playerColor(room.players.length), ready: false })
+    room.players.push({ id: playerId, name: name.trim(), color: playerColor(room.players.length), ready: false, isGuest })
     await sset('room:' + room.id, room)
     sessionStorage.setItem('eights_pname', name.trim()); setPlayerName(name.trim())
     setLoading(false); onJoined(room)

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -6,7 +6,7 @@ import SpectatorList from '../components/SpectatorList.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn } from '../styles.js'
 import { sset, subscribeToRoom, trackRoomPresence } from '../supabase.js'
-import { normalizeRoomSettings } from '../gameLogic.js'
+import { normalizeRoomSettings, kickPlayerFromRoom } from '../gameLogic.js'
 
 const POOL_LABELS = {
   'standard':       'Standard',
@@ -72,11 +72,17 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
   const [presentIds, setPresentIds] = useState([])
   // 'idle' | 'confirming' — guest-host gate before starting the game
   const [guestStartPrompt, setGuestStartPrompt] = useState('idle')
+  // playerId being confirmed for kick, or null
+  const [confirmKick, setConfirmKick] = useState(null)
 
   const isHost = room.host === playerId
 
   useEffect(() => {
     return subscribeToRoom(room.id, r => {
+      if (!(r.players || []).some(p => p.id === playerId)) {
+        localStorage.setItem('eights_kicked', JSON.stringify({ code: r.code, at: Date.now() }))
+        onBack(); return
+      }
       setLocal(r); setRoom(r)
       if (r.phase === 'draft') onStart()
       if (r.phase === 'ended') onBack()
@@ -109,6 +115,12 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
     onBack()
   }
 
+  async function kickPlayer(kickedId) {
+    const { room: updated } = kickPlayerFromRoom(room, kickedId)
+    await sset('room:' + room.id, updated)
+    setLocal(updated); setRoom(updated); setConfirmKick(null)
+  }
+
   return (
     <Screen title={`Room ${room.code}`} onBack={onBack} right={<SpectatorList spectators={room.spectators} />}>
       <p style={{ color: 'var(--color-text-secondary)', fontSize: 14, margin: '0 0 1rem' }}>Share this code with your friends</p>
@@ -121,10 +133,28 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
       <h3 style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 400, margin: '0 0 12px' }}>Players ({room.players.length})</h3>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: '2rem' }}>
         {room.players.map(p => (
-          <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)' }}>
-            <AvatarWithHover player={p} onViewProfile={!p.isBot ? onViewPlayer : null} />
-            <span style={{ color: 'var(--color-text-primary)', fontSize: 15 }}>{p.name}</span>
-            {p.id === room.host && <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--color-text-tertiary)', background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-tertiary)', padding: '2px 6px', borderRadius: 99 }}>host</span>}
+          <div key={p.id} style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: confirmKick === p.id ? 'var(--border-radius-md) var(--border-radius-md) 0 0' : 'var(--border-radius-md)' }}>
+              <AvatarWithHover player={p} onViewProfile={!p.isBot ? onViewPlayer : null} />
+              <span style={{ color: 'var(--color-text-primary)', fontSize: 15 }}>{p.name}</span>
+              {p.id === room.host && <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--color-text-tertiary)', background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-tertiary)', padding: '2px 6px', borderRadius: 99 }}>host</span>}
+              {isHost && p.id !== room.host && p.id !== confirmKick && (
+                <button
+                  onClick={() => setConfirmKick(p.id)}
+                  style={{ marginLeft: p.id === room.host ? 0 : 'auto', background: 'transparent', border: 'none', fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer', padding: '4px 6px' }}
+                  title="Remove player"
+                >✕</button>
+              )}
+              {isHost && confirmKick === p.id && (
+                <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--color-text-danger)' }}>Remove?</span>
+              )}
+            </div>
+            {isHost && confirmKick === p.id && (
+              <div style={{ display: 'flex', gap: 0, background: 'var(--color-background-danger)', border: '0.5px solid var(--color-border-danger)', borderTop: 'none', borderRadius: '0 0 var(--border-radius-md) var(--border-radius-md)', overflow: 'hidden' }}>
+                <button onClick={() => kickPlayer(p.id)} style={{ flex: 1, padding: '8px', background: 'transparent', border: 'none', borderRight: '0.5px solid var(--color-border-danger)', fontSize: 13, color: 'var(--color-text-danger)', cursor: 'pointer' }}>Yes, remove</button>
+                <button onClick={() => setConfirmKick(null)} style={{ flex: 1, padding: '8px', background: 'transparent', border: 'none', fontSize: 13, color: 'var(--color-text-secondary)', cursor: 'pointer' }}>Never mind</button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1023,6 +1023,27 @@ export async function createWorkshopCombatant({ id, name, bio, tags = [], ownerI
   } catch (e) { console.error('createWorkshopCombatant exception', e); return false }
 }
 
+// Stash a set of combatants into a player's Workshop after a kick.
+// The combatants already exist in global_combatants (upserted on draft submit);
+// we flip source to 'created' and status to 'stashed' so they appear in the Workshop.
+export async function stashKickedCombatants(combatants) {
+  if (!combatants?.length) return
+  try {
+    const rows = combatants.map(c => ({
+      id: c.id,
+      name: c.name,
+      bio: c.bio || '',
+      owner_id: c.ownerId || '',
+      owner_name: c.ownerName || '',
+      source: 'created',
+      status: 'stashed',
+      updated_at: new Date().toISOString(),
+    }))
+    const { error } = await supabase.from('combatants').upsert(rows, { onConflict: 'id', ignoreDuplicates: false })
+    if (error) console.error('stashKickedCombatants error', error)
+  } catch (e) { console.error('stashKickedCombatants exception', e) }
+}
+
 // Fetch all combatants for a Workshop owner — stashed and published.
 // Stashed rows are private to the owner so we scope by owner_id; no status filter.
 export async function getWorkshopCombatants(ownerId) {


### PR DESCRIPTION
Closes #93

## What changed

- **`gameLogic.js`** — new `kickPlayerFromRoom(room, kickedId)` pure function that removes the player from `players[]`, `combatants{}`, and `drafts{}`, and returns their submitted combatants for stashing. `prevWinners` is preserved (historical record from a prior game).
- **`gameLogic.test.js`** — 9 unit tests covering all branches of `kickPlayerFromRoom`.
- **`supabase.js`** — new `stashKickedCombatants(combatants)` helper that upserts submitted combatants back into the Workshop (`source='created'`, `status='stashed'`) for logged-in players.
- **`JoinRoom.jsx` / `CreateRoom.jsx`** — `isGuest` is now stored on each player object so the draft kick handler can decide stash vs discard.
- **`LobbyScreen.jsx`** — host sees a ✕ button next to each non-host player; clicking shows an inline "Yes, remove / Never mind" confirm row. Subscription detects when the current player is no longer in `room.players` and redirects them home with a localStorage kick notice.
- **`DraftScreen.jsx`** — same kick UI in the submitted/waiting view. When a logged-in player's submitted combatants are present, `stashKickedCombatants` is called before saving the room update.
- **`HomeScreen.jsx`** — reads `eights_kicked` from localStorage on mount and renders a dismissible warning banner: "You were removed from game [CODE] by the host."

## Kick flow notes

- **Lobby kick**: slot immediately reopens — other players can still join.
- **Draft kick**: game continues short-handed; the kicked player's slot is removed.
- **Stash vs discard**: `isGuest` is now on the player object. Submitted combatants are stashed only for non-guest players; guest combatants are discarded.
- **Kick while host hasn't submitted**: The kick button is in the submitted/waiting view only. The host must submit their own draft before they can kick others — this covers the main case. Can be extended in a follow-up if needed.

## Test notes

- `npx vitest run` — 718 tests, all passing.
- To verify manually: create a room, join with a second browser session, host taps ✕ next to the second player, confirm panel drops in, "Yes, remove" kicks them. Second session redirects home with the banner. Room has no orphaned player entries.