### PR TITLE
Host can invite registered users to a closed lobby

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { getRoomsByIds, getActiveRoomsForPlayer, sget, sset } from './supabase.js'
+import { getRoomsByIds, getActiveRoomsForPlayer, sget, sset, getPendingInvitationsForPlayer, updateRoomInvitationStatus } from './supabase.js'
 import { uid, makeBots, makeBotCombatants, playerColor, prepareNextGame, replacePlayerIdInRoom } from './gameLogic.js'
 
 // Screens
@@ -111,9 +111,28 @@ export default function App() {
 
   async function refreshLobbies() {
     if (currentUser) {
-      const rooms = await getActiveRoomsForPlayer(playerId)
-      setOpenLobbies(rooms)
+      const ACTIVE_PHASES = ['lobby', 'draft', 'battle', 'vote']
+      const [rooms, invitations] = await Promise.all([
+        getActiveRoomsForPlayer(playerId),
+        getPendingInvitationsForPlayer(playerId),
+      ])
       saveLobbyCodes(rooms.map(r => r.id))
+
+      let inviteEntries = []
+      if (invitations.length) {
+        const inviteRooms = await getRoomsByIds(invitations.map(inv => inv.room_id))
+        inviteEntries = invitations
+          .map(inv => {
+            const room = inviteRooms.find(r => r?.id === inv.room_id)
+            // Skip if room is gone, ended, or the player already joined
+            if (!room || !ACTIVE_PHASES.includes(room.phase)) return null
+            if ((room.players || []).some(p => p.id === playerId)) return null
+            return { ...room, isInvitation: true, invitation: inv }
+          })
+          .filter(Boolean)
+      }
+
+      setOpenLobbies([...rooms, ...inviteEntries])
     } else {
       const codes = loadLobbyCodes()
       if (!codes.length) { setOpenLobbies([]); return }
@@ -247,6 +266,30 @@ export default function App() {
     goHome()
   }
 
+  async function handleAcceptInvitation(roomEntry, invitation) {
+    const r = await sget('room:' + roomEntry.id)
+    if (!r || r.phase !== 'lobby') {
+      // Room ended or game already started — decline the stale invite and refresh
+      await updateRoomInvitationStatus(invitation.id, 'declined')
+      await refreshLobbies()
+      return
+    }
+    const count = (r.players || []).length
+    const newPlayer = { id: playerId, name: effectiveName, color: playerColor(count), ready: false, isGuest: false }
+    const updated = { ...r, players: [...(r.players || []), newPlayer] }
+    await sset('room:' + r.id, updated)
+    await updateRoomInvitationStatus(invitation.id, 'accepted')
+    addLobbyCode(r.id)
+    setRoom(updated)
+    setViewLobbies(false)
+    nav('lobby')
+  }
+
+  async function handleDeclineInvitation(invitation) {
+    await updateRoomInvitationStatus(invitation.id, 'declined')
+    await refreshLobbies()
+  }
+
   function goHome() { setRoom(null); refreshLobbies(); nav('home') }
 
   const isSuperHost = !!currentUser?.is_super_host
@@ -257,7 +300,7 @@ export default function App() {
   else if (viewWorkshop)
     content = <WorkshopScreen currentUser={currentUser} onBack={() => setViewWorkshop(false)} onLogin={() => goAuth('home')} />
   else if (viewLobbies)
-    content = <MyLobbiesScreen lobbies={openLobbies} playerId={playerId} onBack={() => { setViewLobbies(false); refreshLobbies() }} onEnter={r => { setRoom(r); setViewLobbies(false); nav(r.phase === 'lobby' ? 'lobby' : r.phase === 'draft' ? 'draft' : r.phase === 'vote' ? 'vote' : 'round') }} />
+    content = <MyLobbiesScreen lobbies={openLobbies} playerId={playerId} onBack={() => { setViewLobbies(false); refreshLobbies() }} onEnter={r => { setRoom(r); setViewLobbies(false); nav(r.phase === 'lobby' ? 'lobby' : r.phase === 'draft' ? 'draft' : r.phase === 'vote' ? 'vote' : 'round') }} onAcceptInvitation={handleAcceptInvitation} onDeclineInvitation={handleDeclineInvitation} />
   else if (viewPlayers && viewPlayerProfile)
     content = <PlayerProfile profileId={viewPlayerProfile} playerId={playerId} onBack={() => setViewPlayerProfile(null)} onViewCombatant={c => setViewGlobalCombatant(c)} onViewRoom={openRoomSummary} />
   else if (viewPlayers)

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import AvatarWithHover from '../components/AvatarWithHover.jsx'
 import ShareLinkButton from '../components/ShareLinkButton.jsx'
 import SpectatorList from '../components/SpectatorList.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn } from '../styles.js'
-import { sset, subscribeToRoom, trackRoomPresence } from '../supabase.js'
+import { sset, subscribeToRoom, trackRoomPresence, searchUsers, createRoomInvitation, deleteRoomInvitation, getRoomInvitations } from '../supabase.js'
 import { normalizeRoomSettings, kickPlayerFromRoom } from '../gameLogic.js'
 
 const POOL_LABELS = {
@@ -75,6 +75,18 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
   // playerId being confirmed for kick, or null
   const [confirmKick, setConfirmKick] = useState(null)
 
+  // Pending invitations (host-only view)
+  const [pendingInvitees, setPendingInvitees] = useState([])
+  const [cancelInviteId, setCancelInviteId] = useState(null)
+
+  // Invite panel state
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [inviteQuery, setInviteQuery] = useState('')
+  const [inviteResults, setInviteResults] = useState([])
+  const [inviteSearching, setInviteSearching] = useState(false)
+  const [inviteSending, setInviteSending] = useState(null) // inviteeId being sent
+  const inviteInputRef = useRef(null)
+
   const isHost = room.host === playerId
 
   useEffect(() => {
@@ -94,6 +106,34 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
       onPresenceChange: setPresentIds,
     })
   }, [room.id])
+
+  // Load pending invitees for host; refresh when player count changes (catches accepts)
+  useEffect(() => {
+    if (!isHost) return
+    getRoomInvitations(room.id).then(setPendingInvitees)
+  }, [room.players?.length, isHost])
+
+  // Debounced user search for the invite panel
+  useEffect(() => {
+    if (!inviteOpen) return
+    if (!inviteQuery.trim()) { setInviteResults([]); return }
+    setInviteSearching(true)
+    const t = setTimeout(async () => {
+      const { items } = await searchUsers({ query: inviteQuery, pageSize: 8 })
+      const joinedIds  = new Set((room.players || []).map(p => p.id))
+      const invitedIds = new Set(pendingInvitees.map(p => p.invitee_id))
+      setInviteResults(
+        items.filter(u => !joinedIds.has(u.id) && !invitedIds.has(u.id) && u.id !== playerId)
+      )
+      setInviteSearching(false)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [inviteQuery, inviteOpen, room.players, pendingInvitees])
+
+  // Focus the search input when the panel opens
+  useEffect(() => {
+    if (inviteOpen) inviteInputRef.current?.focus()
+  }, [inviteOpen])
 
   async function startGame() {
     const updated = { ...room, phase: 'draft' }
@@ -121,6 +161,29 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
     setLocal(updated); setRoom(updated); setConfirmKick(null)
   }
 
+  async function sendInvite(user) {
+    setInviteSending(user.id)
+    const id = await createRoomInvitation(room.id, user.id, user.username, playerId)
+    if (id) {
+      setPendingInvitees(prev => [...prev, { id, invitee_id: user.id, invitee_name: user.username }])
+      setInviteResults(prev => prev.filter(u => u.id !== user.id))
+      setInviteQuery('')
+    }
+    setInviteSending(null)
+  }
+
+  async function cancelInvite(invitationId) {
+    await deleteRoomInvitation(invitationId)
+    setPendingInvitees(prev => prev.filter(p => p.id !== invitationId))
+    setCancelInviteId(null)
+  }
+
+  function closeInvitePanel() {
+    setInviteOpen(false)
+    setInviteQuery('')
+    setInviteResults([])
+  }
+
   return (
     <Screen title={`Room ${room.code}`} onBack={onBack} right={<SpectatorList spectators={room.spectators} />}>
       <p style={{ color: 'var(--color-text-secondary)', fontSize: 14, margin: '0 0 1rem' }}>Share this code with your friends</p>
@@ -131,7 +194,8 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
       <ConnectionStatus players={room.players} presentIds={presentIds} isHost={isHost} roomCode={room.code} />
 
       <h3 style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 400, margin: '0 0 12px' }}>Players ({room.players.length})</h3>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: '2rem' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: '1rem' }}>
+        {/* Joined players */}
         {room.players.map(p => (
           <div key={p.id} style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'var(--color-background-secondary)', borderRadius: confirmKick === p.id ? 'var(--border-radius-md) var(--border-radius-md) 0 0' : 'var(--border-radius-md)' }}>
@@ -157,6 +221,85 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
             )}
           </div>
         ))}
