### PR TITLE
Tone — schema and game-level data model

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -33,8 +33,18 @@ export function normalizeRoomSettings(settings) {
     arenaConfig:          null,
     arenaEvolutionEnabled: false,
     isPublic:             false,
+    tone:                 null,
     ...settings,
   }
+}
+
+/**
+ * Resolves the tone for a game at draft start.
+ * Prefers an explicitly set game-level tone over the parent season's tone.
+ * Returns null if neither has a tone set.
+ */
+export function resolveTone(game, season) {
+  return game?.settings?.tone ?? season?.tone ?? null
 }
 
 /**

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -15,6 +15,7 @@ import {
   canUndoLastRound, canEditCombatant,
   extractPreviousWinners,
   normalizeRoomSettings,
+  resolveTone,
   simulateGameToEnd,
   getLineageStats,
   buildActiveFormMap,
@@ -3310,5 +3311,51 @@ describe('computeSeasonAutoAwards', () => {
   it('returns empty for rooms with no completed games', () => {
     const room = { id: 'room1', phase: 'battle', players: [], combatants: {}, rounds: [] }
     expect(computeSeasonAutoAwards([room], 'season1')).toEqual([])
+  })
+})
+
+// ─── resolveTone ──────────────────────────────────────────────────────────────
+
+describe('resolveTone', () => {
+  const TONE = { tags: ['absurdist', 'horror'], premise: 'Everyone is a food item.' }
+  const SEASON_TONE = { tags: ['wholesome'], premise: '' }
+
+  it('returns game-level tone when explicitly set', () => {
+    const game = { settings: { tone: TONE } }
+    expect(resolveTone(game, { tone: SEASON_TONE })).toEqual(TONE)
+  })
+
+  it('falls back to season tone when game tone is null', () => {
+    const game = { settings: { tone: null } }
+    expect(resolveTone(game, { tone: SEASON_TONE })).toEqual(SEASON_TONE)
+  })
+
+  it('falls back to season tone when game has no settings.tone key', () => {
+    const game = { settings: {} }
+    expect(resolveTone(game, { tone: SEASON_TONE })).toEqual(SEASON_TONE)
+  })
+
+  it('returns null when neither game nor season has a tone', () => {
+    const game = { settings: { tone: null } }
+    expect(resolveTone(game, { tone: null })).toBeNull()
+  })
+
+  it('returns null when season is null', () => {
+    const game = { settings: { tone: null } }
+    expect(resolveTone(game, null)).toBeNull()
+  })
+
+  it('returns null when game is null', () => {
+    expect(resolveTone(null, null)).toBeNull()
+  })
+
+  it('returns game tone even when season has a different tone', () => {
+    const game = { settings: { tone: TONE } }
+    expect(resolveTone(game, { tone: SEASON_TONE })).toEqual(TONE)
+  })
+
+  it('returns season tone when game has no settings at all', () => {
+    const game = {}
+    expect(resolveTone(game, { tone: SEASON_TONE })).toEqual(SEASON_TONE)
   })
 })

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -4,9 +4,82 @@ import AvatarWithHover from '../components/AvatarWithHover.jsx'
 import ShareLinkButton from '../components/ShareLinkButton.jsx'
 import SpectatorList from '../components/SpectatorList.jsx'
 import ConnectionStatus from '../components/ConnectionStatus.jsx'
-import { btn } from '../styles.js'
-import { sset, subscribeToRoom, trackRoomPresence, searchUsers, createRoomInvitation, deleteRoomInvitation, getRoomInvitations } from '../supabase.js'
-import { normalizeRoomSettings, kickPlayerFromRoom } from '../gameLogic.js'
+import TagInput from '../components/TagInput.jsx'
+import { btn, inp } from '../styles.js'
+import { sset, subscribeToRoom, trackRoomPresence, searchUsers, createRoomInvitation, deleteRoomInvitation, getRoomInvitations, getSeason } from '../supabase.js'
+import { normalizeRoomSettings, resolveTone, kickPlayerFromRoom } from '../gameLogic.js'
+
+function ToneSection({ isHost, toneEnabled, toneTags, tonePremise, seasonTone, onToggle, onTagsChange, onPremiseChange }) {
+  const inheritedLabel = seasonTone && !toneEnabled
+    ? <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginLeft: 8 }}>inherited from season</span>
+    : null
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: toneEnabled ? 10 : 0 }}>
+        <h3 style={{ fontSize: 14, color: 'var(--color-text-secondary)', fontWeight: 400, margin: 0 }}>
+          Tone {inheritedLabel}
+        </h3>
+        {isHost && (
+          <button
+            onClick={onToggle}
+            style={{ flexShrink: 0, marginLeft: 16, width: 40, height: 22, borderRadius: 99, border: 'none', outline: toneEnabled ? 'none' : '0.5px solid var(--color-border-secondary)', padding: 0, background: toneEnabled ? 'var(--color-text-info)' : 'var(--color-background-tertiary)', cursor: 'pointer', position: 'relative', transition: 'background 0.15s' }}
+          >
+            <span style={{ position: 'absolute', top: 3, left: toneEnabled ? 20 : 3, width: 16, height: 16, borderRadius: '50%', background: '#fff', transition: 'left 0.15s', display: 'block' }} />
+          </button>
+        )}
+      </div>
+      {toneEnabled && (
+        <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {isHost ? (
+            <>
+              <div>
+                <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginBottom: 5 }}>Tags (2–3)</div>
+                <TagInput value={toneTags} onChange={onTagsChange} />
+              </div>
+              <div>
+                <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginBottom: 5 }}>Premise <span style={{ opacity: 0.6 }}>(optional)</span></div>
+                <textarea
+                  value={tonePremise}
+                  onChange={e => onPremiseChange(e.target.value)}
+                  placeholder="Set the scene in a sentence or two…"
+                  maxLength={280}
+                  rows={2}
+                  style={{ ...inp(), resize: 'vertical', margin: 0 }}
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              {toneTags.length > 0 && (
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  {toneTags.map(t => (
+                    <span key={t} style={{ fontSize: 12, padding: '2px 8px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-secondary)' }}>{t}</span>
+                  ))}
+                </div>
+              )}
+              {tonePremise && (
+                <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>{tonePremise}</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+      {!toneEnabled && seasonTone && !isHost && (
+        <div style={{ background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)', padding: '10px 14px' }}>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: seasonTone.premise ? 6 : 0 }}>
+            {(seasonTone.tags || []).map(t => (
+              <span key={t} style={{ fontSize: 12, padding: '2px 8px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-secondary)' }}>{t}</span>
+            ))}
+          </div>
+          {seasonTone.premise && (
+            <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>{seasonTone.premise}</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
 
 const POOL_LABELS = {
   'standard':       'Standard',
@@ -75,6 +148,12 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
   // playerId being confirmed for kick, or null
   const [confirmKick, setConfirmKick] = useState(null)
 
+  // Tone state — null = off (inherit from season at draft start), object = host-set
+  const [season, setSeason]           = useState(null)
+  const [toneEnabled, setToneEnabled] = useState(() => !!init.settings?.tone)
+  const [toneTags, setToneTags]       = useState(() => init.settings?.tone?.tags || [])
+  const [tonePremise, setTonePremise] = useState(() => init.settings?.tone?.premise || '')
+
   // Pending invitations (host-only view)
   const [pendingInvitees, setPendingInvitees] = useState([])
   const [cancelInviteId, setCancelInviteId] = useState(null)
@@ -107,6 +186,12 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
     })
   }, [room.id])
 
+  // Load season for tone inheritance (if this game belongs to a season)
+  useEffect(() => {
+    if (!room.seasonId) return
+    getSeason(room.seasonId).then(setSeason)
+  }, [room.seasonId])
+
   // Load pending invitees for host; refresh when player count changes (catches accepts)
   useEffect(() => {
     if (!isHost) return
@@ -136,7 +221,12 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
   }, [inviteOpen])
 
   async function startGame() {
-    const updated = { ...room, phase: 'draft' }
+    const gameTone = toneEnabled && toneTags.length > 0
+      ? { tags: toneTags, premise: tonePremise.trim() }
+      : null
+    const gameWithTone = { settings: { ...room.settings, tone: gameTone } }
+    const resolved = resolveTone(gameWithTone, season)
+    const updated = { ...room, phase: 'draft', tone: resolved }
     await sset('room:' + room.id, updated)
     setLocal(updated); setRoom(updated); onStart()
   }
@@ -301,6 +391,23 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
           </div>
         )}
       </div>
+
+      <ToneSection
+        isHost={isHost}
+        toneEnabled={toneEnabled}
+        toneTags={toneTags}
+        tonePremise={tonePremise}
+        seasonTone={season?.tone ?? null}
+        onToggle={() => {
+          if (!toneEnabled && season?.tone && toneTags.length === 0) {
+            setToneTags(season.tone.tags || [])
+            setTonePremise(season.tone.premise || '')
+          }
+          setToneEnabled(v => !v)
+        }}
+        onTagsChange={setToneTags}
+        onPremiseChange={setTonePremise}
+      />
 
       <ArenaModeDisplay settings={room.settings} />
 

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import Screen from '../components/Screen.jsx'
+import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
 import { createSeason, getSeasons, updateSeason, getSeasonRooms, createPendingAward, getAwardsForScope, createAutoAwards } from '../supabase.js'
 import { uid, computeSeriesStandings, groupRoomsForHistory, getSeasonCombatantNominees, getSeasonEvolutionNominees, computeSeasonAutoAwards, AWARD_TYPE_LABELS } from '../gameLogic.js'
@@ -75,6 +76,12 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
   const awardCreationRef = useRef(false)
   const autoAwardRef    = useRef(false)
 
+  // Tone edit state (season creator only, between games)
+  const [toneEnabled,  setToneEnabled]  = useState(() => !!initialSeason.tone)
+  const [toneTags,     setToneTags]     = useState(() => initialSeason.tone?.tags || [])
+  const [tonePremise,  setTonePremise]  = useState(() => initialSeason.tone?.premise || '')
+  const [savingTone,   setSavingTone]   = useState(false)
+
   useEffect(() => {
     getSeasonRooms(season.id).then(rooms => {
       setSeasonRooms(rooms)
@@ -143,6 +150,19 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
     if (season.status !== 'ended') return
     getAwardsForScope(season.id).then(setSeasonAwards)
   }, [season.votes, season.id, season.status])
+
+  async function handleSaveTone() {
+    setSavingTone(true)
+    const tone = toneEnabled && toneTags.length > 0
+      ? { tags: toneTags, premise: tonePremise.trim() }
+      : null
+    try {
+      const updated = await updateSeason(season.id, { tone })
+      setSeason(updated)
+    } finally {
+      setSavingTone(false)
+    }
+  }
 
   async function handleCloseEarly() {
     setClosing(true)
@@ -255,6 +275,50 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
           <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>
             A series is currently in progress. Close it between series to continue the season or close early.
           </p>
+        </div>
+      )}
+
+      {/* Tone settings (season creator, between games) */}
+      {season.status === 'active' && playerId === season.owner_id && !anyActive && (
+        <div style={{ marginBottom: '1.5rem', padding: '12px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: toneEnabled ? 12 : 0 }}>
+            <div style={{ fontSize: 14, color: 'var(--color-text-primary)' }}>Season tone</div>
+            <button
+              onClick={() => setToneEnabled(v => !v)}
+              style={{ flexShrink: 0, marginLeft: 16, width: 40, height: 22, borderRadius: 99, border: 'none', outline: toneEnabled ? 'none' : '0.5px solid var(--color-border-secondary)', padding: 0, background: toneEnabled ? 'var(--color-text-info)' : 'var(--color-background-tertiary)', cursor: 'pointer', position: 'relative', transition: 'background 0.15s' }}
+            >
+              <span style={{ position: 'absolute', top: 3, left: toneEnabled ? 20 : 3, width: 16, height: 16, borderRadius: '50%', background: '#fff', transition: 'left 0.15s', display: 'block' }} />
+            </button>
+          </div>
+          {toneEnabled && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div>
+                <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginBottom: 5 }}>Tags (2–3)</div>
+                <TagInput value={toneTags} onChange={setToneTags} />
+              </div>
+              <div>
+                <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginBottom: 5 }}>Premise <span style={{ opacity: 0.6 }}>(optional)</span></div>
+                <textarea
+                  value={tonePremise}
+                  onChange={e => setTonePremise(e.target.value)}
+                  placeholder="Set the scene in a sentence or two…"
+                  maxLength={280}
+                  rows={2}
+                  style={{ ...inp(), resize: 'vertical', margin: 0 }}
+                />
+              </div>
+            </div>
+          )}
+          <button
+            onClick={handleSaveTone}
+            disabled={savingTone || (toneEnabled && toneTags.length < 2)}
+            style={{ ...btn('primary'), marginTop: toneEnabled ? 12 : 10, fontSize: 13, padding: '7px 14px' }}
+          >
+            {savingTone ? 'Saving…' : 'Save tone'}
+          </button>
+          {toneEnabled && toneTags.length < 2 && (
+            <p style={{ fontSize: 12, color: 'var(--color-text-tertiary)', margin: '6px 0 0' }}>Add at least 2 tags to save.</p>
+          )}
         </div>
       )}
 

