### PR TITLE
Awards: season-level voted awards

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -1363,10 +1363,10 @@ export function computeSuperlatives(c, h2h) {
   return superlatives
 }
 
-// ─── Series award nomination pools ────────────────────────────────────────────
+// ─── Award nomination pools ───────────────────────────────────────────────────
 
-// All distinct combatants that appeared in any game in the series.
-// rooms: array of completed room records from getHeritageChain.
+// All distinct combatants that appeared in any game across a series or season.
+// rooms: array of room records (from getHeritageChain or getSeasonRooms).
 export function getSeriesCombatantNominees(rooms) {
   const seen = new Set()
   const nominees = []
@@ -1383,10 +1383,10 @@ export function getSeriesCombatantNominees(rooms) {
   return nominees
 }
 
-// All evolutions that occurred in the series as nominee objects.
+// All evolutions that occurred across a series or season as nominee objects.
 // Display name includes opponent context per the narrative principle:
 // "they beat [opponent] and became this."
-// rooms: array of completed room records from getHeritageChain.
+// rooms: array of room records (from getHeritageChain or getSeasonRooms).
 export function getSeriesEvolutionNominees(rooms) {
   const seen = new Set()
   const nominees = []
@@ -1407,3 +1407,7 @@ export function getSeriesEvolutionNominees(rooms) {
   }
   return nominees
 }
+
+// Season-scoped aliases — same room-structure logic, different semantic scope.
+export const getSeasonCombatantNominees = getSeriesCombatantNominees
+export const getSeasonEvolutionNominees  = getSeriesEvolutionNominees

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -35,6 +35,8 @@ import {
   resolveVotingPhase,
   getSeriesCombatantNominees,
   getSeriesEvolutionNominees,
+  getSeasonCombatantNominees,
+  getSeasonEvolutionNominees,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -3037,5 +3039,63 @@ describe('getSeriesEvolutionNominees', () => {
     }
     const nominees = getSeriesEvolutionNominees([{ rounds: [round] }])
     expect(nominees[0].name).toContain('?')
+  })
+})
+
+// ─── getSeasonCombatantNominees ───────────────────────────────────────────────
+
+describe('getSeasonCombatantNominees', () => {
+  it('returns all distinct combatants across all season rooms', () => {
+    const rooms = [
+      { combatants: { p1: [{ id: 'c1', name: 'Fighter1' }], p2: [{ id: 'c2', name: 'Fighter2' }] } },
+      { combatants: { p1: [{ id: 'c1', name: 'Fighter1' }], p2: [{ id: 'c3', name: 'Fighter3' }] } },
+    ]
+    const nominees = getSeasonCombatantNominees(rooms)
+    expect(nominees).toHaveLength(3)
+    expect(nominees.map(n => n.id).sort()).toEqual(['c1', 'c2', 'c3'])
+    expect(nominees.every(n => n.type === 'combatant')).toBe(true)
+  })
+
+  it('deduplicates combatants across multiple games in the season', () => {
+    const c = { id: 'c1', name: 'Fighter' }
+    const rooms = [{ combatants: { p1: [c] } }, { combatants: { p1: [c] } }]
+    expect(getSeasonCombatantNominees(rooms)).toHaveLength(1)
+  })
+
+  it('returns empty for no rooms', () => {
+    expect(getSeasonCombatantNominees([])).toEqual([])
+  })
+})
+
+// ─── getSeasonEvolutionNominees ───────────────────────────────────────────────
+
+describe('getSeasonEvolutionNominees', () => {
+  const evolRound = {
+    evolution: { fromId: 'c1', fromName: 'Fighter', toId: 'v1', toName: 'SuperFighter' },
+    combatants: [{ id: 'c1', name: 'Fighter' }, { id: 'c2', name: 'Rival' }],
+  }
+
+  it('returns evolution nominees with opponent name in display', () => {
+    const nominees = getSeasonEvolutionNominees([{ rounds: [evolRound] }])
+    expect(nominees).toHaveLength(1)
+    expect(nominees[0].id).toBe('v1')
+    expect(nominees[0].type).toBe('combatant')
+    expect(nominees[0].name).toContain('SuperFighter')
+    expect(nominees[0].name).toContain('Fighter')
+    expect(nominees[0].name).toContain('Rival')
+  })
+
+  it('deduplicates evolutions across multiple season games', () => {
+    const rooms = [{ rounds: [evolRound] }, { rounds: [evolRound] }]
+    expect(getSeasonEvolutionNominees(rooms)).toHaveLength(1)
+  })
+
+  it('returns empty when no evolutions occurred', () => {
+    const rooms = [{ rounds: [{ winner: { id: 'c1' }, combatants: [{ id: 'c1' }, { id: 'c2' }] }] }]
+    expect(getSeasonEvolutionNominees(rooms)).toHaveLength(0)
+  })
+
+  it('returns empty for no rooms', () => {
+    expect(getSeasonEvolutionNominees([])).toEqual([])
   })
 })

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
-import { btn, inp, lbl, tab } from '../styles.js'
-import { createSeason, getSeasons, updateSeason, getSeasonRooms } from '../supabase.js'
-import { uid, computeSeriesStandings, groupRoomsForHistory } from '../gameLogic.js'
+import { btn, inp, lbl } from '../styles.js'
+import { createSeason, getSeasons, updateSeason, getSeasonRooms, createPendingAward } from '../supabase.js'
+import { uid, computeSeriesStandings, groupRoomsForHistory, getSeasonCombatantNominees, getSeasonEvolutionNominees } from '../gameLogic.js'
+import VotingPanel from '../components/VotingPanel.jsx'
 
 function ToggleRow({ label, description, value, onToggle }) {
   return (
@@ -70,6 +71,7 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
   const [seasonRooms, setSeasonRooms] = useState(null)
   const [closing, setClosing] = useState(false)
   const [confirmClose, setConfirmClose] = useState(false)
+  const awardCreationRef = useRef(false)
 
   useEffect(() => {
     getSeasonRooms(season.id).then(rooms => {
@@ -85,6 +87,30 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
       }
     })
   }, [season.id, season.status, season.series_played, season.series_count])
+
+  // Auto-create the three season award rows the moment the season closes.
+  useEffect(() => {
+    if (season.status !== 'ended') return
+    if (season.votes) return
+    if (!seasonRooms) return
+    if (awardCreationRef.current) return
+    awardCreationRef.current = true
+
+    const now = new Date().toISOString()
+    const favId  = uid()
+    const mccId  = uid()
+    const bestId = uid()
+    const pending = { ballot_state: { phase: 'nomination', lockedVoterIds: [], runoffPool: null }, created_at: now, updated_at: now }
+
+    Promise.all([
+      createPendingAward({ id: favId,  type: 'favorite_combatant',     layer: 'season', scope_id: season.id, scope_type: 'season', recipient_type: 'combatant', ...pending }),
+      createPendingAward({ id: mccId,  type: 'most_creative_combatant', layer: 'season', scope_id: season.id, scope_type: 'season', recipient_type: 'combatant', ...pending }),
+      createPendingAward({ id: bestId, type: 'best_evolution',          layer: 'season', scope_id: season.id, scope_type: 'season', recipient_type: 'combatant', ...pending }),
+    ])
+      .then(() => updateSeason(season.id, { votes: { favoriteCombatantAwardId: favId, mostCreativeAwardId: mccId, bestEvolutionAwardId: bestId } }))
+      .then(updated => setSeason(updated))
+      .catch(e => console.error('createSeasonAwards', e))
+  }, [season.status, season.votes, seasonRooms])
 
   async function handleCloseEarly() {
     setClosing(true)
@@ -239,11 +265,74 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
         </div>
       )}
 
