### PR TITLE
Context Strip — ambient game info on draft, vote, and end screens

### DIFF
--- a/src/components/ContextStrip.jsx
+++ b/src/components/ContextStrip.jsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react'
+import Pill from './Pill.jsx'
+import { getSeason } from '../supabase.js'
+
+// Compact ambient strip shown at the top of draft, vote, and game-end screens.
+// Surfaces season context, tone, and (when relevant) the current arena.
+// Returns null when there is nothing to show.
+export default function ContextStrip({ room, currentArena }) {
+  const [season, setSeason] = useState(null)
+
+  useEffect(() => {
+    if (!room.seasonId) return
+    getSeason(room.seasonId).then(setSeason)
+  }, [room.seasonId])
+
+  const tone     = room.tone
+  const hasTone  = tone?.tags?.length > 0 || !!tone?.premise
+  const hasArena = !!currentArena
+
+  if (!season && !hasTone && !hasArena) return null
+
+  const seasonLabel = season
+    ? [season.name, room.seriesIndex ? `Game ${room.seriesIndex}` : null].filter(Boolean).join(' · ')
+    : null
+
+  return (
+    <div style={{ marginBottom: '1rem', padding: '8px 12px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        {seasonLabel && (
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+            {seasonLabel}
+          </div>
+        )}
+        {tone?.tags?.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            {tone.tags.map(tag => <Pill key={tag}>{tag}</Pill>)}
+          </div>
+        )}
+        {tone?.premise && (
+          <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', fontStyle: 'italic' }}>
+            {tone.premise}
+          </div>
+        )}
+        {hasArena && (
+          <div style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>
+            @ {currentArena.name}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -5,6 +5,7 @@ import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
 import { sget, sset, incrementCombatantStats, subscribeToRoom, trackRoomPresence, getRandomArenaFromPool, getHeritageChain, getArena, createArenaVariant, getPlaylistForDelivery, createPendingAward, appendMvpRecord, createAutoAwards } from '../supabase.js'
 import VotingPanel from '../components/VotingPanel.jsx'
+import ContextStrip from '../components/ContextStrip.jsx'
 import { uid, canUndoLastRound, undoRound, tallyReactions, normalizeRoomSettings, computeGameAutoAwards } from '../gameLogic.js'
 
 // Inline form for evolving the current arena after a round resolves.
@@ -322,6 +323,7 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
     <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
       {room.devMode && <DevBanner />}
       <ConnectionStatus players={room.players} presentIds={presentIds} isHost={isHost} roomCode={room.code} />
+      <ContextStrip room={room} currentArena={null} />
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
         <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>Battle arena</h2>
         <div style={{ display: 'flex', gap: 6 }}>

--- a/src/screens/DraftScreen.jsx
+++ b/src/screens/DraftScreen.jsx
@@ -3,6 +3,7 @@ import Screen from '../components/Screen.jsx'
 import AvatarWithHover from '../components/AvatarWithHover.jsx'
 import Pill from '../components/Pill.jsx'
 import DevBanner from '../components/DevBanner.jsx'
+import ContextStrip from '../components/ContextStrip.jsx'
 import FighterAutocomplete from '../components/FighterAutocomplete.jsx'
 import CombatantStatsPill from '../components/CombatantStatsPill.jsx'
 import { btn, inp } from '../styles.js'
@@ -18,7 +19,7 @@ import {
 
 export default function DraftScreen({ room: init, playerId, setRoom, onDone, isGuest, onLogin, onBack, onEndSeries }) {
   const [room, setLocal] = useState(init)
-  const { rosterSize } = normalizeRoomSettings(init.settings)
+  const { rosterSize, arenaMode, arenaConfig } = normalizeRoomSettings(init.settings)
   // substitutions: { [originalId]: combatant } — active-form overrides for heritage games
   const [substitutions, setSubstitutions] = useState({})
   // stashedCombatants: logged-in player's private stash — shown only in their own autocomplete
@@ -429,6 +430,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
     <div style={{ padding: '1rem', maxWidth: 500, margin: '0 auto' }}>
       {room.devMode && <DevBanner />}
       <button onClick={onBack} style={{ ...btn('ghost'), padding: '4px 10px', fontSize: 13, marginBottom: '1rem' }}>← Back</button>
+      <ContextStrip room={room} currentArena={arenaMode === 'single' ? arenaConfig?.arenaSnapshot : null} />
       <p style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.08em', margin: '0 0 4px' }}>The Fight Card</p>
       <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: '0.25rem' }}>
         <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>Your {rosterSize} combatants</h2>

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -8,6 +8,7 @@ import ConnectionStatus from '../components/ConnectionStatus.jsx'
 import { btn, inp } from '../styles.js'
 import { sget, sset, incrementCombatantStats, publishCombatants, publishArenas, publishPlaylist, subscribeToRoom, createVariantCombatant, checkCombatantNameExists, getCombatant, trackRoomPresence, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getGroupsForCombatants, getCombatantGroupIds, setCombatantGroups } from '../supabase.js'
 import SpectatorList from '../components/SpectatorList.jsx'
+import ContextStrip from '../components/ContextStrip.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { uid, canEditCombatant, simulateGameToEnd, applyWinner, applyDraw, applyMerge, toggleReaction, tallyReactions, isFinalRound, normalizeRoomSettings, buildEvolutionRound, getEphemeralBadges, getCombatantsToPublish, resolveAllAdvanceSelection } from '../gameLogic.js'
 
@@ -694,6 +695,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
           {simulating ? 'Simulating…' : '🧪 Simulate to end of game'}
         </button>
       )}
+      <ContextStrip room={room} currentArena={round.arena} />
 
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.25rem' }}>
         <h2 style={{ fontSize: 22, fontWeight: 500, margin: 0, color: 'var(--color-text-primary)' }}>Round {round.number}</h2>


### PR DESCRIPTION
Closes #111

## What changed

New `ContextStrip` component (`src/components/ContextStrip.jsx`) that renders a compact, read-only ambient info strip. It:

- Loads the season name from Supabase when `room.seasonId` is set (self-contained fetch, no parent refactoring needed)
- Shows season name + game counter (`Season Name · Game N` when in a series)
- Shows tone tags as `Pill` components + premise line when `room.tone` is set
- Shows the arena name when `currentArena` is passed
- Returns `null` if none of the above apply — no empty box ever renders

Placed in three screens:

| Screen | Arena prop | Notes |
|---|---|---|
| `DraftScreen` | `arenaConfig?.arenaSnapshot` when `arenaMode === 'single'`, else `null` | `arenaMode`/`arenaConfig` added to the existing `normalizeRoomSettings` destructure |
| `VoteScreen` | `round.arena` | Always; round is guaranteed non-null at render |
| `BattleScreen` | `null` | Season/tone shown throughout game and at the game-end state |

## Test notes

- Play a game in a season with tone set — strip should appear on draft and vote screens showing season name, tone pills, and premise
- Play with single-arena mode — arena name should appear in draft strip and vote strip
- Play with playlist/random-pool — no arena in draft strip, arena still shown on vote screen
- Game with no season and no tone — strip renders nothing (invisible)
- Series game (`room.seriesIndex` set) — counter appends `· Game N`