+
+        {/* Pending invitees (host view) */}
+        {isHost && pendingInvitees.map(inv => (
+          <div key={inv.id} style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: cancelInviteId === inv.id ? 'var(--border-radius-md) var(--border-radius-md) 0 0' : 'var(--border-radius-md)', opacity: 0.75 }}>
+              <span style={{ width: 28, height: 28, borderRadius: '50%', background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-tertiary)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, flexShrink: 0 }}>⏳</span>
+              <span style={{ color: 'var(--color-text-primary)', fontSize: 15 }}>{inv.invitee_name}</span>
+              <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-tertiary)', padding: '2px 6px', borderRadius: 99 }}>invited</span>
+              {cancelInviteId !== inv.id && (
+                <button
+                  onClick={() => setCancelInviteId(inv.id)}
+                  style={{ marginLeft: 'auto', background: 'transparent', border: 'none', fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer', padding: '4px 6px' }}
+                  title="Cancel invitation"
+                >✕</button>
+              )}
+              {cancelInviteId === inv.id && (
+                <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--color-text-danger)' }}>Cancel?</span>
+              )}
+            </div>
+            {cancelInviteId === inv.id && (
+              <div style={{ display: 'flex', gap: 0, background: 'var(--color-background-danger)', border: '0.5px solid var(--color-border-danger)', borderTop: 'none', borderRadius: '0 0 var(--border-radius-md) var(--border-radius-md)', overflow: 'hidden' }}>
+                <button onClick={() => cancelInvite(inv.id)} style={{ flex: 1, padding: '8px', background: 'transparent', border: 'none', borderRight: '0.5px solid var(--color-border-danger)', fontSize: 13, color: 'var(--color-text-danger)', cursor: 'pointer' }}>Yes, cancel</button>
+                <button onClick={() => setCancelInviteId(null)} style={{ flex: 1, padding: '8px', background: 'transparent', border: 'none', fontSize: 13, color: 'var(--color-text-secondary)', cursor: 'pointer' }}>Never mind</button>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Invite panel (host only) */}
+        {isHost && !inviteOpen && (
+          <button
+            onClick={() => setInviteOpen(true)}
+            style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', background: 'transparent', border: '0.5px dashed var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', color: 'var(--color-text-tertiary)', fontSize: 13, cursor: 'pointer', textAlign: 'left' }}
+          >
+            <span style={{ fontSize: 16, lineHeight: 1 }}>+</span> Invite a player
+          </button>
+        )}
+        {isHost && inviteOpen && (
+          <div style={{ border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', overflow: 'hidden' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 0, borderBottom: inviteResults.length > 0 || inviteSearching ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
+              <input
+                ref={inviteInputRef}
+                value={inviteQuery}
+                onChange={e => setInviteQuery(e.target.value)}
+                placeholder="Search by username…"
+                style={{ flex: 1, padding: '10px 14px', background: 'var(--color-background-secondary)', border: 'none', outline: 'none', fontSize: 14, color: 'var(--color-text-primary)' }}
+              />
+              <button
+                onClick={closeInvitePanel}
+                style={{ padding: '10px 14px', background: 'transparent', border: 'none', fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
+              >
+                Cancel
+              </button>
+            </div>
+            {inviteSearching && (
+              <div style={{ padding: '10px 14px', fontSize: 13, color: 'var(--color-text-tertiary)', background: 'var(--color-background-secondary)' }}>
+                Searching…
+              </div>
+            )}
+            {!inviteSearching && inviteQuery.trim() && inviteResults.length === 0 && (
+              <div style={{ padding: '10px 14px', fontSize: 13, color: 'var(--color-text-tertiary)', background: 'var(--color-background-secondary)' }}>
+                No registered players found
+              </div>
+            )}
+            {inviteResults.map(user => (
+              <button
+                key={user.id}
+                onClick={() => sendInvite(user)}
+                disabled={inviteSending === user.id}
+                style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', padding: '10px 14px', background: 'var(--color-background-secondary)', border: 'none', borderTop: '0.5px solid var(--color-border-tertiary)', fontSize: 14, color: inviteSending === user.id ? 'var(--color-text-tertiary)' : 'var(--color-text-primary)', cursor: inviteSending === user.id ? 'default' : 'pointer', textAlign: 'left' }}
+              >
+                <span>{user.username}</span>
+                <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+                  {inviteSending === user.id ? 'Sending…' : 'Invite'}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       <ArenaModeDisplay settings={room.settings} />

--- a/src/screens/MyLobbiesScreen.jsx
+++ b/src/screens/MyLobbiesScreen.jsx
@@ -2,52 +2,79 @@ import Screen from '../components/Screen.jsx'
 import { btn } from '../styles.js'
 import { normalizeRoomSettings } from '../gameLogic.js'
 
-export default function MyLobbiesScreen({ lobbies, playerId, onBack, onEnter }) {
+export default function MyLobbiesScreen({ lobbies, playerId, onBack, onEnter, onAcceptInvitation, onDeclineInvitation }) {
   return (
     <Screen title="My open lobbies" onBack={onBack}>
       <p style={{ color: 'var(--color-text-secondary)', fontSize: 13, margin: '-0.5rem 0 1.25rem' }}>
         These games are still in progress. Rejoin anytime.
       </p>
       {lobbies.map(r => {
-        const host = r.players.find(p => p.id === r.host)
+        const isInvite  = !!r.isInvitation
+        const host      = r.players.find(p => p.id === r.host)
         const realPlayers = r.players.filter(p => !p.isBot)
         const { rosterSize } = normalizeRoomSettings(r.settings)
         const submitted = realPlayers.filter(p => (r.combatants[p.id] || []).length === rosterSize)
-        const isMyTurn  = r.phase === 'draft' && (r.combatants[playerId] || []).length < rosterSize
+        const isMyTurn  = !isInvite && r.phase === 'draft' && (r.combatants[playerId] || []).length < rosterSize
         const phaseLabel = r.phase === 'lobby' ? 'Waiting to start' : r.phase === 'draft' ? 'Drafting combatants' : r.phase === 'vote' ? 'Voting in progress' : 'Rounds in progress'
 
+        const borderStyle = isInvite
+          ? '1.5px solid var(--color-border-warning)'
+          : isMyTurn
+            ? '1.5px solid var(--color-border-info)'
+            : '0.5px solid var(--color-border-tertiary)'
+
         return (
-          <div key={r.id} style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', border: isMyTurn ? '1.5px solid var(--color-border-info)' : '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-lg)', marginBottom: 12 }}>
+          <div key={isInvite ? `inv-${r.invitation.id}` : r.id} style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', border: borderStyle, borderRadius: 'var(--border-radius-lg)', marginBottom: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
-              <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <span style={{ fontSize: 18, fontWeight: 500, letterSpacing: 2, color: 'var(--color-text-primary)' }}>{r.code}</span>
-                <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginLeft: 10 }}>{phaseLabel}</span>
+                {isInvite && (
+                  <span style={{ fontSize: 11, color: 'var(--color-text-warning)', background: 'var(--color-background-warning)', border: '0.5px solid var(--color-border-warning)', padding: '2px 7px', borderRadius: 99 }}>Invited</span>
+                )}
+                {!isInvite && <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>{phaseLabel}</span>}
               </div>
               <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Host: {host?.name || '?'}</span>
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 5, marginBottom: 12 }}>
-              {realPlayers.map(p => {
-                const ready = (r.combatants[p.id] || []).length === rosterSize
-                const isMe  = p.id === playerId
-                return (
-                  <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
-                    <span style={{ width: 8, height: 8, borderRadius: '50%', background: ready ? 'var(--color-text-success)' : 'var(--color-text-tertiary)', flexShrink: 0 }} />
-                    <span style={{ color: isMe ? 'var(--color-text-info)' : 'var(--color-text-primary)' }}>
-                      {p.name}{isMe ? ' (you)' : ''}{p.id === r.host ? ' · host' : ''}
-                    </span>
-                    <span style={{ marginLeft: 'auto', fontSize: 11, color: ready ? 'var(--color-text-success)' : 'var(--color-text-tertiary)' }}>
-                      {r.phase === 'lobby' ? 'waiting' : r.phase === 'battle' || r.phase === 'vote' ? 'in game' : ready ? 'ready ✓' : 'working…'}
-                    </span>
-                  </div>
-                )
-              })}
-              {r.phase === 'draft' && <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 2 }}>{submitted.length} / {realPlayers.length} ready</div>}
-            </div>
+            {isInvite ? (
+              <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: '0 0 12px' }}>
+                You've been invited to join this lobby. Accept to enter.
+              </p>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5, marginBottom: 12 }}>
+                {realPlayers.map(p => {
+                  const ready = (r.combatants[p.id] || []).length === rosterSize
+                  const isMe  = p.id === playerId
+                  return (
+                    <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+                      <span style={{ width: 8, height: 8, borderRadius: '50%', background: ready ? 'var(--color-text-success)' : 'var(--color-text-tertiary)', flexShrink: 0 }} />
+                      <span style={{ color: isMe ? 'var(--color-text-info)' : 'var(--color-text-primary)' }}>
+                        {p.name}{isMe ? ' (you)' : ''}{p.id === r.host ? ' · host' : ''}
+                      </span>
+                      <span style={{ marginLeft: 'auto', fontSize: 11, color: ready ? 'var(--color-text-success)' : 'var(--color-text-tertiary)' }}>
+                        {r.phase === 'lobby' ? 'waiting' : r.phase === 'battle' || r.phase === 'vote' ? 'in game' : ready ? 'ready ✓' : 'working…'}
+                      </span>
+                    </div>
+                  )
+                })}
+                {r.phase === 'draft' && <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 2 }}>{submitted.length} / {realPlayers.length} ready</div>}
+              </div>
+            )}
 
-            <button onClick={() => onEnter(r)} style={{ ...btn(isMyTurn || r.phase === 'battle' || r.phase === 'vote' ? 'primary' : 'ghost'), padding: '8px 14px', fontSize: 13 }}>
-              {isMyTurn ? 'Rejoin — your turn ⚔️' : r.phase === 'battle' || r.phase === 'vote' ? 'Rejoin battle ⚔️' : 'Rejoin'}
-            </button>
+            {isInvite ? (
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button onClick={() => onAcceptInvitation(r, r.invitation)} style={{ ...btn('primary'), flex: 1, padding: '8px 14px', fontSize: 13 }}>
+                  Accept →
+                </button>
+                <button onClick={() => onDeclineInvitation(r.invitation)} style={{ ...btn('ghost'), padding: '8px 14px', fontSize: 13, color: 'var(--color-text-secondary)' }}>
+                  Decline
+                </button>
+              </div>
+            ) : (
+              <button onClick={() => onEnter(r)} style={{ ...btn(isMyTurn || r.phase === 'battle' || r.phase === 'vote' ? 'primary' : 'ghost'), padding: '8px 14px', fontSize: 13 }}>
+                {isMyTurn ? 'Rejoin — your turn ⚔️' : r.phase === 'battle' || r.phase === 'vote' ? 'Rejoin battle ⚔️' : 'Rejoin'}
+              </button>
+            )}
           </div>
         )
       })}

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -634,6 +634,67 @@ export async function getHeritageChain(startRoomId) {
   return rooms
 }
 
+// ─── Room invitations ─────────────────────────────────────────────────────────
+
+// Send an invitation from host to a registered user. Returns the new invitation id or null.
+export async function createRoomInvitation(roomId, inviteeId, inviteeName, invitedBy) {
+  try {
+    const { data, error } = await supabase
+      .from('room_invitations')
+      .insert({ room_id: roomId, invitee_id: inviteeId, invitee_name: inviteeName, invited_by: invitedBy })
+      .select('id')
+      .single()
+    if (error) { console.error('createRoomInvitation error', error); return null }
+    return data?.id ?? null
+  } catch (e) { console.error('createRoomInvitation exception', e); return null }
+}
+
+// Cancel a pending invitation (host action). Hard delete — no record needed.
+export async function deleteRoomInvitation(invitationId) {
+  try {
+    const { error } = await supabase.from('room_invitations').delete().eq('id', invitationId)
+    if (error) console.error('deleteRoomInvitation error', error)
+    return !error
+  } catch (e) { console.error('deleteRoomInvitation exception', e); return false }
+}
+
+// Update invitation status — 'accepted' or 'declined'.
+export async function updateRoomInvitationStatus(invitationId, status) {
+  try {
+    const { error } = await supabase.from('room_invitations').update({ status }).eq('id', invitationId)
+    if (error) console.error('updateRoomInvitationStatus error', error)
+    return !error
+  } catch (e) { console.error('updateRoomInvitationStatus exception', e); return false }
+}
+
+// Pending invitations for a room — for the host's lobby view.
+export async function getRoomInvitations(roomId) {
+  try {
+    const { data, error } = await supabase
+      .from('room_invitations')
+      .select('id, invitee_id, invitee_name, invited_at')
+      .eq('room_id', roomId)
+      .eq('status', 'pending')
+      .order('invited_at', { ascending: true })
+    if (error) { console.error('getRoomInvitations error', error); return [] }
+    return data || []
+  } catch (e) { console.error('getRoomInvitations exception', e); return [] }
+}
+
+// Pending invitations for a player — drives the "Invited" entries in My Open Lobbies.
+export async function getPendingInvitationsForPlayer(playerId) {
+  try {
+    const { data, error } = await supabase
+      .from('room_invitations')
+      .select('id, room_id, invitee_name, invited_by, invited_at')
+      .eq('invitee_id', playerId)
+      .eq('status', 'pending')
+      .order('invited_at', { ascending: false })
+    if (error) { console.error('getPendingInvitationsForPlayer error', error); return [] }
+    return data || []
+  } catch (e) { console.error('getPendingInvitationsForPlayer exception', e); return [] }
+}
+
 // ─── Admin action dispatcher ─────────────────────────────────────────────────
 //
 // Routes admin write operations through the admin-action Edge Function, which


### PR DESCRIPTION
Closes #95

## What changed

**`supabase.js`** — 5 new functions for the `room_invitations` table:
- `createRoomInvitation` — host sends an invite (inserts a `pending` row)
- `deleteRoomInvitation` — host cancels a pending invite (hard delete)
- `updateRoomInvitationStatus` — invitee accepts or declines
- `getRoomInvitations(roomId)` — host's pending invitees for a room
- `getPendingInvitationsForPlayer(playerId)` — invitee's pending invites across all rooms

**`LobbyScreen.jsx`** — host invite UI:
- Pending invitees load on mount and refresh whenever room player count changes (catches accepts)
- Each pending invitee appears in the player list with a ⏳ avatar, "invited" badge, and a cancel confirm
- "+ Invite a player" dashed button expands an inline search panel (debounced 300ms)
- Search filters out already-joined players, already-invited players, and self
- Sending/cancelling updates local state optimistically

**`MyLobbiesScreen.jsx`** — invitee experience:
- Invitation entries render with a yellow "Invited" badge, an explanatory line, and Accept / Decline buttons
- Joined room entries are unchanged

**`App.jsx`** — lobby refresh:
- `refreshLobbies` now fetches pending invitations alongside active rooms (logged-in users only; guests cannot be invited)
- Invitation entries are mixed into `openLobbies` with `isInvitation: true` and the invitation object attached
- If the player is already in the room the invitation entry is suppressed
- `handleAcceptInvitation`: fetches latest room, adds player to `room.players`, marks invitation accepted, navigates to lobby. If room has ended or moved past lobby, declines the stale invite and refreshes
- `handleDeclineInvitation`: marks declined, refreshes list

## Design decisions documented

**Notification badge**: invitation entries are merged into the `openLobbies` array, so the existing badge count on "My open lobbies" automatically includes pending invitations. No separate indicator — one number for "things waiting for you".

**Stale invitations on accept**: if the game already started when the player accepts, the invite is silently declined and the list refreshes. No error UI — the entry simply disappears.

**Hard delete on cancel**: cancelling a pending invitation uses a hard delete. The record has no narrative value once cancelled.

## Test notes
- Create a room as a logged-in host and open the lobby
- Tap "+ Invite a player" — search appears, type a registered username, results show after 300ms
- Tap "Invite" — username appears in the lobby list with the ⏳ badge
- Log into the invitee's account in another tab — "My open lobbies" badge shows +1
- Open "My open lobbies" — invited room shows yellow "Invited" badge with Accept / Decline
- Accept → player joins the lobby, navigated to LobbyScreen; host sees them move from pending to joined
- Cancel from host side → pending row disappears
- Decline from invitee side → entry disappears from My Open Lobbies