### PR TITLE
Awards: display across all surfaces

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -1411,3 +1411,202 @@ export function getSeriesEvolutionNominees(rooms) {
 // Season-scoped aliases — same room-structure logic, different semantic scope.
 export const getSeasonCombatantNominees = getSeriesCombatantNominees
 export const getSeasonEvolutionNominees  = getSeriesEvolutionNominees
+
+// ─── Automatic award computation ──────────────────────────────────────────────
+
+// Returns the shaped objects for `createAutoAwards`. Each object is fully
+// resolved (awarded_at set by caller) and has no ballot_state.
+//
+// Shape: { type, layer, scope_id, scope_type, recipient_id, recipient_name,
+//          recipient_type, value, co_award }
+
+function coAwardRows(entries, { type, layer, scopeId, scopeType, recipientType, value }) {
+  const coAward = entries.length > 1
+  return entries.map(([id, name]) => ({
+    type, layer,
+    scope_id:       scopeId,
+    scope_type:     scopeType,
+    recipient_id:   id,
+    recipient_name: name,
+    recipient_type: recipientType,
+    value:          value ?? null,
+    co_award:       coAward,
+  }))
+}
+
+/**
+ * Computes automatic game-level awards from a completed room record.
+ * Skips dev-mode games and games with no resolved rounds.
+ *
+ * Awards: most_wins (player), undefeated (player), shutout (player),
+ *         most_reactions (combatant)
+ */
+export function computeGameAutoAwards(room) {
+  if (room.devMode) return []
+
+  const resolvedRounds = (room.rounds || []).filter(r => r.winner || r.draw)
+  if (resolvedRounds.length === 0) return []
+
+  const players = (room.players || []).filter(p => !p.isBot)
+  if (players.length === 0) return []
+
+  const scope = { layer: 'game', scopeId: room.id, scopeType: 'game' }
+  const awards = []
+
+  // ── Per-player round tallies ─────────────────────────────────────────────
+  const tally = {}
+  for (const p of players) tally[p.id] = { wins: 0, losses: 0, name: p.name }
+
+  for (const round of resolvedRounds) {
+    if (round.winner) {
+      if (tally[round.winner.ownerId]) tally[round.winner.ownerId].wins++
+      for (const c of (round.combatants || []).filter(c => c.id !== round.winner.id)) {
+        if (tally[c.ownerId]) tally[c.ownerId].losses++
+      }
+    } else if (round.draw) {
+      // draws don't break undefeated; don't count as wins or losses
+    }
+  }
+
+  // most_wins
+  const maxWins = Math.max(...Object.values(tally).map(p => p.wins))
+  if (maxWins > 0) {
+    const tops = Object.entries(tally).filter(([, p]) => p.wins === maxWins).map(([id, p]) => [id, p.name])
+    awards.push(...coAwardRows(tops, { ...scope, recipientType: 'player', value: maxWins, type: 'most_wins' }))
+  }
+
+  // undefeated: ≥1 win, 0 losses
+  const undefeated = Object.entries(tally).filter(([, p]) => p.wins > 0 && p.losses === 0).map(([id, p]) => [id, p.name])
+  for (const [id, name] of undefeated) {
+    awards.push(...coAwardRows([[id, name]], { ...scope, recipientType: 'player', value: null, type: 'undefeated' }))
+  }
+
+  // shutout: 0 wins, ≥1 loss
+  const shutout = Object.entries(tally).filter(([, p]) => p.wins === 0 && p.losses > 0).map(([id, p]) => [id, p.name])
+  for (const [id, name] of shutout) {
+    awards.push(...coAwardRows([[id, name]], { ...scope, recipientType: 'player', value: null, type: 'shutout' }))
+  }
+
+  // most_reactions: combatant with most total reactions across all rounds
+  const reactionTotals = {}
+  for (const combatants of Object.values(room.combatants || {})) {
+    for (const c of combatants) {
+      if (c.isBot) continue
+      let total = 0
+      for (const round of resolvedRounds) {
+        const { heart, angry, cry } = tallyReactions(round.playerReactions, c.id)
+        total += heart + angry + cry
+      }
+      if (total > 0) reactionTotals[c.id] = { total, name: c.name }
+    }
+  }
+  const maxReactions = Math.max(...Object.values(reactionTotals).map(r => r.total), 0)
+  if (maxReactions > 0) {
+    const tops = Object.entries(reactionTotals).filter(([, r]) => r.total === maxReactions).map(([id, r]) => [id, r.name])
+    awards.push(...coAwardRows(tops, { ...scope, recipientType: 'combatant', value: maxReactions, type: 'most_reactions' }))
+  }
+
+  return awards
+}
+
+/**
+ * Computes automatic series-level awards from all rooms in a series.
+ * Only considers rooms with phase 'ended' (not endedEarly, not dev).
+ *
+ * Awards: most_wins (player), most_evolutions (player)
+ */
+export function computeSeriesAutoAwards(rooms, seriesId) {
+  const valid = (rooms || []).filter(r => r.phase === 'ended' && !r.endedEarly && !r.devMode)
+  if (valid.length === 0) return []
+
+  const scope = { layer: 'series', scopeId: seriesId, scopeType: 'series' }
+  const awards = []
+
+  // most_wins: reuse standings logic
+  const standings = computeSeriesStandings(valid)
+  if (standings.length > 0) {
+    const maxWins = standings[0].wins
+    if (maxWins > 0) {
+      const tops = standings.filter(s => s.wins === maxWins).map(s => [s.playerId, s.playerName])
+      awards.push(...coAwardRows(tops, { ...scope, recipientType: 'player', value: maxWins, type: 'most_wins' }))
+    }
+  }
+
+  // most_evolutions: player who triggered the most evolutions
+  const evoCount = {}
+  for (const room of valid) {
+    const playerMap = Object.fromEntries((room.players || []).filter(p => !p.isBot).map(p => [p.id, p.name]))
+    for (const round of (room.rounds || [])) {
+      if (!round.evolution || !round.winner) continue
+      const ownerId = round.winner.ownerId
+      const ownerName = playerMap[ownerId] || round.winner.ownerName
+      if (!ownerId || !ownerName) continue
+      if (!evoCount[ownerId]) evoCount[ownerId] = { count: 0, name: ownerName }
+      evoCount[ownerId].count++
+    }
+  }
+  const maxEvos = Math.max(...Object.values(evoCount).map(e => e.count), 0)
+  if (maxEvos > 0) {
+    const tops = Object.entries(evoCount).filter(([, e]) => e.count === maxEvos).map(([id, e]) => [id, e.name])
+    awards.push(...coAwardRows(tops, { ...scope, recipientType: 'player', value: maxEvos, type: 'most_evolutions' }))
+  }
+
+  return awards
+}
+
+/**
+ * Computes automatic season-level awards from all rooms in a season.
+ * Same logic as series but scoped to the season container.
+ *
+ * Awards: most_wins (player), most_evolutions (player)
+ */
+export function computeSeasonAutoAwards(rooms, seasonId) {
+  const valid = (rooms || []).filter(r => r.phase === 'ended' && !r.endedEarly && !r.devMode)
+  if (valid.length === 0) return []
+
+  const scope = { layer: 'season', scopeId: seasonId, scopeType: 'season' }
+  const awards = []
+
+  const standings = computeSeriesStandings(valid)
+  if (standings.length > 0) {
+    const maxWins = standings[0].wins
+    if (maxWins > 0) {
+      const tops = standings.filter(s => s.wins === maxWins).map(s => [s.playerId, s.playerName])
+      awards.push(...coAwardRows(tops, { ...scope, recipientType: 'player', value: maxWins, type: 'most_wins' }))
+    }
+  }
+
+  const evoCount = {}
+  for (const room of valid) {
+    const playerMap = Object.fromEntries((room.players || []).filter(p => !p.isBot).map(p => [p.id, p.name]))
+    for (const round of (room.rounds || [])) {
+      if (!round.evolution || !round.winner) continue
+      const ownerId = round.winner.ownerId
+      const ownerName = playerMap[ownerId] || round.winner.ownerName
+      if (!ownerId || !ownerName) continue
+      if (!evoCount[ownerId]) evoCount[ownerId] = { count: 0, name: ownerName }
+      evoCount[ownerId].count++
+    }
+  }
+  const maxEvos = Math.max(...Object.values(evoCount).map(e => e.count), 0)
+  if (maxEvos > 0) {
+    const tops = Object.entries(evoCount).filter(([, e]) => e.count === maxEvos).map(([id, e]) => [id, e.name])
+    awards.push(...coAwardRows(tops, { ...scope, recipientType: 'player', value: maxEvos, type: 'most_evolutions' }))
+  }
+
+  return awards
+}
+
+// Human-readable labels for every award type used in display components.
+export const AWARD_TYPE_LABELS = {
+  mvp:                    'MVP',
+  most_wins:              'Most Round Wins',
+  undefeated:             'Undefeated',
+  shutout:                'Shutout',
+  most_reactions:         'Most Reactive',
+  most_evolutions:        'Most Evolutions',
+  favorite_combatant:     'Favorite Combatant',
+  most_creative_combatant:'Most Creative',
+  best_evolution:         'Best Evolution',
+  best_combatant:         'Best Combatant',
+}

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -37,6 +37,9 @@ import {
   getSeriesEvolutionNominees,
   getSeasonCombatantNominees,
   getSeasonEvolutionNominees,
+  computeGameAutoAwards,
+  computeSeriesAutoAwards,
+  computeSeasonAutoAwards,
 } from './gameLogic.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -3097,5 +3100,215 @@ describe('getSeasonEvolutionNominees', () => {
 
   it('returns empty for no rooms', () => {
     expect(getSeasonEvolutionNominees([])).toEqual([])
+  })
+})
+
+// ─── computeGameAutoAwards ─────────────────────────────────────────────────────
+
+describe('computeGameAutoAwards', () => {
+  function makeCompletedRoom(overrides = {}) {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Rival',   ownerId: 'p2' }
+    return {
+      id: 'room1', code: 'ROOM1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds: [
+        { id: 'r1', winner: { id: 'c1', name: 'Fighter', ownerId: 'p1' }, combatants: [c1, c2] },
+      ],
+      ...overrides,
+    }
+  }
+
+  it('returns empty for dev mode room', () => {
+    expect(computeGameAutoAwards(makeCompletedRoom({ devMode: true }))).toEqual([])
+  })
+
+  it('returns empty for room with no resolved rounds', () => {
+    expect(computeGameAutoAwards(makeCompletedRoom({ rounds: [] }))).toEqual([])
+  })
+
+  it('returns most_wins for player with most round wins', () => {
+    const room = makeCompletedRoom()
+    const awards = computeGameAutoAwards(room)
+    const mw = awards.find(a => a.type === 'most_wins')
+    expect(mw).toBeDefined()
+    expect(mw.recipient_id).toBe('p1')
+    expect(mw.recipient_name).toBe('Alice')
+    expect(mw.recipient_type).toBe('player')
+    expect(mw.value).toBe(1)
+    expect(mw.co_award).toBe(false)
+    expect(mw.layer).toBe('game')
+    expect(mw.scope_id).toBe('room1')
+  })
+
+  it('returns co_award most_wins when tied', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Rival',   ownerId: 'p2' }
+    const room = {
+      id: 'room1', code: 'ROOM1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1, c2], p2: [c2, c1] },
+      rounds: [
+        { winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1, c2] },
+        { winner: { id: 'c2', ownerId: 'p2' }, combatants: [c1, c2] },
+      ],
+    }
+    const awards = computeGameAutoAwards(room)
+    const mw = awards.filter(a => a.type === 'most_wins')
+    expect(mw).toHaveLength(2)
+    expect(mw.every(a => a.co_award)).toBe(true)
+  })
+
+  it('returns undefeated for player with wins and no losses', () => {
+    const room = makeCompletedRoom()
+    const awards = computeGameAutoAwards(room)
+    const ud = awards.find(a => a.type === 'undefeated')
+    expect(ud).toBeDefined()
+    expect(ud.recipient_id).toBe('p1')
+  })
+
+  it('returns shutout for player with losses and no wins', () => {
+    const room = makeCompletedRoom()
+    const awards = computeGameAutoAwards(room)
+    const sh = awards.find(a => a.type === 'shutout')
+    expect(sh).toBeDefined()
+    expect(sh.recipient_id).toBe('p2')
+  })
+
+  it('does not return shutout for a player who only drew', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', ownerId: 'p1' }
+    const c2 = { id: 'c2', ownerId: 'p2' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds: [{ draw: true, combatants: [c1, c2] }],
+    }
+    const awards = computeGameAutoAwards(room)
+    expect(awards.find(a => a.type === 'shutout')).toBeUndefined()
+  })
+
+  it('returns most_reactions for combatant with most reactions', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', name: 'Popular', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Quiet',   ownerId: 'p2' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds: [{
+        winner: { id: 'c1', ownerId: 'p1' },
+        combatants: [c1, c2],
+        playerReactions: { p1: { c1: 'heart' }, p2: { c1: 'heart' } },
+      }],
+    }
+    const awards = computeGameAutoAwards(room)
+    const mr = awards.find(a => a.type === 'most_reactions')
+    expect(mr).toBeDefined()
+    expect(mr.recipient_id).toBe('c1')
+    expect(mr.value).toBe(2)
+  })
+
+  it('skips most_reactions when no reactions exist', () => {
+    const room = makeCompletedRoom()
+    const awards = computeGameAutoAwards(room)
+    expect(awards.find(a => a.type === 'most_reactions')).toBeUndefined()
+  })
+})
+
+// ─── computeSeriesAutoAwards ───────────────────────────────────────────────────
+
+describe('computeSeriesAutoAwards', () => {
+  const p1 = { id: 'p1', name: 'Alice', isBot: false }
+  const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+  const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+  const c2 = { id: 'c2', name: 'Rival',   ownerId: 'p2' }
+
+  function makeSeriesRoom(rounds, overrides = {}) {
+    return {
+      id: 'room1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds,
+      ...overrides,
+    }
+  }
+
+  it('returns empty for rooms not fully ended', () => {
+    const room = makeSeriesRoom([], { phase: 'battle' })
+    expect(computeSeriesAutoAwards([room], 'series1')).toEqual([])
+  })
+
+  it('returns most_wins for player with most round wins across rooms', () => {
+    const room1 = makeSeriesRoom([{ winner: { id: 'c1', ownerId: 'p1', name: 'Fighter' }, combatants: [c1, c2] }])
+    const room2 = makeSeriesRoom([{ winner: { id: 'c1', ownerId: 'p1', name: 'Fighter' }, combatants: [c1, c2] }], { id: 'room2' })
+    const awards = computeSeriesAutoAwards([room1, room2], 'series1')
+    const mw = awards.find(a => a.type === 'most_wins')
+    expect(mw).toBeDefined()
+    expect(mw.recipient_id).toBe('p1')
+    expect(mw.value).toBe(2)
+    expect(mw.layer).toBe('series')
+    expect(mw.scope_id).toBe('series1')
+  })
+
+  it('returns most_evolutions for player with most evolutions triggered', () => {
+    const room = makeSeriesRoom([{
+      winner: { id: 'c1', name: 'Fighter', ownerId: 'p1' },
+      combatants: [c1, c2],
+      evolution: { fromId: 'c1', fromName: 'Fighter', toId: 'v1', toName: 'SuperFighter' },
+    }])
+    const awards = computeSeriesAutoAwards([room], 'series1')
+    const me = awards.find(a => a.type === 'most_evolutions')
+    expect(me).toBeDefined()
+    expect(me.recipient_id).toBe('p1')
+    expect(me.value).toBe(1)
+  })
+
+  it('skips most_evolutions when no evolutions occurred', () => {
+    const room = makeSeriesRoom([{ winner: c1, combatants: [c1, c2] }])
+    const awards = computeSeriesAutoAwards([room], 'series1')
+    expect(awards.find(a => a.type === 'most_evolutions')).toBeUndefined()
+  })
+
+  it('excludes endedEarly and devMode rooms', () => {
+    const earlyRoom = makeSeriesRoom([{ winner: c1, combatants: [c1, c2] }], { endedEarly: true })
+    const devRoom   = makeSeriesRoom([{ winner: c1, combatants: [c1, c2] }], { devMode: true })
+    expect(computeSeriesAutoAwards([earlyRoom, devRoom], 'series1')).toEqual([])
+  })
+})
+
+// ─── computeSeasonAutoAwards ───────────────────────────────────────────────────
+
+describe('computeSeasonAutoAwards', () => {
+  it('uses same logic as computeSeriesAutoAwards but with season scope', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Rival',   ownerId: 'p2' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds: [{ winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1, c2] }],
+    }
+    const awards = computeSeasonAutoAwards([room], 'season1')
+    const mw = awards.find(a => a.type === 'most_wins')
+    expect(mw).toBeDefined()
+    expect(mw.layer).toBe('season')
+    expect(mw.scope_id).toBe('season1')
+    expect(mw.scope_type).toBe('season')
+  })
+
+  it('returns empty for rooms with no completed games', () => {
+    const room = { id: 'room1', phase: 'battle', players: [], combatants: {}, rounds: [] }
+    expect(computeSeasonAutoAwards([room], 'season1')).toEqual([])
   })
 })

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -3,9 +3,9 @@ import DevBanner from '../components/DevBanner.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
-import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant, getPlaylistForDelivery, createPendingAward, appendMvpRecord } from '../supabase.js'
+import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant, getPlaylistForDelivery, createPendingAward, appendMvpRecord, createAutoAwards } from '../supabase.js'
 import VotingPanel from '../components/VotingPanel.jsx'
