### PR TITLE
Season: creation, standings, close, and resume

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { getRoomsByIds, getActiveRoomsForPlayer, sget, sset, getPendingInvitationsForPlayer, updateRoomInvitationStatus } from './supabase.js'
+import { getRoomsByIds, getActiveRoomsForPlayer, sget, sset, getPendingInvitationsForPlayer, updateRoomInvitationStatus, updateSeason } from './supabase.js'
 import { uid, makeBots, makeBotCombatants, playerColor, prepareNextGame, replacePlayerIdInRoom } from './gameLogic.js'
 
 // Screens
@@ -24,6 +24,7 @@ import SpectateScreen from './screens/SpectateScreen.jsx'
 import GameSummaryScreen from './screens/GameSummaryScreen.jsx'
 import WorkshopScreen from './screens/WorkshopScreen.jsx'
 import SuperHostScreen from './screens/SuperHostScreen.jsx'
+import SeasonScreen from './screens/SeasonScreen.jsx'
 import HelpModal from './components/HelpModal.jsx'
 
 function UserPill({ currentUser, isGuest, effectiveName, onLogout, onLogin }) {
@@ -161,6 +162,10 @@ export default function App() {
   const [viewWorkshop, setViewWorkshop] = useState(false)
   const [viewSuperHost, setViewSuperHost] = useState(false)
   const [viewRoomSummary, setViewRoomSummary] = useState(null)
+  const [viewSeasons, setViewSeasons] = useState(false)
+  // When a season's "Start series" is tapped, store the season here so the created room
+  // can carry the seasonId and series_played can increment after the room is created.
+  const [pendingSeason, setPendingSeason] = useState(null)
 
   async function openRoomSummary(roomId) {
     const r = await sget('room:' + roomId)
@@ -292,6 +297,26 @@ export default function App() {
 
   function goHome() { setRoom(null); refreshLobbies(); nav('home') }
 
+  function handleSeasonStartSeries(season) {
+    setPendingSeason(season)
+    setViewSeasons(false)
+    nav('create')
+  }
+
+  async function handleSeasonRoomCreated(r) {
+    addLobbyCode(r.id)
+    setRoom(r)
+    if (pendingSeason) {
+      try {
+        await updateSeason(pendingSeason.id, { series_played: pendingSeason.series_played + 1 })
+      } catch (e) {
+        console.error('updateSeason series_played failed', e)
+      }
+      setPendingSeason(null)
+    }
+    nav('lobby')
+  }
+
   const isSuperHost = !!currentUser?.is_super_host
 
   let content = null
@@ -311,8 +336,10 @@ export default function App() {
     content = <ArenaDetailScreen key={viewArena?.id} arena={viewArena} playerId={playerId} isSuperHost={isSuperHost} onBack={() => setViewArena(null)} onViewArena={setViewArena} />
   else if (viewArchive)
     content = <ArchiveScreen playerId={playerId} isSuperHost={isSuperHost} onBack={() => setViewArchive(false)} onViewCombatant={c => setViewGlobalCombatant(c)} onViewArena={a => setViewArena(a)} />
+  else if (viewSeasons)
+    content = <SeasonScreen playerId={playerId} playerName={effectiveName} onBack={() => setViewSeasons(false)} onStartSeries={handleSeasonStartSeries} />
   else if (viewChronicles)
-    content = <ChroniclesScreen onBack={() => setViewChronicles(false)} setViewCombatant={c => { setViewCombatant(c); setViewChronicles(false) }} playerId={playerId} onNextGame={r => { setViewChronicles(false); handleHostNextGame(r) }} />
+    content = <ChroniclesScreen onBack={() => setViewChronicles(false)} setViewCombatant={c => { setViewCombatant(c); setViewChronicles(false) }} playerId={playerId} onNextGame={r => { setViewChronicles(false); handleHostNextGame(r) }} onSeasons={() => { setViewChronicles(false); setViewSeasons(true) }} />
   else if (viewCombatant)
     content = <CombatantScreen room={room} combatant={viewCombatant} playerId={playerId} onBack={() => setViewCombatant(null)} onViewCombatant={setViewCombatant} />
   else if (screen === 'auth')
@@ -322,7 +349,7 @@ export default function App() {
   else if (screen === 'home')
     content = <HomeScreen onCreate={() => nav('create')} onJoin={() => nav('join')} onChronicles={() => setViewChronicles(true)} onArchive={() => setViewArchive(true)} onPlayers={() => setViewPlayers(true)} onWorkshop={() => setViewWorkshop(true)} onSuperHost={() => setViewSuperHost(true)} onDev={startDevMode} currentUser={currentUser} onLogin={() => nav('auth')} onLogout={logout} onAdmin={() => nav('admin')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} onHelp={() => setViewHelp(true)} />
   else if (screen === 'create')
-    content = <CreateRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} onLogin={() => goAuth('create')} onCreated={r => { addLobbyCode(r.id); setRoom(r); nav('lobby') }} onBack={() => nav('home')} />
+    content = <CreateRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} onLogin={() => goAuth('create')} onCreated={pendingSeason ? handleSeasonRoomCreated : r => { addLobbyCode(r.id); setRoom(r); nav('lobby') }} onBack={pendingSeason ? () => { setPendingSeason(null); setViewSeasons(true) } : () => nav('home')} seasonId={pendingSeason?.id} />
   else if (screen === 'join')
     content = <JoinRoom playerId={playerId} playerName={effectiveName} setPlayerName={setPlayerName} lockedName={!isGuest} isGuest={isGuest} initialCode={_urlJoinCode || _urlSpectateCode || _urlCode} spectateMode={!!_urlSpectateCode} onJoined={r => { addLobbyCode(r.id); setRoom(r); nav(r.phase === 'draft' ? 'draft' : r.phase === 'battle' ? 'round' : r.phase === 'vote' ? 'vote' : 'lobby') }} onSpectated={r => { setRoom(r); nav('spectate') }} onBack={() => nav('home')} onLogin={() => goAuth('join')} openLobbies={openLobbies} onLobbies={() => setViewLobbies(true)} />
   else if (screen === 'spectate')

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -432,7 +432,7 @@ function SeriesRow({ item, onSelect, playerId }) {
   )
 }
 
-export default function ChroniclesScreen({ onBack, setViewCombatant, playerId, onNextGame }) {
+export default function ChroniclesScreen({ onBack, setViewCombatant, playerId, onNextGame, onSeasons }) {
   const [rooms, setRooms] = useState(null)
   const [selected, setSelected] = useState(null)
 
@@ -461,6 +461,11 @@ export default function ChroniclesScreen({ onBack, setViewCombatant, playerId, o
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: '1.5rem' }}>
         <button onClick={onBack} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13 }}>← Back</button>
         <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>The Chronicles</h2>
+        {onSeasons && (
+          <button onClick={onSeasons} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 12, marginLeft: 'auto' }}>
+            Seasons ↗
+          </button>
+        )}
       </div>
 
       {rooms === null && <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>Loading…</p>}

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -63,7 +63,7 @@ const POOL_OPTIONS = [
   { value: 'weighted-liked', label: 'Fan favourites' },
 ]
 
-export default function CreateRoom({ playerId, playerName, setPlayerName, lockedName, isGuest, onLogin, onCreated, onBack }) {
+export default function CreateRoom({ playerId, playerName, setPlayerName, lockedName, isGuest, onLogin, onCreated, onBack, seasonId }) {
   const [name, setName] = useState(playerName)
   const [loading, setLoading] = useState(false)
   const [settings, setSettings] = useState({ rosterSize: 8, isPublic: false, spectatorsAllowed: true, anonymousCombatants: false, blindVoting: false, biosRequired: false, allowEvolutions: true, allowDraws: true, allowMerges: true, arenaMode: 'none', arenaConfig: null, arenaEvolutionEnabled: false })
@@ -128,6 +128,7 @@ export default function CreateRoom({ playerId, playerName, setPlayerName, locked
       players: [{ id: playerId, name: name.trim(), color: playerColor(0), ready: false, isGuest }],
       combatants: {}, rounds: [], currentRound: 0, createdAt: Date.now(),
       settings,
+      ...(seasonId ? { seasonId } : {}),
     }
     await sset('room:' + roomCode, room)
     sessionStorage.setItem('eights_pname', name.trim())

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -1,0 +1,458 @@
+import { useState, useEffect } from 'react'
+import Screen from '../components/Screen.jsx'
+import { btn, inp, lbl, tab } from '../styles.js'
+import { createSeason, getSeasons, updateSeason, getSeasonRooms } from '../supabase.js'
+import { uid, computeSeriesStandings, groupRoomsForHistory } from '../gameLogic.js'
+
+function ToggleRow({ label, description, value, onToggle }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 0', borderBottom: '0.5px solid var(--color-border-tertiary)' }}>
+      <div>
+        <div style={{ fontSize: 14, color: 'var(--color-text-primary)' }}>{label}</div>
+        {description && <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 1 }}>{description}</div>}
+      </div>
+      <button
+        onClick={onToggle}
+        style={{ flexShrink: 0, marginLeft: 16, width: 40, height: 22, borderRadius: 99, border: 'none', outline: value ? 'none' : '0.5px solid var(--color-border-secondary)', padding: 0, background: value ? 'var(--color-text-info)' : 'var(--color-background-tertiary)', cursor: 'pointer', position: 'relative', transition: 'background 0.15s' }}
+      >
+        <span style={{ position: 'absolute', top: 3, left: value ? 20 : 3, width: 16, height: 16, borderRadius: '50%', background: '#fff', transition: 'left 0.15s', display: 'block' }} />
+      </button>
+    </div>
+  )
+}
+
+function StatusBadge({ status }) {
+  const style = {
+    fontSize: 11, padding: '2px 8px', borderRadius: 99, fontWeight: 500,
+    ...(status === 'active'
+      ? { background: 'var(--color-background-success)', color: 'var(--color-text-success)', border: '0.5px solid var(--color-border-success)' }
+      : status === 'ended'
+        ? { background: 'var(--color-background-tertiary)', color: 'var(--color-text-tertiary)', border: '0.5px solid var(--color-border-tertiary)' }
+        : { background: 'var(--color-background-danger)', color: 'var(--color-text-danger)', border: '0.5px solid var(--color-border-danger)' })
+  }
+  return <span style={style}>{status}</span>
+}
+
+function StandingsTable({ rooms }) {
+  const rows = computeSeriesStandings(rooms)
+  if (rows.length === 0) return null
+  return (
+    <div style={{ padding: '12px 16px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: '1rem' }}>
+      <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 8 }}>Standings</div>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', fontWeight: 400, color: 'var(--color-text-tertiary)', paddingBottom: 4, paddingRight: 8 }}>Player</th>
+            <th style={{ textAlign: 'right', fontWeight: 400, color: 'var(--color-text-tertiary)', paddingBottom: 4, paddingRight: 8 }}>W</th>
+            <th style={{ textAlign: 'right', fontWeight: 400, color: 'var(--color-text-tertiary)', paddingBottom: 4, paddingRight: 8 }}>D</th>
+            <th style={{ textAlign: 'right', fontWeight: 400, color: 'var(--color-text-tertiary)', paddingBottom: 4, paddingRight: 8 }}>L</th>
+            <th style={{ textAlign: 'right', fontWeight: 400, color: 'var(--color-text-tertiary)', paddingBottom: 4 }}>G</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={r.playerId} style={{ borderTop: i > 0 ? '0.5px solid var(--color-border-tertiary)' : 'none' }}>
+              <td style={{ paddingTop: 5, paddingBottom: 5, paddingRight: 8, color: 'var(--color-text-primary)' }}>{r.playerName}</td>
+              <td style={{ textAlign: 'right', paddingRight: 8, color: 'var(--color-text-success)', fontWeight: 500 }}>{r.wins}</td>
+              <td style={{ textAlign: 'right', paddingRight: 8, color: 'var(--color-text-secondary)' }}>{r.draws}</td>
+              <td style={{ textAlign: 'right', paddingRight: 8, color: 'var(--color-text-tertiary)' }}>{r.losses}</td>
+              <td style={{ textAlign: 'right', color: 'var(--color-text-tertiary)' }}>{r.games}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }) {
+  const [season, setSeason] = useState(initialSeason)
+  const [seasonRooms, setSeasonRooms] = useState(null)
+  const [closing, setClosing] = useState(false)
+  const [confirmClose, setConfirmClose] = useState(false)
+
+  useEffect(() => {
+    getSeasonRooms(season.id).then(rooms => {
+      setSeasonRooms(rooms)
+      // Auto-close when last series has ended
+      if (
+        season.status === 'active' &&
+        season.series_played >= season.series_count &&
+        rooms.length > 0 &&
+        rooms.every(r => r.phase === 'ended')
+      ) {
+        updateSeason(season.id, { status: 'ended' }).then(updated => setSeason(updated))
+      }
+    })
+  }, [season.id, season.status, season.series_played, season.series_count])
+
+  async function handleCloseEarly() {
+    setClosing(true)
+    try {
+      const updated = await updateSeason(season.id, { status: 'ended' })
+      setSeason(updated)
+    } finally {
+      setClosing(false)
+      setConfirmClose(false)
+    }
+  }
+
+  const hasRooms    = seasonRooms !== null && seasonRooms.length > 0
+  const allEnded    = hasRooms && seasonRooms.every(r => r.phase === 'ended')
+  const anyActive   = hasRooms && seasonRooms.some(r => r.phase !== 'ended')
+  const seriesItems = seasonRooms ? groupRoomsForHistory(seasonRooms).filter(i => i.type === 'series') : []
+  const standaloneItems = seasonRooms ? groupRoomsForHistory(seasonRooms).filter(i => i.type === 'standalone') : []
+
+  const canStartFirst = season.status === 'active' && !hasRooms
+  const canStartNext  = season.status === 'active' && allEnded && season.series_played < season.series_count
+  const canCloseEarly = season.status === 'active' && (allEnded || !hasRooms)
+
+  const firstDate = seasonRooms && hasRooms
+    ? new Date(Math.min(...seasonRooms.map(r => r.createdAt))).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+    : null
+  const lastDate = seasonRooms && hasRooms
+    ? new Date(Math.max(...seasonRooms.map(r => r.createdAt))).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+    : null
+
+  return (
+    <Screen title={season.name} onBack={onBack}>
+      {/* Header meta */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: '1rem', flexWrap: 'wrap' }}>
+        <StatusBadge status={season.status} />
+        <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
+          {season.series_played} / {season.series_count} series played
+        </span>
+        {firstDate && (
+          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+            {firstDate}{lastDate && lastDate !== firstDate ? ` – ${lastDate}` : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Players roster */}
+      {(season.players || []).length > 0 && (
+        <div style={{ marginBottom: '1rem', display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {season.players.map((p, i) => (
+            <span key={i} style={{ fontSize: 12, padding: '3px 10px', borderRadius: 99, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', color: 'var(--color-text-secondary)' }}>
+              {p.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Standings */}
+      {seasonRooms === null && (
+        <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', marginBottom: '1rem' }}>Loading…</p>
+      )}
+      {seasonRooms !== null && seasonRooms.length > 0 && (
+        <StandingsTable rooms={seasonRooms} />
+      )}
+
+      {/* Series history */}
+      {[...seriesItems, ...standaloneItems].length > 0 && (
+        <div style={{ marginBottom: '1rem' }}>
+          <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 8 }}>Series history</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {seriesItems.map((item, idx) => {
+              const firstGame = item.rooms[0]
+              const lastGame  = item.rooms[item.rooms.length - 1]
+              const allDone   = item.rooms.every(r => r.phase === 'ended')
+              const dateStr   = new Date(firstGame.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+              const totalRounds = item.rooms.reduce((n, r) => n + (r.rounds || []).filter(rd => rd.winner || rd.draw).length, 0)
+              return (
+                <div key={item.seriesId} style={{ padding: '12px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-info)', borderRadius: 'var(--border-radius-md)' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span style={{ fontSize: 11, padding: '1px 6px', background: 'var(--color-background-info)', color: 'var(--color-text-info)', borderRadius: 99, border: '0.5px solid var(--color-border-info)', fontWeight: 500 }}>Series {idx + 1}</span>
+                      <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>{item.rooms.length} game{item.rooms.length !== 1 ? 's' : ''} · {totalRounds} rounds</span>
+                    </div>
+                    <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                      {!allDone && <span style={{ fontSize: 11, padding: '1px 6px', background: 'var(--color-background-warning)', color: 'var(--color-text-warning)', borderRadius: 99, border: '0.5px solid var(--color-border-warning)' }}>active</span>}
+                      {dateStr}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+            {standaloneItems.map((item, idx) => {
+              const r = item.room
+              const dateStr = new Date(r.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+              const rounds = (r.rounds || []).filter(rd => rd.winner || rd.draw).length
+              return (
+                <div key={r.id} style={{ padding: '12px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <span style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>{r.code} · {rounds} round{rounds !== 1 ? 's' : ''}</span>
+                    <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>{dateStr}</span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Active series notice */}
+      {anyActive && season.status === 'active' && (
+        <div style={{ padding: '12px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', marginBottom: '1rem' }}>
+          <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>
+            A series is currently in progress. Close it between series to continue the season or close early.
+          </p>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {canStartFirst && (
+        <div style={{ marginBottom: '1rem' }}>
+          <button style={btn('primary')} onClick={() => onStartSeries(season)}>
+            Start first series
+          </button>
+        </div>
+      )}
+
+      {canStartNext && (
+        <div style={{ marginBottom: '1rem' }}>
+          <button style={btn('primary')} onClick={() => onStartSeries(season)}>
+            Start next series ({season.series_played + 1} of {season.series_count})
+          </button>
+        </div>
+      )}
+
+      {canCloseEarly && !confirmClose && (
+        <button style={{ ...btn('ghost'), color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }} onClick={() => setConfirmClose(true)}>
+          Close season early
+        </button>
+      )}
+
+      {confirmClose && (
+        <div style={{ padding: '14px 16px', background: 'var(--color-background-danger)', border: '0.5px solid var(--color-border-danger)', borderRadius: 'var(--border-radius-md)' }}>
+          <p style={{ fontSize: 13, color: 'var(--color-text-danger)', margin: '0 0 12px' }}>
+            Close this season early? Standings and history are preserved. This cannot be undone.
+          </p>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button style={{ ...btn('ghost'), flex: 1, color: 'var(--color-text-danger)', borderColor: 'var(--color-border-danger)' }} onClick={handleCloseEarly} disabled={closing}>
+              {closing ? 'Closing…' : 'Yes, close season'}
+            </button>
+            <button style={{ ...btn('ghost'), flex: 1 }} onClick={() => setConfirmClose(false)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {season.status === 'ended' && (
+        <div style={{ padding: '10px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+          <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>This season is complete.</p>
+        </div>
+      )}
+    </Screen>
+  )
+}
+
+function CreateSeasonForm({ playerId, playerName, onBack, onCreate }) {
+  const [name, setName]                       = useState('')
+  const [players, setPlayers]                 = useState(playerName ? [{ name: playerName }] : [])
+  const [playerInput, setPlayerInput]         = useState('')
+  const [seriesCount, setSeriesCount]         = useState(3)
+  const [latestEvosOnly, setLatestEvosOnly]   = useState(false)
+  const [saving, setSaving]                   = useState(false)
+  const [error, setError]                     = useState(null)
+
+  function addPlayer() {
+    const trimmed = playerInput.trim()
+    if (!trimmed) return
+    if (players.some(p => p.name.toLowerCase() === trimmed.toLowerCase())) {
+      setPlayerInput('')
+      return
+    }
+    setPlayers(prev => [...prev, { name: trimmed }])
+    setPlayerInput('')
+  }
+
+  function removePlayer(idx) {
+    setPlayers(prev => prev.filter((_, i) => i !== idx))
+  }
+
+  async function handleCreate() {
+    if (!name.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      const season = {
+        id:                     uid(),
+        name:                   name.trim(),
+        league_id:              null,
+        owner_id:               playerId,
+        owner_name:             playerName,
+        status:                 'active',
+        series_count:           seriesCount,
+        series_played:          0,
+        latest_evolutions_only: latestEvosOnly,
+        players,
+      }
+      const saved = await createSeason(season)
+      onCreate(saved)
+    } catch (e) {
+      console.error('createSeason failed', e)
+      setError('Failed to create season. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Screen title="New season" onBack={onBack}>
+      <label style={lbl}>Season name</label>
+      <input
+        style={inp()}
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="e.g. Spring 2026"
+        autoFocus
+        onKeyDown={e => e.key === 'Enter' && handleCreate()}
+      />
+
+      <label style={{ ...lbl, marginBottom: 6 }}>Players</label>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
+        <input
+          style={{ ...inp(), margin: 0, flex: 1 }}
+          value={playerInput}
+          onChange={e => setPlayerInput(e.target.value)}
+          placeholder="Add a player name"
+          onKeyDown={e => e.key === 'Enter' && addPlayer()}
+        />
+        <button style={{ ...btn('ghost'), flexShrink: 0 }} onClick={addPlayer} disabled={!playerInput.trim()}>
+          Add
+        </button>
+      </div>
+      {players.length > 0 && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 16 }}>
+          {players.map((p, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 13, padding: '3px 8px 3px 10px', borderRadius: 99, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-primary)' }}>
+              {p.name}
+              <button onClick={() => removePlayer(i)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)', fontSize: 14, lineHeight: 1, padding: '0 2px' }}>✕</button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={{ marginBottom: '1.5rem' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 0', borderBottom: '0.5px solid var(--color-border-tertiary)' }}>
+          <div>
+            <div style={{ fontSize: 14, color: 'var(--color-text-primary)' }}>Series count</div>
+            <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 1 }}>How many series make up this season</div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0, marginLeft: 16 }}>
+            <button onClick={() => setSeriesCount(n => Math.max(1, n - 1))} disabled={seriesCount <= 1}
+              style={{ width: 28, height: 28, borderRadius: '50%', border: '0.5px solid var(--color-border-tertiary)', background: 'var(--color-background-tertiary)', color: 'var(--color-text-primary)', fontSize: 16, cursor: seriesCount <= 1 ? 'default' : 'pointer', opacity: seriesCount <= 1 ? 0.35 : 1, lineHeight: 1 }}>−</button>
+            <span style={{ fontSize: 15, fontWeight: 500, color: 'var(--color-text-primary)', minWidth: 18, textAlign: 'center' }}>{seriesCount}</span>
+            <button onClick={() => setSeriesCount(n => Math.min(12, n + 1))} disabled={seriesCount >= 12}
+              style={{ width: 28, height: 28, borderRadius: '50%', border: '0.5px solid var(--color-border-tertiary)', background: 'var(--color-background-tertiary)', color: 'var(--color-text-primary)', fontSize: 16, cursor: seriesCount >= 12 ? 'default' : 'pointer', opacity: seriesCount >= 12 ? 0.35 : 1, lineHeight: 1 }}>+</button>
+          </div>
+        </div>
+        <ToggleRow
+          label="Latest evolutions only"
+          description="Stored now — draft-time enforcement coming in a follow-up."
+          value={latestEvosOnly}
+          onToggle={() => setLatestEvosOnly(v => !v)}
+        />
+      </div>
+
+      {error && <p style={{ fontSize: 13, color: 'var(--color-text-danger)', marginBottom: 12 }}>{error}</p>}
+      <button style={btn('primary')} onClick={handleCreate} disabled={!name.trim() || saving}>
+        {saving ? 'Creating…' : 'Create season'}
+      </button>
+    </Screen>
+  )
+}
+
+function SeasonRow({ season, onSelect }) {
+  const dateStr = new Date(season.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+  return (
+    <button
+      onClick={() => onSelect(season)}
+      style={{ display: 'block', width: '100%', textAlign: 'left', padding: '14px 16px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-lg)', marginBottom: 10, cursor: 'pointer' }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 16, fontWeight: 500, color: 'var(--color-text-primary)' }}>{season.name}</span>
+          <StatusBadge status={season.status} />
+        </div>
+        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0, marginLeft: 8 }}>{dateStr}</span>
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
+        {season.series_played} / {season.series_count} series
+        {(season.players || []).length > 0 && ` · ${season.players.map(p => p.name).join(', ')}`}
+      </div>
+    </button>
+  )
+}
+
+export default function SeasonScreen({ playerId, playerName, onBack, onStartSeries }) {
+  const [view, setView]           = useState('list')
+  const [seasons, setSeasons]     = useState(null)
+  const [selected, setSelected]   = useState(null)
+
+  useEffect(() => {
+    if (!playerId) return
+    getSeasons(playerId).then(setSeasons)
+  }, [playerId])
+
+  function handleCreated(season) {
+    setSeasons(prev => [season, ...(prev || [])])
+    setSelected(season)
+    setView('detail')
+  }
+
+  function handleSelectSeason(season) {
+    setSelected(season)
+    setView('detail')
+  }
+
+  if (view === 'create') {
+    return (
+      <CreateSeasonForm
+        playerId={playerId}
+        playerName={playerName}
+        onBack={() => setView('list')}
+        onCreate={handleCreated}
+      />
+    )
+  }
+
+  if (view === 'detail' && selected) {
+    return (
+      <SeasonDetail
+        season={selected}
+        playerId={playerId}
+        onBack={() => { setSelected(null); setView('list') }}
+        onStartSeries={onStartSeries}
+      />
+    )
+  }
+
+  // List view
+  return (
+    <Screen
+      title="Seasons"
+      onBack={onBack}
+      right={
+        <button style={{ ...btn('ghost'), padding: '5px 12px', fontSize: 13 }} onClick={() => setView('create')}>
+          + New season
+        </button>
+      }
+    >
+      {seasons === null && <p style={{ fontSize: 14, color: 'var(--color-text-secondary)' }}>Loading…</p>}
+      {seasons !== null && seasons.length === 0 && (
+        <div style={{ textAlign: 'center', padding: '2rem 0' }}>
+          <p style={{ fontSize: 14, color: 'var(--color-text-secondary)', marginBottom: 16 }}>No seasons yet.</p>
+          <button style={{ ...btn(), display: 'inline-block', width: 'auto', padding: '10px 20px' }} onClick={() => setView('create')}>
+            Create your first season
+          </button>
+        </div>
+      )}
+      {(seasons || []).map(s => (
+        <SeasonRow key={s.id} season={s} onSelect={handleSelectSeason} />
+      ))}
+    </Screen>
+  )
+}

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1646,6 +1646,40 @@ export async function hasPlayerEncounteredArena(arenaId, playerId) {
   } catch (e) { console.error('hasPlayerEncounteredArena exception', e); return false }
 }
 
+// ─── Seasons ──────────────────────────────────────────────────────────────────
+
+export async function createSeason(season) {
+  const { data, error } = await supabase.from('seasons').insert(season).select().single()
+  if (error) throw error
+  return data
+}
+
+export async function getSeasons(ownerId) {
+  const { data, error } = await supabase.from('seasons').select('*').eq('owner_id', ownerId).order('created_at', { ascending: false })
+  if (error) { console.error('getSeasons error', error); return [] }
+  return data || []
+}
+
+export async function getSeason(id) {
+  const { data, error } = await supabase.from('seasons').select('*').eq('id', id).single()
+  if (error) { console.error('getSeason error', error); return null }
+  return data
+}
+
+export async function updateSeason(id, changes) {
+  const { data, error } = await supabase.from('seasons').update({ ...changes, updated_at: new Date().toISOString() }).eq('id', id).select().single()
+  if (error) throw error
+  return data
+}
+
+// Filter all rooms by seasonId — used to build season standings and series list.
+export async function getSeasonRooms(seasonId) {
+  const all = await slist()
+  return all.filter(r => r.seasonId === seasonId)
+}
+
+// ─── Tags ─────────────────────────────────────────────────────────────────────
+
 // All distinct tags across published combatants, groups, and arenas.
 // Returns [{tag, count}] sorted by frequency desc then alphabetical.
 export async function listAllDistinctTags() {

--- a/supabase/migrations/20260430_seasons_players.sql
+++ b/supabase/migrations/20260430_seasons_players.sql
@@ -1,0 +1,9 @@
+-- Migration: add players column to seasons table (issue #25)
+--
+-- The initial seasons migration omitted the player roster field declared in
+-- the issue spec. This adds it as a JSONB array of { name: string } objects.
+--
+-- Safe to re-run (idempotent).
+
+alter table seasons
+  add column if not exists players jsonb not null default '[]'::jsonb;


### PR DESCRIPTION
Closes #25

## What changed

- **`supabase/migrations/20260430_seasons_players.sql`** — adds `players jsonb` column to the `seasons` table (omitted from the initial schema migration)
- **`src/supabase.js`** — five new season functions: `createSeason`, `getSeasons`, `getSeason`, `updateSeason`, `getSeasonRooms` (filters `slist()` by `seasonId`)
- **`src/screens/SeasonScreen.jsx`** — new screen handling list, create form, and detail views:
  - Create form: name, player roster (add/remove by name), series count stepper (1–12), latest-evolutions-only toggle (stored; not enforced)
  - Detail: status badge, series_played/series_count progress, declared players roster, cumulative standings (W/D/L via `computeSeriesStandings`), series history list
  - Controls: "Start first series" (no rooms yet), "Start next series (N of M)" + "Close early" (between series), "Series in progress" notice (mid-series, controls locked), auto-close when `series_played` reaches `series_count` after last series ends
  - Early close: two-step confirm before writing `status: 'ended'`
- **`src/screens/CreateRoom.jsx`** — accepts optional `seasonId` prop; embeds it on the created room
- **`src/screens/ChroniclesScreen.jsx`** — adds "Seasons ↗" button in the header when `onSeasons` prop is provided
- **`src/App.jsx`** — imports `SeasonScreen`; adds `viewSeasons` + `pendingSeason` state; adds `handleSeasonStartSeries` (stores pending season, navigates to create) and `handleSeasonRoomCreated` (increments `series_played` in Supabase after room creation); wires CreateRoom to use season-aware `onCreated`/`onBack`/`seasonId` when context is present; threads `onSeasons` to Chronicles

## Test notes

- Create a season from The Chronicles → "Seasons ↗" — verify it appears in the list
- Tap "Start first series" — navigates to CreateRoom; after creating the room, check the room object has `seasonId` set
- Return to the season detail — standings show rounds from that game; series history shows the game
- After the series/game ends, come back to the season detail — "Start next series (2 of N)" appears
- Tap "Start next series" — `series_played` in the `seasons` table increments; new room carries `seasonId`
- Start and complete the final series — season auto-closes when detail loads after all rooms end
- "Close early" — confirm dialog appears; cancelling leaves season active; confirming sets status to 'ended'
- `latest_evolutions_only` stored on the season row but not enforced (deferred per spec)

## Backfill

None — new tables and new room field only. Existing rooms without `seasonId` are unaffected.