### PR TITLE
Awards: game-level MVP

### DIFF
--- a/src/components/VotingPanel.jsx
+++ b/src/components/VotingPanel.jsx
@@ -146,12 +146,19 @@ export default function VotingPanel({ awardId, label, nominees, voters, playerId
       return
     }
 
+    // Tally votes in the final phase so callers can compute vote share.
+    const finalPhaseVotes = votes.filter(v => v.phase === phase)
+    const votesByNomineeId = {}
+    finalPhaseVotes.forEach(v => {
+      votesByNomineeId[v.nominee_id] = (votesByNomineeId[v.nominee_id] || 0) + 1
+    })
+
     const winners = winnerIds.map(id => {
       const n = activeNominees.find(x => x.id === id)
       return n || { id, name: id, type: 'combatant' }
     })
     await resolveAward({ awardId, winners, coAward: outcome === 'co_award' })
-    onResolved({ outcome, winners })
+    onResolved({ outcome, winners, votesByNomineeId })
   }
 
   // ── Render ───────────────────────────────────────────────────────────────

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -3,7 +3,8 @@ import DevBanner from '../components/DevBanner.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant, getPlaylistForDelivery } from '../supabase.js'
+import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant, getPlaylistForDelivery, createPendingAward, appendMvpRecord } from '../supabase.js'
+import VotingPanel from '../components/VotingPanel.jsx'
 import { uid, canUndoLastRound, undoRound, tallyReactions, normalizeRoomSettings } from '../gameLogic.js'
 
 // Inline form for evolving the current arena after a round resolves.
@@ -61,6 +62,24 @@ function ArenaEvolveForm({ currentArena, onSubmit, onCancel, error, submitting }
   )
 }
 
+function getMvpNominees(room, pool) {
+  if (pool === 'full') {
+    const seen = new Set()
+    return Object.values(room.combatants).flat()
+      .filter(c => { if (seen.has(c.id)) return false; seen.add(c.id); return true })
+      .map(c => ({ id: c.id, name: c.name, type: 'combatant' }))
+  }
+  const seen = new Set()
+  const winners = []
+  for (const rd of room.rounds) {
+    if (rd.winner && !seen.has(rd.winner.id)) {
+      seen.add(rd.winner.id)
+      winners.push({ id: rd.winner.id, name: rd.winner.name, type: 'combatant' })
+    }
+  }
+  return winners
+}
+
 export default function BattleScreen({ room: init, playerId, setRoom, onVote, onChronicles, onHome, onNextGame, onRejoinNextGame }) {
   const [room, setLocal] = useState(init)
   const [confirmUndo, setConfirmUndo] = useState(false)
@@ -73,6 +92,9 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
   const [arenaEvolveFlow, setArenaEvolveFlow] = useState(null)
   const [arenaEvolveError, setArenaEvolveError] = useState(null)
   const [arenaEvolving, setArenaEvolving] = useState(false)
+  // MVP vote: 'winners' | 'full' — pool selection before vote starts
+  const [mvpPoolMode, setMvpPoolMode] = useState('winners')
+  const [mvpStarting, setMvpStarting] = useState(false)
   const prevRoundRef = useRef(init.currentRound)
   const undoTimerRef = useRef(null)
 
@@ -157,6 +179,40 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
     await sset('room:' + r.id, updated)
     setLocal(updated); setRoom(updated)
     onHome()
+  }
+
+  async function startMvpVote() {
+    setMvpStarting(true)
+    const r = await sget('room:' + room.id)
+    if (!r || r.mvpVote) { setMvpStarting(false); return }
+    const awardId = uid()
+    const now = new Date().toISOString()
+    await createPendingAward({
+      id:             awardId,
+      type:           'mvp',
+      layer:          'game',
+      scope_id:       r.id,
+      scope_type:     'game',
+      recipient_type: 'combatant',
+      ballot_state:   { phase: 'nomination', lockedVoterIds: [], runoffPool: null },
+      created_at:     now,
+      updated_at:     now,
+    })
+    const updated = { ...r, mvpVote: { awardId, pool: mvpPoolMode } }
+    await sset('room:' + r.id, updated)
+    setLocal(updated); setRoom(updated)
+    setMvpStarting(false)
+  }
+
+  async function handleMvpResolved({ outcome, winners, votesByNomineeId }) {
+    if (outcome === 'no_votes' || !winners.length) return
+    const totalVotes = Object.values(votesByNomineeId || {}).reduce((s, n) => s + n, 0)
+    const coMvp = outcome === 'co_award'
+    for (const winner of winners) {
+      const winnerVotes = votesByNomineeId?.[winner.id] || 0
+      const voteShare = totalVotes > 0 ? Math.round(winnerVotes / totalVotes * 100) : 0
+      await appendMvpRecord(winner.id, { gameCode: room.code, voteShare, coMvp })
+    }
   }
 
   async function undoLastRound() {
@@ -414,6 +470,26 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
             <h3 style={{ fontSize: 18, fontWeight: 500, margin: '0 0 8px', color: 'var(--color-text-primary)' }}>Game complete!</h3>
             <p style={{ color: 'var(--color-text-secondary)', fontSize: 14, margin: 0 }}>All {totalRounds} rounds fought.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 16 }}>
+
+              {/* ── MVP voting panel (all players once vote is open) ─────── */}
+              {room.mvpVote && (() => {
+                const { awardId, pool } = room.mvpVote
+                const nominees = getMvpNominees(room, pool)
+                const voters   = room.players.filter(p => !p.isBot).map(p => ({ id: p.id, name: p.name }))
+                return (
+                  <VotingPanel
+                    key={awardId}
+                    awardId={awardId}
+                    label="MVP"
+                    nominees={nominees}
+                    voters={voters}
+                    playerId={playerId}
+                    isHost={isHost}
+                    onResolved={handleMvpResolved}
+                  />
+                )
+              })()}
+
               {isHost && (
                 <>
                   {/* Arena evolution on the final round — records the variant but no future rounds benefit */}
@@ -438,6 +514,30 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
                       )}
                     </>
                   )}