--- a/supabase/migrations/20260501_tone.sql
+++ b/supabase/migrations/20260501_tone.sql
@@ -1,0 +1,6 @@
+-- Tone: JSONB column on rooms and seasons
+-- Shape: { tags: string[], premise: string } | null
+-- Snapshotted onto rooms.tone at draft start; never mutated after that point.
+
+ALTER TABLE rooms ADD COLUMN tone jsonb DEFAULT NULL;
+ALTER TABLE seasons ADD COLUMN tone jsonb DEFAULT NULL;


### PR DESCRIPTION
Closes #110

## What changed

- **Migration** (`20260501_tone.sql`): adds nullable `tone jsonb` column to `rooms` and `seasons` tables. Shape: `{ tags: string[], premise: string } | null`.
- **`gameLogic.js`**: adds `tone: null` default to `normalizeRoomSettings` (backwards-compat for old rooms) and exports `resolveTone(game, season)` — prefers an explicitly set game-level tone over the parent season's tone, falls through to `null` if neither is set.
- **`gameLogic.test.js`**: 8 unit tests covering all `resolveTone` resolution paths.
- **`LobbyScreen.jsx`**: host-only `ToneSection` component (toggle, TagInput, premise textarea); pre-populates from season tone when host first enables it. At draft start (`startGame()`), the resolved tone is snapshotted onto `room.tone` before the phase transition — never mutated after that point.
- **`SeasonScreen.jsx`**: season creator sees a "Season tone" edit panel between games (`status === 'active' && !anyActive`). Toggle + TagInput + premise + save button (requires ≥2 tags). Saves via existing `updateSeason`.

## Test notes

- Create a season, open season settings → tone toggle appears between games; requires 2+ tags to save.
- Create a room under that season, open lobby → tone section shows "inherited from season" label; host can override or leave as-is.
- Start the draft → `room.tone` is snapshotted (check via Supabase table editor or browser state).
- Create a room with no season → tone toggle defaults off; leaving it off results in `room.tone = null` after draft start.
- Unit tests: `npx vitest run` → 770 passed.