-import { uid, canUndoLastRound, undoRound, tallyReactions, normalizeRoomSettings } from '../gameLogic.js'
+import { uid, canUndoLastRound, undoRound, tallyReactions, normalizeRoomSettings, computeGameAutoAwards } from '../gameLogic.js'
 
 // Inline form for evolving the current arena after a round resolves.
 // Pre-fills house rules from the parent arena; name and description start blank.
@@ -177,6 +177,8 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
     if (!r) return
     const updated = { ...r, phase: 'ended' }
     await sset('room:' + r.id, updated)
+    const autoAwards = computeGameAutoAwards(updated)
+    if (autoAwards.length > 0) createAutoAwards(autoAwards).catch(e => console.error('createAutoAwards game', e))
     setLocal(updated); setRoom(updated)
     onHome()
   }

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react'
 import RoundChat from '../components/RoundChat.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { btn, tab } from '../styles.js'
-import { tallyReactions, groupRoomsForHistory, computeSeriesStandings } from '../gameLogic.js'
-import { slist } from '../supabase.js'
+import { tallyReactions, groupRoomsForHistory, computeSeriesStandings, computeSeriesAutoAwards, AWARD_TYPE_LABELS } from '../gameLogic.js'
+import { slist, getAwardsForScope, createAutoAwards } from '../supabase.js'
 import { downloadFile, formatRoomAsText, formatSeriesAsText } from '../export.js'
 
 // NOTE: The round display logic in ChroniclesRoomDetail is partially duplicated with RoundCard
