### PR TITLE
Voting engine

### DIFF
--- a/src/components/VotingPanel.jsx
+++ b/src/components/VotingPanel.jsx
@@ -1,0 +1,283 @@
+import { useState, useEffect } from 'react'
+import { btn } from '../styles.js'
+import { resolveVotingPhase } from '../gameLogic.js'
+import {
+  getAwardWithBallot,
+  getVotesForAward,
+  subscribeToAward,
+  lockInVote,
+  lockInAbstain,
+  advanceToRunoff,
+  resolveAward,
+} from '../supabase.js'
+
+// Shared voting engine component used for MVP (game level), series awards,
+// season awards, and any future voted award.
+//
+// Manages its own Supabase subscriptions and handles all phase transitions
+// (nomination → runoff → resolution). The parent provides the award ID and
+// nomination pool; VotingPanel drives the rest.
+//
+// Props:
+//   awardId    — ID of the pending award row (recipient_id null, awarded_at null)
+//   label      — display label for this award ('MVP', 'Best combatant of the series', …)
+//   nominees   — [{ id, name, type: 'combatant'|'player' }] — initial nomination pool
+//   voters     — [{ id, name }] — eligible voters
+//   playerId   — current player's ID
+//   isHost     — bool; only the host may close the ballot or trigger phase transitions
+//   onResolved — ({ outcome, winners: [{ id, name }] }) → called when award is decided
+//               outcome: 'winner' | 'co_award' | 'no_votes'
+export default function VotingPanel({ awardId, label, nominees, voters, playerId, isHost, onResolved }) {
+  const [award,        setAward]        = useState(null)
+  const [votes,        setVotes]        = useState([])
+  const [myNomineeId,  setMyNomineeId]  = useState(null)  // picked but not yet locked
+  const [submitting,   setSubmitting]   = useState(false)
+  const [resolved,     setResolved]     = useState(false)
+
+  // Load initial award state and any existing votes
+  useEffect(() => {
+    getAwardWithBallot(awardId).then(a => {
+      setAward(a)
+      // If already resolved when we load (edge case: re-mount after resolution)
+      if (a?.awarded_at) setResolved(true)
+    })
+    getVotesForAward(awardId).then(setVotes)
+  }, [awardId])
+
+  // Subscribe to award row updates (ballot_state and resolution changes)
+  useEffect(() => {
+    return subscribeToAward(awardId, updated => {
+      setAward(updated)
+      if (updated.awarded_at) setResolved(true)
+    })
+  }, [awardId])
+
+  // ── Derived ballot state ─────────────────────────────────────────────────
+
+  const ballotState      = award?.ballot_state || { phase: 'nomination', lockedVoterIds: [], runoffPool: null }
+  const phase            = ballotState.phase || 'nomination'
+  const lockedVoterIds   = ballotState.lockedVoterIds || []
+  const runoffPool       = ballotState.runoffPool || null
+  const activeNominees   = phase === 'runoff' && runoffPool ? runoffPool : nominees
+  const isLockedIn       = lockedVoterIds.includes(playerId)
+  const myVote           = votes.find(v => v.voter_id === playerId && v.phase === phase)
+
+  // ── Resolution check (host only to avoid write races) ────────────────────
+
+  useEffect(() => {
+    if (!isHost || resolved || !award || award.awarded_at) return
+
+    const phaseVotes = votes.filter(v => v.phase === phase)
+    const resolution = resolveVotingPhase({
+      votes:          phaseVotes,
+      voterCount:     voters.length,
+      lockedVoterIds,
+      phase,
+      hostClose:      false,
+      runoffPool:     runoffPool?.map(n => n.id) || null,
+    })
+
+    if (resolution.outcome === 'pending') return
+
+    if (resolution.outcome === 'runoff') {
+      const pool = resolution.winnerIds.map(id => {
+        const n = nominees.find(x => x.id === id)
+        return n || { id, name: id, type: 'combatant' }
+      })
+      advanceToRunoff(awardId, pool).catch(console.error)
+      return
+    }
+
+    handleResolution(resolution)
+  }, [votes, award, phase, lockedVoterIds, resolved, isHost])
+
+  // ── Actions ──────────────────────────────────────────────────────────────
+
+  async function handleLockIn() {
+    if (!myNomineeId || submitting || isLockedIn) return
+    setSubmitting(true)
+    const nominee = activeNominees.find(n => n.id === myNomineeId)
+    if (!nominee) { setSubmitting(false); return }
+    const voter = voters.find(v => v.id === playerId)
+    await lockInVote({
+      awardId, voterId: playerId, voterName: voter?.name || '?',
+      nomineeId: myNomineeId, nomineeType: nominee.type, nomineeName: nominee.name,
+      phase,
+    })
+    // Update local votes so the resolution effect runs immediately on the host
+    const newVote = {
+      award_id: awardId, voter_id: playerId, voter_name: voter?.name || '?',
+      nominee_id: myNomineeId, nominee_type: nominee.type, nominee_name: nominee.name,
+      phase, cast_at: new Date().toISOString(),
+    }
+    setVotes(prev => [...prev, newVote])
+    setSubmitting(false)
+  }
+
+  async function handleAbstain() {
+    if (submitting || isLockedIn) return
+    setSubmitting(true)
+    await lockInAbstain(awardId, playerId)
+    setSubmitting(false)
+  }
+
+  async function handleHostClose() {
+    if (!isHost || resolved) return
+    const phaseVotes = votes.filter(v => v.phase === phase)
+    const resolution = resolveVotingPhase({
+      votes:          phaseVotes,
+      voterCount:     voters.length,
+      lockedVoterIds,
+      phase,
+      hostClose:      true,
+      runoffPool:     runoffPool?.map(n => n.id) || null,
+    })
+    handleResolution(resolution)
+  }
+
+  async function handleResolution(resolution) {
+    if (resolved) return
+    setResolved(true)
+    const { outcome, winnerIds } = resolution
+
+    if (outcome === 'no_votes') {
+      // No nominations — clear ballot_state and notify parent (no award written)
+      onResolved({ outcome: 'no_votes', winners: [] })
+      return
+    }
+
+    const winners = winnerIds.map(id => {
+      const n = activeNominees.find(x => x.id === id)
+      return n || { id, name: id, type: 'combatant' }
+    })
+    await resolveAward({ awardId, winners, coAward: outcome === 'co_award' })
+    onResolved({ outcome, winners })
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  if (!award) return null
+
+  // After resolution: show the result
+  if (resolved && award.awarded_at) {
+    return <VotingResult award={award} label={label} nominees={nominees} />
+  }
+
+  const lockedCount = lockedVoterIds.length
+  const totalVoters = voters.length
+
+  return (
+    <div style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 10 }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+          {phase === 'runoff' ? `${label} — Tiebreaker` : label}
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+          {lockedCount} of {totalVoters} locked in
+        </div>
+      </div>
+
+      {/* Live status strip — names visible, picks hidden */}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 14 }}>
+        {voters.map(v => {
+          const didLockIn = lockedVoterIds.includes(v.id)
+          return (
+            <span
+              key={v.id}
+              style={{
+                fontSize: 11, padding: '2px 8px', borderRadius: 99,
+                background:   didLockIn ? 'var(--color-background-success)' : 'var(--color-background-tertiary)',
+                color:        didLockIn ? 'var(--color-text-success)'       : 'var(--color-text-tertiary)',
+                border:       didLockIn ? '0.5px solid var(--color-border-success)' : '0.5px solid var(--color-border-tertiary)',
+                fontWeight:   didLockIn ? 500 : 400,
+              }}
+            >
+              {v.name}
+            </span>
+          )
+        })}
+      </div>
+
+      {/* Nomination pool */}
+      {!isLockedIn && (
+        <>
+          <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginBottom: 8 }}>
+            {phase === 'runoff' ? 'It\'s a tie — vote again:' : 'Your nomination:'}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 10 }}>
+            {activeNominees.map(n => {
+              const selected = myNomineeId === n.id
+              return (
+                <button
+                  key={n.id}
+                  onClick={() => setMyNomineeId(selected ? null : n.id)}
+                  style={{ ...btn(selected ? 'primary' : 'ghost'), textAlign: 'left', fontSize: 14, padding: '9px 13px' }}
+                >
+                  {selected ? '✓ ' : ''}{n.name}
+                </button>
+              )
+            })}
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              onClick={handleLockIn}
+              disabled={!myNomineeId || submitting}
+              style={{ ...btn('primary'), flex: 2, fontSize: 13, padding: '9px' }}
+            >
+              {submitting ? 'Locking in…' : 'Lock in'}
+            </button>
+            <button
+              onClick={handleAbstain}
+              disabled={submitting}
+              style={{ ...btn('ghost'), flex: 1, fontSize: 13, padding: '9px' }}
+            >
+              Abstain
+            </button>
+          </div>
+        </>
+      )}
+
+      {/* Locked-in confirmation for the current player */}
+      {isLockedIn && !resolved && (
+        <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', textAlign: 'center', margin: '4px 0' }}>
+          {myVote ? `You nominated ${myVote.nominee_name}.` : 'You abstained.'} Waiting for others…
+        </p>
+      )}
+
+      {/* Host controls */}
+      {isHost && (
+        <button
+          onClick={handleHostClose}
+          disabled={resolved}
+          style={{ ...btn('ghost'), width: '100%', fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 10 }}
+        >
+          Close ballot early
+        </button>
+      )}
+    </div>
+  )
+}
+
+// Read-only result display shown after the award is resolved.
+function VotingResult({ award, label, nominees }) {
+  const recipientName = award.recipient_name || '?'
+  const isCoAward = award.co_award
+
+  return (
+    <div style={{ padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-success)' }}>
+      <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-success)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+        {isCoAward ? `${label} — co-award` : label}
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+        {recipientName}
+      </div>
+      {isCoAward && (
+        <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+          Shared award — all nominees tied
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -1248,6 +1248,57 @@ export function groupRoomsForHistory(rooms) {
   return items.sort((a, b) => b.latestAt - a.latestAt)
 }
 
+// ─── Voting engine ────────────────────────────────────────────────────────────
+
+/**
+ * Pure voting resolution function. Determines the outcome of a ballot phase.
+ * Called by VotingPanel on every state change and used directly in unit tests.
+ *
+ * @param {object}   params
+ * @param {{ nomineeId: string }[]} params.votes          — actual nominations cast; abstains are absent
+ * @param {number}                  params.voterCount     — total eligible voters
+ * @param {string[]}                params.lockedVoterIds — voters who locked in (voted OR abstained)
+ * @param {'nomination'|'runoff'}   params.phase
+ * @param {boolean}                 params.hostClose      — true when host forces early resolution
+ * @param {string[]|null}           [params.runoffPool]   — nominee IDs active in the runoff phase;
+ *                                                          required when phase is 'runoff' and hostClose is true
+ *
+ * @returns {{ outcome: string, winnerIds: string[] }}
+ *   pending   — not everyone has locked in and host hasn't closed; nothing to resolve yet
+ *   winner    — one clear winner; winnerIds has exactly one entry
+ *   runoff    — nomination-phase tie with no host close; winnerIds lists the tied nominees
+ *   co_award  — forced tie resolution; winnerIds lists all co-recipients
+ *   no_votes  — no nominations were cast; no award
+ */
+export function resolveVotingPhase({ votes, voterCount, lockedVoterIds, phase, hostClose, runoffPool }) {
+  const allLockedIn = lockedVoterIds.length >= voterCount
+  if (!allLockedIn && !hostClose) return { outcome: 'pending', winnerIds: [] }
+
+  // Closing the runoff early co-awards all runoff nominees regardless of current votes.
+  // (This differs from closing nomination early, which resolves with current votes.)
+  if (phase === 'runoff' && hostClose) {
+    const ids = runoffPool?.length ? runoffPool : []
+    return ids.length ? { outcome: 'co_award', winnerIds: ids } : { outcome: 'no_votes', winnerIds: [] }
+  }
+
+  const tally = {}
+  for (const v of votes) {
+    tally[v.nomineeId] = (tally[v.nomineeId] || 0) + 1
+  }
+
+  if (Object.keys(tally).length === 0) return { outcome: 'no_votes', winnerIds: [] }
+
+  const maxVotes = Math.max(...Object.values(tally))
+  const leaders  = Object.keys(tally).filter(id => tally[id] === maxVotes)
+
+  if (leaders.length === 1) return { outcome: 'winner', winnerIds: leaders }
+
+  // Tie: open runoff only during nomination without a host close.
+  // Any other tie context (runoff deadlock, nomination host close) resolves as co-award.
+  if (phase === 'nomination' && !hostClose) return { outcome: 'runoff', winnerIds: leaders }
+  return { outcome: 'co_award', winnerIds: leaders }
+}
+
 // ─── Achievement superlatives ─────────────────────────────────────────────────
 
 /**

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -32,6 +32,7 @@ import {
   computeSuperlatives,
   getCombatantsToPublish,
   kickPlayerFromRoom,
+  resolveVotingPhase,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -2811,5 +2812,154 @@ describe('computeSuperlatives', () => {
       expect(s.label.length).toBeGreaterThan(0)
       expect(s.tooltip.length).toBeGreaterThan(0)
     })
+  })
+})
+
+// ─── resolveVotingPhase ───────────────────────────────────────────────────────
+
+describe('resolveVotingPhase', () => {
+  function votes(...nomineeIds) {
+    return nomineeIds.map(id => ({ nomineeId: id }))
+  }
+
+  it('returns pending when not all voters have locked in and host has not closed', () => {
+    expect(resolveVotingPhase({
+      votes:          votes('c1'),
+      voterCount:     3,
+      lockedVoterIds: ['p1'],
+      phase:          'nomination',
+      hostClose:      false,
+    }).outcome).toBe('pending')
+  })
+
+  it('returns pending with zero votes if nobody has acted', () => {
+    expect(resolveVotingPhase({
+      votes:          [],
+      voterCount:     3,
+      lockedVoterIds: [],
+      phase:          'nomination',
+      hostClose:      false,
+    }).outcome).toBe('pending')
+  })
+
+  it('returns winner when there is a clear majority after all lock in', () => {
+    const result = resolveVotingPhase({
+      votes:          votes('c1', 'c1', 'c2'),
+      voterCount:     3,
+      lockedVoterIds: ['p1', 'p2', 'p3'],
+      phase:          'nomination',
+      hostClose:      false,
+    })
+    expect(result.outcome).toBe('winner')
+    expect(result.winnerIds).toEqual(['c1'])
+  })
+
+  it('returns runoff on a nomination-phase tie when all have locked in', () => {
+    const result = resolveVotingPhase({
+      votes:          votes('c1', 'c2'),
+      voterCount:     2,
+      lockedVoterIds: ['p1', 'p2'],
+      phase:          'nomination',
+      hostClose:      false,
+    })
+    expect(result.outcome).toBe('runoff')
+    expect(result.winnerIds).toHaveLength(2)
+    expect(result.winnerIds).toContain('c1')
+    expect(result.winnerIds).toContain('c2')
+  })
+
+  it('returns co_award on a runoff-phase tie after all lock in (deadlock)', () => {
+    const result = resolveVotingPhase({
+      votes:          votes('c1', 'c2'),
+      voterCount:     2,
+      lockedVoterIds: ['p1', 'p2'],
+      phase:          'runoff',
+      hostClose:      false,
+    })
+    expect(result.outcome).toBe('co_award')
+    expect(result.winnerIds).toContain('c1')
+    expect(result.winnerIds).toContain('c2')
+  })
+
+  it('resolves early with winner on host close (nomination phase, clear leader)', () => {
+    const result = resolveVotingPhase({
+      votes:          votes('c1', 'c1'),
+      voterCount:     4,
+      lockedVoterIds: ['p1', 'p2'],
+      phase:          'nomination',
+      hostClose:      true,
+    })
+    expect(result.outcome).toBe('winner')
+    expect(result.winnerIds).toEqual(['c1'])
+  })
+
+  it('returns co_award on tied host close during nomination', () => {
+    const result = resolveVotingPhase({
+      votes:          votes('c1', 'c2'),
+      voterCount:     4,
+      lockedVoterIds: ['p1', 'p2'],
+      phase:          'nomination',
+      hostClose:      true,
+    })
+    expect(result.outcome).toBe('co_award')
+    expect(result.winnerIds).toContain('c1')
+    expect(result.winnerIds).toContain('c2')
+  })
+
+  it('returns co_award on host close during runoff with all runoff nominees', () => {
+    // c1 is "leading" with one vote but host closes — both runoff nominees co-award
+    const result = resolveVotingPhase({
+      votes:          votes('c1'),
+      voterCount:     3,
+      lockedVoterIds: ['p1'],
+      phase:          'runoff',
+      hostClose:      true,
+      runoffPool:     ['c1', 'c2'],
+    })
+    expect(result.outcome).toBe('co_award')
+    expect(result.winnerIds).toContain('c1')
+    expect(result.winnerIds).toContain('c2')
+  })
+
+  it('returns no_votes when host closes with no nominations at all', () => {
+    expect(resolveVotingPhase({
+      votes:          [],
+      voterCount:     2,
+      lockedVoterIds: ['p1', 'p2'],
+      phase:          'nomination',
+      hostClose:      true,
+    }).outcome).toBe('no_votes')
+  })
+
+  it('abstainers count toward allLockedIn without contributing a vote', () => {
+    // p1 voted c1, p2 and p3 abstained — c1 is the winner
+    const result = resolveVotingPhase({
+      votes:          votes('c1'),
+      voterCount:     3,
+      lockedVoterIds: ['p1', 'p2', 'p3'],
+      phase:          'nomination',
+      hostClose:      false,
+    })
+    expect(result.outcome).toBe('winner')
+    expect(result.winnerIds).toEqual(['c1'])
+  })
+
+  it('returns three-way co_award when three nominees are tied', () => {
+    const result = resolveVotingPhase({
+      votes:          votes('c1', 'c2', 'c3'),
+      voterCount:     3,
+      lockedVoterIds: ['p1', 'p2', 'p3'],
+      phase:          'runoff',
+      hostClose:      false,
+    })
+    expect(result.outcome).toBe('co_award')
+    expect(result.winnerIds).toHaveLength(3)
+  })
+
+  it('winnerIds is empty for pending and no_votes outcomes', () => {
+    const pending = resolveVotingPhase({ votes: [], voterCount: 2, lockedVoterIds: [], phase: 'nomination', hostClose: false })
+    expect(pending.winnerIds).toEqual([])
+    const noVotes = resolveVotingPhase({ votes: [], voterCount: 2, lockedVoterIds: ['p1', 'p2'], phase: 'nomination', hostClose: false })
+    expect(noVotes.winnerIds).toEqual([])
   })
 })

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1678,6 +1678,119 @@ export async function getSeasonRooms(seasonId) {
   return all.filter(r => r.seasonId === seasonId)
 }
 
+// ─── Awards & votes ───────────────────────────────────────────────────────────
+
+// Insert a pending award row. ballot_state should be initialized by the caller:
+//   { phase: 'nomination', lockedVoterIds: [], runoffPool: null }
+export async function createPendingAward(award) {
+  const { data, error } = await supabase.from('awards').insert(award).select().single()
+  if (error) throw error
+  return data
+}
+
+export async function getAwardWithBallot(awardId) {
+  const { data, error } = await supabase.from('awards').select('*').eq('id', awardId).single()
+  if (error) { console.error('getAwardWithBallot error', error); return null }
+  return data
+}
+
+export async function getVotesForAward(awardId) {
+  const { data, error } = await supabase.from('votes').select('*').eq('award_id', awardId)
+  if (error) { console.error('getVotesForAward error', error); return [] }
+  return data || []
+}
+
+// Subscribe to updates on an award row (ballot_state changes, resolution).
+// Returns an unsubscribe function for useEffect cleanup.
+export function subscribeToAward(awardId, onUpdate) {
+  const channel = supabase
+    .channel('award-' + awardId)
+    .on(
+      'postgres_changes',
+      { event: 'UPDATE', schema: 'public', table: 'awards', filter: `id=eq.${awardId}` },
+      payload => { if (payload.new) onUpdate(payload.new) }
+    )
+    .subscribe()
+  return () => supabase.removeChannel(channel)
+}
+
+// Lock in a nomination. Inserts a vote record and appends voterId to ballot_state.lockedVoterIds.
+export async function lockInVote({ awardId, voterId, voterName, nomineeId, nomineeType, nomineeName, phase }) {
+  await supabase.from('votes').insert({
+    id: genId(), award_id: awardId, voter_id: voterId, voter_name: voterName,
+    nominee_id: nomineeId, nominee_type: nomineeType, nominee_name: nomineeName,
+    phase, cast_at: new Date().toISOString(),
+  })
+  const award = await getAwardWithBallot(awardId)
+  if (!award) return
+  const bs = award.ballot_state || { phase, lockedVoterIds: [], runoffPool: null }
+  const lockedVoterIds = [...new Set([...(bs.lockedVoterIds || []), voterId])]
+  await supabase.from('awards').update({
+    ballot_state: { ...bs, lockedVoterIds },
+    updated_at: new Date().toISOString(),
+  }).eq('id', awardId)
+}
+
+// Record an abstain — adds voterId to lockedVoterIds without inserting a vote record.
+export async function lockInAbstain(awardId, voterId) {
+  const award = await getAwardWithBallot(awardId)
+  if (!award) return
+  const bs = award.ballot_state || { phase: 'nomination', lockedVoterIds: [], runoffPool: null }
+  const lockedVoterIds = [...new Set([...(bs.lockedVoterIds || []), voterId])]
+  await supabase.from('awards').update({
+    ballot_state: { ...bs, lockedVoterIds },
+    updated_at: new Date().toISOString(),
+  }).eq('id', awardId)
+}
+
+// Transition a ballot from nomination to runoff.
+// runoffPool is [{ id, name, type }] — the tied nominees who advance to runoff.
+export async function advanceToRunoff(awardId, runoffPool) {
+  await supabase.from('awards').update({
+    ballot_state: { phase: 'runoff', lockedVoterIds: [], runoffPool },
+    updated_at: new Date().toISOString(),
+  }).eq('id', awardId)
+}
+
+// Resolve an award. Updates the pending row with the first winner and inserts
+// additional rows for co-winners. Clears ballot_state on all rows.
+//
+// winners is [{ id, name, type }] — the resolved recipients.
+// coAward is true when more than one recipient shares the award.
+export async function resolveAward({ awardId, winners, coAward }) {
+  const award = await getAwardWithBallot(awardId)
+  if (!award) return
+  const now = new Date().toISOString()
+  const isCoAward = coAward || winners.length > 1
+
+  await supabase.from('awards').update({
+    recipient_id:   winners[0].id,
+    recipient_name: winners[0].name,
+    co_award:       isCoAward,
+    awarded_at:     now,
+    ballot_state:   null,
+    updated_at:     now,
+  }).eq('id', awardId)
+
+  for (let i = 1; i < winners.length; i++) {
+    await supabase.from('awards').insert({
+      id:             genId(),
+      type:           award.type,
+      layer:          award.layer,
+      scope_id:       award.scope_id,
+      scope_type:     award.scope_type,
+      recipient_type: award.recipient_type,
+      recipient_id:   winners[i].id,
+      recipient_name: winners[i].name,
+      co_award:       true,
+      awarded_at:     now,
+      ballot_state:   null,
+      created_at:     now,
+      updated_at:     now,
+    })
+  }
+}
+
 // ─── Tags ─────────────────────────────────────────────────────────────────────
 
 // All distinct tags across published combatants, groups, and arenas.

--- a/supabase/migrations/20260501_awards_ballot_state.sql
+++ b/supabase/migrations/20260501_awards_ballot_state.sql
@@ -1,0 +1,19 @@
+-- Migration: ballot_state column on awards (issue #26)
+--
+-- The ballot_state column tracks live voting progress while a ballot is open.
+-- It is set when the ballot opens and cleared to null on resolution —
+-- the votes and awards tables are the permanent record.
+--
+--   ballot_state jsonb — nullable; present while the ballot is open
+--     phase            — 'nomination' | 'runoff'
+--     lockedVoterIds   — voter IDs who have locked in (voted or explicitly abstained)
+--     runoffPool       — [{ id, name, type }] | null — populated on runoff transition
+--
+-- Safe to re-run (idempotent).
+
+alter table awards add column if not exists ballot_state jsonb;
+
+-- Enable realtime for live ballot status strip (subscription on award row updates)
+-- and vote insert events.
+alter publication supabase_realtime add table awards;
+alter publication supabase_realtime add table votes;


### PR DESCRIPTION
Closes #26

## What changed

- **`resolveVotingPhase`** in `gameLogic.js` — pure function handling all four resolution paths: clear winner, nomination tie → runoff, runoff deadlock → co-award, runoff host close → co-award all runoff nominees. Fully unit tested (13 cases).

- **`VotingPanel`** component (`src/components/VotingPanel.jsx`) — shared UI used by all voted awards. Takes an `awardId`, `nominees`, `voters`, and `onResolved` callback. Manages its own Supabase subscriptions. Handles nomination → runoff phase transitions automatically on the host client. Shows the live status strip (names visible, picks hidden) via `ballot_state.lockedVoterIds`.

- **Supabase helpers** — `createPendingAward`, `getAwardWithBallot`, `getVotesForAward`, `subscribeToAward`, `lockInVote`, `lockInAbstain`, `advanceToRunoff`, `resolveAward`.

- **Migration** `20260501_awards_ballot_state.sql` — adds `ballot_state jsonb` to the `awards` table to track live voting progress (phase, locked-in voter IDs, runoff pool). Cleared to null on resolution; the `votes` and `awards` tables remain the permanent record. Also enables realtime on `awards` and `votes` tables.

## Resolution rules implemented

| Situation | Outcome |
|---|---|
| All locked in, one clear leader | `winner` |
| All locked in, nomination-phase tie | `runoff` (advances phase) |
| All locked in, runoff deadlock | `co_award` all runoff nominees |
| Host closes nomination early, clear leader | `winner` |
| Host closes nomination early, tied | `co_award` |
| Host closes during runoff | `co_award` all runoff nominees |
| Host closes with no nominations | `no_votes` (no award written) |

## Test notes

Run `npx vitest run` — all 730 tests pass. The new `resolveVotingPhase` suite covers all resolution paths including abstainer semantics and three-way ties.

Issues #27–#29 wire this engine into game-level MVP, series awards, and season awards respectively.