+                  {!arenaEvolveFlow && !room.mvpVote && (
+                    /* MVP vote setup — optional; host picks pool then starts */
+                    <div style={{ textAlign: 'left', padding: '12px 14px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-md)', border: '0.5px solid var(--color-border-tertiary)' }}>
+                      <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>MVP vote (optional)</div>
+                      <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
+                        {[['winners', 'Round winners'], ['full', 'Full roster']].map(([val, lbl]) => (
+                          <button
+                            key={val}
+                            onClick={() => setMvpPoolMode(val)}
+                            style={{ ...btn(mvpPoolMode === val ? 'primary' : 'ghost'), flex: 1, fontSize: 12, padding: '6px' }}
+                          >
+                            {lbl}
+                          </button>
+                        ))}
+                      </div>
+                      <button
+                        onClick={startMvpVote}
+                        disabled={mvpStarting}
+                        style={{ ...btn('ghost'), width: '100%', fontSize: 13 }}
+                      >
+                        {mvpStarting ? 'Opening vote…' : 'Start MVP vote'}
+                      </button>
+                    </div>
+                  )}
                   {!arenaEvolveFlow && (
                     <>
                       <button style={btn('primary')} onClick={completeGame}>Complete game ✓</button>
@@ -452,7 +552,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
                   )}
                 </>
               )}
-              {!isHost && (
+              {!isHost && !room.mvpVote && (
                 <>
                   <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Waiting for host to start next game…</p>
                   <div style={{ display: 'flex', gap: 8 }}>
@@ -460,6 +560,12 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
                     <button style={btn()} onClick={onHome}>Back to home</button>
                   </div>
                 </>
+              )}
+              {!isHost && room.mvpVote && (
+                <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+                  <button style={{ ...btn('ghost'), flex: 1 }} onClick={onChronicles}>The Chronicles</button>
+                  <button style={{ ...btn('ghost'), flex: 1 }} onClick={onHome}>Back to home</button>
+                </div>
               )}
             </div>
           </div>

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -457,6 +457,23 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
         </div>
       )}
 
+      {/* ── MVP record ───────────────────────────────────────────────────── */}
+      {(c.mvp_record || []).length > 0 && (
+        <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+          <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 10px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            MVP
+          </h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {(c.mvp_record || []).map((entry, i) => (
+              <div key={i} style={{ fontSize: 13, color: 'var(--color-text-primary)' }}>
+                MVP in <span style={{ fontWeight: 500 }}>{entry.gameCode}</span>
+                <span style={{ color: 'var(--color-text-tertiary)', marginLeft: 6 }}>— {entry.voteShare}% of the vote{entry.coMvp ? ' (co-MVP)' : ''}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* ── Bio ──────────────────────────────────────────────────────────── */}
       <div style={{ marginBottom: '1.5rem' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1791,6 +1791,18 @@ export async function resolveAward({ awardId, winners, coAward }) {
   }
 }
 
+// Append a single entry to a combatant's mvp_record.
+// entry: { gameCode, voteShare, coMvp }
+export async function appendMvpRecord(combatantId, entry) {
+  const { data, error: fetchError } = await supabase
+    .from('combatants').select('mvp_record').eq('id', combatantId).single()
+  if (fetchError) { console.error('appendMvpRecord fetch', fetchError); return }
+  const current = data?.mvp_record || []
+  const { error } = await supabase.from('combatants')
+    .update({ mvp_record: [...current, entry] }).eq('id', combatantId)
+  if (error) console.error('appendMvpRecord update', error)
+}
+
 // ─── Tags ─────────────────────────────────────────────────────────────────────
 
 // All distinct tags across published combatants, groups, and arenas.


### PR DESCRIPTION
Closes #27

## What changed
- **`supabase.js`**: Added `appendMvpRecord(combatantId, entry)` — appends `{ gameCode, voteShare, coMvp }` to a combatant's `mvp_record` array.
- **`VotingPanel.jsx`**: Extended `onResolved` callback to include `votesByNomineeId` (final-phase vote tally), enabling callers to compute vote share.
- **`BattleScreen.jsx`**: After the final round, the host sees an optional "MVP vote" setup block with a pool toggle (Round winners / Full roster). Clicking "Start MVP vote" creates a pending award in Supabase and writes `room.mvpVote` to the room — all connected players see `VotingPanel` mount automatically via the room subscription. On resolution, `mvp_record` is appended for each winner with game code, vote share %, and co-MVP flag. "Complete game ✓" remains available at all times (host may complete without running MVP).
- **`GlobalCombatantDetail.jsx`**: Displays `mvp_record` entries in The Cast — "MVP in [game code] — [X]% of the vote (co-MVP)" per entry.

No migration needed — `mvp_record jsonb default '[]'` already exists on the combatants table from migration `20260414_combatants_status_source_tags_mvp.sql`.

## Test notes
- Start a game, play all rounds, reach "Game complete!"
- Host: toggle between "Round winners" and "Full roster" — starts MVP vote
- Non-host players: VotingPanel appears automatically; vote or abstain
- After all players lock in (or host uses "Close ballot early"): winner is shown, `mvp_record` is updated on the combatant in Supabase
- Navigate to The Cast → combatant detail → MVP section shows the entry
- Verify co-MVP works: with 2 voters, each votes different — both get the co-award entry
- Skip MVP: click "Complete game ✓" without starting a vote — game ends normally