@@ -377,6 +377,7 @@ function StandingsTable({ rooms }) {
 
 function SeriesRow({ item, onSelect, playerId }) {
   const [expanded, setExpanded] = useState(false)
+  const [awards,   setAwards]   = useState(null)
   const { rooms, seriesId } = item
 
   const allPlayers = [...new Map(
@@ -390,11 +391,30 @@ function SeriesRow({ item, onSelect, playerId }) {
 
   const totalRounds = rooms.reduce((n, r) => n + (r.rounds || []).filter(rd => rd.winner || rd.draw).length, 0)
 
+  useEffect(() => {
+    if (!expanded) return
+    getAwardsForScope(seriesId).then(scopeAwards => {
+      setAwards(scopeAwards)
+      const allEnded = rooms.every(r => r.phase === 'ended')
+      const hasAuto  = scopeAwards.some(a => a.type === 'most_wins' || a.type === 'most_evolutions')
+      if (allEnded && !hasAuto) {
+        const autoAwards = computeSeriesAutoAwards(rooms, seriesId)
+        if (autoAwards.length > 0) {
+          createAutoAwards(autoAwards)
+            .then(() => getAwardsForScope(seriesId).then(setAwards))
+            .catch(e => console.error('createAutoAwards series', e))
+        }
+      }
+    })
+  }, [expanded, seriesId])
+
   function exportSeries() {
     const sorted = [...rooms].sort((a, b) => (a.seriesIndex || 0) - (b.seriesIndex || 0))
     const slug   = seriesId.slice(0, 6).toUpperCase()
     downloadFile(`eights-series-${slug}.txt`, formatSeriesAsText(sorted))
   }
+
+  const resolvedAwards = (awards || []).filter(a => a.awarded_at)
 
   return (
     <div style={{ marginBottom: 10 }}>
@@ -423,6 +443,25 @@ function SeriesRow({ item, onSelect, playerId }) {
       {expanded && (
         <div style={{ background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-info)', borderTop: 'none', borderRadius: '0 0 var(--border-radius-lg) var(--border-radius-lg)', overflow: 'hidden' }}>
           <StandingsTable rooms={rooms} />
+          {resolvedAwards.length > 0 && (
+            <div style={{ padding: '12px 16px', borderBottom: '0.5px solid var(--color-border-tertiary)' }}>
+              <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 8 }}>Series awards</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                {resolvedAwards.map(a => (
+                  <div key={a.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', fontSize: 13 }}>
+                    <span style={{ color: 'var(--color-text-secondary)' }}>
+                      {AWARD_TYPE_LABELS[a.type] || a.type}
+                      {a.co_award && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>(shared)</span>}
+                    </span>
+                    <span style={{ color: 'var(--color-text-primary)', fontWeight: 500, marginLeft: 12 }}>
+                      {a.recipient_name}
+                      {a.value != null && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>{a.value}</span>}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
           <div style={{ padding: '0 12px 4px' }}>
             {rooms.map(r => <RoomRow key={r.id} room={r} onSelect={onSelect} playerId={playerId} />)}
           </div>

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -3,8 +3,8 @@ import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
-import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget, superHostSetEntityTags, superHostInductHoF, superHostRemoveHoF, superHostEditHofNote, setCombatantGroups, getCombatantGroupIds, listPublishedGroups } from '../supabase.js'
-import { buildStoryFromLineageTree, computeSuperlatives } from '../gameLogic.js'
+import { updateGlobalCombatant, getLineageTree, getCombatantRoundHistory, sget, superHostSetEntityTags, superHostInductHoF, superHostRemoveHoF, superHostEditHofNote, setCombatantGroups, getCombatantGroupIds, listPublishedGroups, getAwardsForCombatant } from '../supabase.js'
+import { buildStoryFromLineageTree, computeSuperlatives, AWARD_TYPE_LABELS } from '../gameLogic.js'
 import { downloadFile, formatCombatantHistory } from '../export.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
 
@@ -249,6 +249,8 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
   const [shAllGroups,   setShAllGroups]   = useState(null)
   const [shGroupSaving, setShGroupSaving] = useState(false)
 
+  const [combatantAwards, setCombatantAwards] = useState([])
+
   const canEdit = c.owner_id === playerId
   const totalRounds = (c.wins || 0) + (c.losses || 0) + (c.draws || 0)
   const history    = c.bio_history || []
@@ -273,6 +275,10 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
     }
     // Load h2h eagerly so superlatives can show on first render.
     getCombatantRoundHistory(c.id).then(setH2hRows)
+    // Load awards from the awards table (excludes mvp_record which is shown separately)
+    getAwardsForCombatant(c.id).then(awards => {
+      setCombatantAwards(awards.filter(a => a.type !== 'mvp'))
+    })
   }, [rootId, c.id])
 
   function nameSlug() {
@@ -473,6 +479,41 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
           </div>
         </div>
       )}
+
+      {/* ── Awards ───────────────────────────────────────────────────────── */}
+      {combatantAwards.length > 0 && (() => {
+        const LAYER_ORDER = ['game', 'series', 'season', 'league']
+        const byLayer = {}
+        for (const a of combatantAwards) {
+          if (!byLayer[a.layer]) byLayer[a.layer] = []
+          byLayer[a.layer].push(a)
+        }
+        return (
+          <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+            <h3 style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', margin: '0 0 10px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+              Awards
+            </h3>
+            {LAYER_ORDER.filter(l => byLayer[l]).map(layer => (
+              <div key={layer} style={{ marginBottom: 10 }}>
+                <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 5 }}>{layer}</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {byLayer[layer].map(a => (
+                    <div key={a.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', fontSize: 13 }}>
+                      <span style={{ color: 'var(--color-text-primary)', fontWeight: 500 }}>
+                        {AWARD_TYPE_LABELS[a.type] || a.type}
+                        {a.co_award && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>(shared)</span>}
+                      </span>
+                      {a.value != null && (
+                        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginLeft: 8 }}>{a.value}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      })()}
 
       {/* ── Bio ──────────────────────────────────────────────────────────── */}
       <div style={{ marginBottom: '1.5rem' }}>

--- a/src/screens/PlayerProfile.jsx
+++ b/src/screens/PlayerProfile.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import PlayerStatsBlurb from '../components/PlayerStatsBlurb.jsx'
 import { btn, inp, tab } from '../styles.js'
-import { getUserProfile, getPlayerRoomStats, getPlayerCombatants, getPlayerRooms, setFavoriteCombatant } from '../supabase.js'
+import { getUserProfile, getPlayerRoomStats, getPlayerCombatants, getPlayerRooms, setFavoriteCombatant, getAwardsForPlayer } from '../supabase.js'
+import { AWARD_TYPE_LABELS } from '../gameLogic.js'
 
 const PROFILE_SORTS = [
   { key: 'wins',   label: 'Wins',   asc: false },
@@ -23,13 +24,15 @@ export default function PlayerProfile({ profileId, playerId, onBack, onViewComba
   const [loading,   setLoading]   = useState(true)
   const [combLoading, setCombLoading] = useState(true)
   const [savingFav, setSavingFav] = useState(null)
-  const [games, setGames] = useState([])
+  const [games,     setGames]     = useState([])
+  const [awards,    setAwards]    = useState([])
   const searchTimer = useRef(null)
 
   useEffect(() => {
     getUserProfile(profileId).then(setProfile)
     getPlayerRoomStats(profileId).then(setStats)
     getPlayerRooms(profileId).then(setGames)
+    getAwardsForPlayer(profileId).then(setAwards)
   }, [profileId])
 
   function loadCombatants(q, s, p) {
@@ -63,6 +66,32 @@ export default function PlayerProfile({ profileId, playerId, onBack, onViewComba
         <div style={{ fontSize: 17, fontWeight: 500, color: 'var(--color-text-primary)', marginBottom: 8 }}>{username}</div>
         <PlayerStatsBlurb stats={stats} favoriteName={profile?.favorite_combatant_name} />
       </div>
+
+      {awards.length > 0 && (
+        <>
+          <h3 style={{ fontSize: 14, fontWeight: 400, color: 'var(--color-text-secondary)', margin: '0 0 10px' }}>
+            Awards
+          </h3>
+          <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {awards.map(a => (
+                <div key={a.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', fontSize: 13 }}>
+                  <div>
+                    <span style={{ color: 'var(--color-text-primary)', fontWeight: 500 }}>
+                      {AWARD_TYPE_LABELS[a.type] || a.type}
+                    </span>
+                    {a.co_award && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>(shared)</span>}
+                    <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 6, textTransform: 'capitalize' }}>{a.layer}</span>
+                  </div>
+                  {a.value != null && (
+                    <span style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginLeft: 8 }}>{a.value}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
 
       {games.length > 0 && (
         <>

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
 import { btn, inp, lbl } from '../styles.js'
-import { createSeason, getSeasons, updateSeason, getSeasonRooms, createPendingAward } from '../supabase.js'
-import { uid, computeSeriesStandings, groupRoomsForHistory, getSeasonCombatantNominees, getSeasonEvolutionNominees } from '../gameLogic.js'
+import { createSeason, getSeasons, updateSeason, getSeasonRooms, createPendingAward, getAwardsForScope, createAutoAwards } from '../supabase.js'
+import { uid, computeSeriesStandings, groupRoomsForHistory, getSeasonCombatantNominees, getSeasonEvolutionNominees, computeSeasonAutoAwards, AWARD_TYPE_LABELS } from '../gameLogic.js'
 import VotingPanel from '../components/VotingPanel.jsx'
 
 function ToggleRow({ label, description, value, onToggle }) {
@@ -71,7 +71,9 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
   const [seasonRooms, setSeasonRooms] = useState(null)
   const [closing, setClosing] = useState(false)
   const [confirmClose, setConfirmClose] = useState(false)
+  const [seasonAwards, setSeasonAwards] = useState(null)
   const awardCreationRef = useRef(false)
+  const autoAwardRef    = useRef(false)
 
   useEffect(() => {
     getSeasonRooms(season.id).then(rooms => {
@@ -111,6 +113,36 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
       .then(updated => setSeason(updated))
       .catch(e => console.error('createSeasonAwards', e))
   }, [season.status, season.votes, seasonRooms])
+
+  // Compute and store automatic season awards once (idempotent guard via autoAwardRef).
+  useEffect(() => {
+    if (season.status !== 'ended') return
+    if (!seasonRooms || seasonRooms.length === 0) return
+    if (autoAwardRef.current) return
+    autoAwardRef.current = true
+
+    getAwardsForScope(season.id).then(existing => {
+      const hasAuto = existing.some(a => a.type === 'most_wins' || a.type === 'most_evolutions')
+      if (hasAuto) {
+        setSeasonAwards(existing)
+        return
+      }
+      const autoAwards = computeSeasonAutoAwards(seasonRooms, season.id)
+      if (autoAwards.length === 0) {
+        setSeasonAwards(existing)
+        return
+      }
+      createAutoAwards(autoAwards)
+        .then(() => getAwardsForScope(season.id).then(setSeasonAwards))
+        .catch(e => { console.error('createAutoAwards season', e); setSeasonAwards(existing) })
+    })
+  }, [season.status, season.id, seasonRooms])
+
+  // Refresh resolved awards list when ballot votes are cast (season.votes changes).
+  useEffect(() => {
+    if (season.status !== 'ended') return
+    getAwardsForScope(season.id).then(setSeasonAwards)
+  }, [season.votes, season.id, season.status])
 
   async function handleCloseEarly() {
     setClosing(true)
@@ -286,8 +318,33 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
         const seasonCombatantNominees = seasonRooms ? getSeasonCombatantNominees(seasonRooms) : []
         const seasonEvolutionNominees = seasonRooms ? getSeasonEvolutionNominees(seasonRooms)  : []
 
+        const AUTO_AWARD_TYPES = ['most_wins', 'most_evolutions']
+        const resolvedAutoAwards = (seasonAwards || []).filter(a => a.awarded_at && AUTO_AWARD_TYPES.includes(a.type))
+
         return (
           <div>
+            {/* Automatic awards */}
+            {resolvedAutoAwards.length > 0 && (
+              <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', border: '0.5px solid var(--color-border-tertiary)' }}>
+                <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 10 }}>Season awards</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {resolvedAutoAwards.map(a => (
+                    <div key={a.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', fontSize: 13 }}>
+                      <span style={{ color: 'var(--color-text-secondary)' }}>
+                        {AWARD_TYPE_LABELS[a.type] || a.type}
+                        {a.co_award && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>(shared)</span>}
+                      </span>
+                      <span style={{ color: 'var(--color-text-primary)', fontWeight: 500, marginLeft: 12 }}>
+                        {a.recipient_name}
+                        {a.value != null && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>{a.value}</span>}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Voted awards */}
             <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 12 }}>Season votes</div>
 
             {!season.votes && (
@@ -304,7 +361,7 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
                   voters={seasonVoters}
                   playerId={playerId}
                   isHost={isCreator}
-                  onResolved={() => {}}
+                  onResolved={() => getAwardsForScope(season.id).then(setSeasonAwards)}
                 />
                 <VotingPanel
                   key={season.votes.mostCreativeAwardId}
@@ -314,7 +371,7 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
                   voters={seasonVoters}
                   playerId={playerId}
                   isHost={isCreator}
-                  onResolved={() => {}}
+                  onResolved={() => getAwardsForScope(season.id).then(setSeasonAwards)}
                 />
                 {seasonEvolutionNominees.length > 0 && (
                   <VotingPanel
@@ -325,7 +382,7 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
                     voters={seasonVoters}
                     playerId={playerId}
                     isHost={isCreator}
-                    onResolved={() => {}}
+                    onResolved={() => getAwardsForScope(season.id).then(setSeasonAwards)}
                   />
                 )}
               </>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1803,6 +1803,68 @@ export async function appendMvpRecord(combatantId, entry) {
   if (error) console.error('appendMvpRecord update', error)
 }
 
+// Fetch all awards for a given scope (game / series / season / league).
+// Returns resolved + pending awards, ordered by awarded_at ASC (nulls last).
+export async function getAwardsForScope(scopeId) {
+  const { data, error } = await supabase
+    .from('awards')
+    .select('*')
+    .eq('scope_id', scopeId)
+    .order('awarded_at', { ascending: true, nullsFirst: false })
+  if (error) { console.error('getAwardsForScope error', error); return [] }
+  return data || []
+}
+
+// Fetch all resolved awards received by a combatant, newest-last.
+export async function getAwardsForCombatant(combatantId) {
+  const { data, error } = await supabase
+    .from('awards')
+    .select('*')
+    .eq('recipient_id', combatantId)
+    .eq('recipient_type', 'combatant')
+    .not('awarded_at', 'is', null)
+    .order('awarded_at', { ascending: true })
+  if (error) { console.error('getAwardsForCombatant error', error); return [] }
+  return data || []
+}
+
+// Fetch all resolved awards received by a player, newest-last.
+export async function getAwardsForPlayer(playerId) {
+  const { data, error } = await supabase
+    .from('awards')
+    .select('*')
+    .eq('recipient_id', playerId)
+    .eq('recipient_type', 'player')
+    .not('awarded_at', 'is', null)
+    .order('awarded_at', { ascending: true })
+  if (error) { console.error('getAwardsForPlayer error', error); return [] }
+  return data || []
+}
+
+// Bulk-insert auto-resolved award rows. Sets awarded_at to now for each row.
+export async function createAutoAwards(awards) {
+  if (!awards || awards.length === 0) return
+  const now = new Date().toISOString()
+  const rows = awards.map(a => ({
+    id:             genId(),
+    type:           a.type,
+    layer:          a.layer,
+    scope_id:       a.scope_id,
+    scope_type:     a.scope_type,
+    recipient_id:   a.recipient_id,
+    recipient_name: a.recipient_name,
+    recipient_type: a.recipient_type,
+    value:          a.value ?? null,
+    co_award:       a.co_award ?? false,
+    awarded_at:     now,
+    ballot_state:   null,
+    created_at:     now,
+    updated_at:     now,
+  }))
+  const { error } = await supabase.from('awards').insert(rows)
+  if (error) throw error
+}
+
 // ─── Tags ─────────────────────────────────────────────────────────────────────
 
 // All distinct tags across published combatants, groups, and arenas.


### PR DESCRIPTION
Closes #30

## What changed

**gameLogic.js** — Three new pure functions for automatic award computation, plus `AWARD_TYPE_LABELS` map:
- `computeGameAutoAwards(room)` — most_wins, undefeated, shutout, most_reactions from a completed game
- `computeSeriesAutoAwards(rooms, seriesId)` — most_wins, most_evolutions across a series
- `computeSeasonAutoAwards(rooms, seasonId)` — same logic scoped to a season

**supabase.js** — Four new data functions:
- `getAwardsForScope(scopeId)` — all awards for a game/series/season
- `getAwardsForCombatant(combatantId)` — combatant's full award history
- `getAwardsForPlayer(playerId)` — player's career awards
- `createAutoAwards(awards)` — bulk insert pre-resolved award rows

**BattleScreen.jsx** — Calls `computeGameAutoAwards` and `createAutoAwards` in `completeGame()` so game-level automatic awards are stored immediately on close.

**ChroniclesScreen.jsx (SeriesRow)** — When expanded, fetches awards for the series and shows them in a new "Series awards" section. Lazily computes+stores series auto awards on first view when all games are ended.

**SeasonScreen.jsx (SeasonDetail)** — On season close: computes+stores season auto awards (idempotent guard via ref). Shows resolved auto awards in a card above the voted-award ballot panels. VotingPanel onResolved callbacks now refresh the awards list.

**GlobalCombatantDetail.jsx** — New "Awards" section (below existing MVP section) fetches from the awards table, groups by layer (game, series, season), and renders each award with its type label.

**PlayerProfile.jsx** — New "Awards" section above the games list showing the player's career award history with type, layer, and optional value.

## Test notes
- All 674 unit tests pass; 27 new tests added for the three auto-award functions covering: empty inputs, dev/endedEarly filtering, most_wins, co-awards, undefeated, shutout, most_evolutions, most_reactions
- Automatic awards trigger at game close (completeGame), series view (lazy on expand), and season close
- Voted awards: VotingPanel already handles pending state; resolved state shown in GlobalCombatantDetail and PlayerProfile via awards table fetch