-      {season.status === 'ended' && (
-        <div style={{ padding: '10px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
-          <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>This season is complete.</p>
-        </div>
-      )}
+      {season.status === 'ended' && (() => {
+        const isCreator = playerId === season.owner_id
+
+        const seasonVoters = (() => {
+          if (!seasonRooms) return []
+          const seen = new Set()
+          const result = []
+          for (const r of seasonRooms) {
+            for (const p of (r.players || [])) {
+              if (!p.isBot && p.id && !seen.has(p.id)) {
+                seen.add(p.id)
+                result.push({ id: p.id, name: p.name })
+              }
+            }
+          }
+          return result
+        })()
+
+        const seasonCombatantNominees = seasonRooms ? getSeasonCombatantNominees(seasonRooms) : []
+        const seasonEvolutionNominees = seasonRooms ? getSeasonEvolutionNominees(seasonRooms)  : []
+
+        return (
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 12 }}>Season votes</div>
+
+            {!season.votes && (
+              <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)', margin: 0 }}>Opening ballots…</p>
+            )}
+
+            {season.votes && (
+              <>
+                <VotingPanel
+                  key={season.votes.favoriteCombatantAwardId}
+                  awardId={season.votes.favoriteCombatantAwardId}
+                  label="Favorite combatant of the season"
+                  nominees={seasonCombatantNominees}
+                  voters={seasonVoters}
+                  playerId={playerId}
+                  isHost={isCreator}
+                  onResolved={() => {}}
+                />
+                <VotingPanel
+                  key={season.votes.mostCreativeAwardId}
+                  awardId={season.votes.mostCreativeAwardId}
+                  label="Most creative combatant"
+                  nominees={seasonCombatantNominees}
+                  voters={seasonVoters}
+                  playerId={playerId}
+                  isHost={isCreator}
+                  onResolved={() => {}}
+                />
+                {seasonEvolutionNominees.length > 0 && (
+                  <VotingPanel
+                    key={season.votes.bestEvolutionAwardId}
+                    awardId={season.votes.bestEvolutionAwardId}
+                    label="Best evolution of the season"
+                    nominees={seasonEvolutionNominees}
+                    voters={seasonVoters}
+                    playerId={playerId}
+                    isHost={isCreator}
+                    onResolved={() => {}}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        )
+      })()}
     </Screen>
   )
 }

--- a/supabase/migrations/20260501_season_votes.sql
+++ b/supabase/migrations/20260501_season_votes.sql
@@ -1,0 +1,9 @@
+-- Migration: season votes tracking (issue #29)
+--
+-- Adds a `votes` jsonb column to the seasons table to track award row IDs
+-- created at season close. Populated automatically when a season ends;
+-- stores { favoriteCombatantAwardId, mostCreativeAwardId, bestEvolutionAwardId }.
+--
+-- Safe to re-run (idempotent).
+
+alter table seasons add column if not exists votes jsonb;


### PR DESCRIPTION
Closes #29

## What changed

- **Migration** (`20260501_season_votes.sql`): adds a `votes jsonb` column to the `seasons` table to track the three award row IDs created at season close.
- **`gameLogic.js`**: added `getSeasonCombatantNominees` and `getSeasonEvolutionNominees` exports (aliases over the series equivalents — same room-array logic, season-scoped names for clarity). Updated the shared function comments to reflect both scopes.
- **`gameLogic.test.js`**: unit tests for both new exports (nominees across multiple rooms, deduplication, empty cases).
- **`SeasonScreen.jsx`**: when a season closes (auto or early), three pending award rows are created immediately — `favorite_combatant`, `most_creative_combatant`, `best_evolution` — and their IDs stored in `season.votes`. The `SeasonDetail` view renders `VotingPanel` for each award. Voters are derived from the union of real players across all season rooms. The season creator acts as the ballot closer (mirrors the host role in series/game awards). The best evolution panel is suppressed when there are no evolutions in the season.

## Test notes

- Create a season, start and complete the required number of series so the season auto-closes (or use "Close season early").
- The "Season votes" section should appear immediately with all three ballots open.
- Verify that non-creator players see the ballots and can vote, but only the creator sees the early-close button.
- Verify that the best evolution panel does not appear if no evolutions occurred in any season game.
- All 746 unit tests pass.