### PR TITLE
Tone in the Chronicles — season/series tone display and 'So Many Tones' fallback

### DIFF
--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -48,6 +48,34 @@ export function resolveTone(game, season) {
 }
 
 /**
+ * Derives a display tone for a season or series by comparing the snapshotted
+ * room.tone across all games in the container.
+ *
+ * Returns:
+ *   { type: 'consistent', tags: string[], premise: string | null }
+ *     when all games with a tone share identical tag sets
+ *   { type: 'varied' }
+ *     when tone tags differ across any games
+ *   null
+ *     when no games had tone set
+ */
+export function computeSeasonToneDisplay(rooms) {
+  const toned = (rooms || []).filter(r => r.tone?.tags?.length > 0)
+  if (toned.length === 0) return null
+
+  const fingerprint = r => [...r.tone.tags].sort().join('\0')
+  const first = fingerprint(toned[0])
+  const consistent = toned.every(r => fingerprint(r) === first)
+
+  if (!consistent) return { type: 'varied' }
+
+  const sorted = [...toned].sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))
+  const premise = sorted.find(r => r.tone.premise)?.tone.premise ?? null
+
+  return { type: 'consistent', tags: toned[0].tone.tags, premise }
+}
+
+/**
  * Builds a round.arena snapshot from an arena DB record.
  * Maps arena.bio → description and arena.rules → houseRules per the schema contract.
  */

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -16,6 +16,7 @@ import {
   extractPreviousWinners,
   normalizeRoomSettings,
   resolveTone,
+  computeSeasonToneDisplay,
   simulateGameToEnd,
   getLineageStats,
   buildActiveFormMap,
@@ -3357,5 +3358,73 @@ describe('resolveTone', () => {
   it('returns season tone when game has no settings at all', () => {
     const game = {}
     expect(resolveTone(game, { tone: SEASON_TONE })).toEqual(SEASON_TONE)
+  })
+})
+
+// ─── computeSeasonToneDisplay ─────────────────────────────────────────────────
+
+describe('computeSeasonToneDisplay', () => {
+  const tone = (tags, premise = '') => ({ tone: { tags, premise } })
+
+  it('returns null when no rooms have tone', () => {
+    expect(computeSeasonToneDisplay([{ tone: null }, {}])).toBeNull()
+  })
+
+  it('returns null for empty array', () => {
+    expect(computeSeasonToneDisplay([])).toBeNull()
+  })
+
+  it('returns null when called with no argument', () => {
+    expect(computeSeasonToneDisplay()).toBeNull()
+  })
+
+  it('returns consistent when single room has tone', () => {
+    const result = computeSeasonToneDisplay([tone(['dark', 'comedic'])])
+    expect(result).toEqual({ type: 'consistent', tags: ['dark', 'comedic'], premise: null })
+  })
+
+  it('returns consistent when all rooms share identical tags', () => {
+    const rooms = [tone(['absurdist', 'horror']), tone(['absurdist', 'horror'])]
+    expect(computeSeasonToneDisplay(rooms)).toEqual({ type: 'consistent', tags: ['absurdist', 'horror'], premise: null })
+  })
+
+  it('is tag-order insensitive when comparing', () => {
+    const rooms = [tone(['b', 'a']), tone(['a', 'b'])]
+    const result = computeSeasonToneDisplay(rooms)
+    expect(result.type).toBe('consistent')
+  })
+
+  it('returns varied when tags differ across rooms', () => {
+    const rooms = [tone(['dark']), tone(['wholesome'])]
+    expect(computeSeasonToneDisplay(rooms)).toEqual({ type: 'varied' })
+  })
+
+  it('ignores rooms with no tone when checking consistency', () => {
+    const rooms = [tone(['dark', 'comedic']), { tone: null }, tone(['dark', 'comedic'])]
+    const result = computeSeasonToneDisplay(rooms)
+    expect(result).toEqual({ type: 'consistent', tags: ['dark', 'comedic'], premise: null })
+  })
+
+  it('includes premise from the most recently created room', () => {
+    const rooms = [
+      { tone: { tags: ['dark'], premise: 'older' }, createdAt: 1000 },
+      { tone: { tags: ['dark'], premise: 'newer' }, createdAt: 2000 },
+    ]
+    const result = computeSeasonToneDisplay(rooms)
+    expect(result.premise).toBe('newer')
+  })
+
+  it('premise is null when no rooms have a premise', () => {
+    const rooms = [tone(['dark']), tone(['dark'])]
+    expect(computeSeasonToneDisplay(rooms).premise).toBeNull()
+  })
+
+  it('premise falls back to room with premise even if not most recent', () => {
+    const rooms = [
+      { tone: { tags: ['dark'], premise: 'has one' }, createdAt: 1000 },
+      { tone: { tags: ['dark'], premise: '' }, createdAt: 2000 },
+    ]
+    const result = computeSeasonToneDisplay(rooms)
+    expect(result.premise).toBe('has one')
   })
 })

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import RoundChat from '../components/RoundChat.jsx'
 import CombatantSheet from '../components/CombatantSheet.jsx'
 import { btn, tab } from '../styles.js'
-import { tallyReactions, groupRoomsForHistory, computeSeriesStandings, computeSeriesAutoAwards, AWARD_TYPE_LABELS } from '../gameLogic.js'
+import { tallyReactions, groupRoomsForHistory, computeSeriesStandings, computeSeriesAutoAwards, computeSeasonToneDisplay, AWARD_TYPE_LABELS } from '../gameLogic.js'
 import { slist, getAwardsForScope, createAutoAwards } from '../supabase.js'
 import { downloadFile, formatRoomAsText, formatSeriesAsText } from '../export.js'
 
@@ -62,6 +62,20 @@ function ChroniclesRoomDetail({ room, onBack, setViewCombatant, playerId, onNext
         <div style={{ marginBottom: '1.5rem', padding: '14px 16px', background: 'var(--color-background-info)', border: '0.5px solid var(--color-border-info)', borderRadius: 'var(--border-radius-lg)' }}>
           <p style={{ fontSize: 13, color: 'var(--color-text-info)', margin: '0 0 10px' }}>You hosted this game. Continue the series with the same players.</p>
           <button onClick={() => onNextGame(room)} style={{ ...btn('ghost'), padding: '6px 14px', fontSize: 13, color: 'var(--color-text-info)', borderColor: 'var(--color-border-info)' }}>Continue series ⚔️</button>
+        </div>
+      )}
+
+      {room.tone?.tags?.length > 0 && (
+        <div style={{ marginBottom: '1.5rem', padding: '10px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+          <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 7 }}>Tone</div>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: room.tone.premise ? 6 : 0 }}>
+            {room.tone.tags.map(t => (
+              <span key={t} style={{ fontSize: 12, padding: '2px 8px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-secondary)' }}>{t}</span>
+            ))}
+          </div>
+          {room.tone.premise && (
+            <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>{room.tone.premise}</p>
+          )}
         </div>
       )}
 
@@ -462,6 +476,28 @@ function SeriesRow({ item, onSelect, playerId }) {
               </div>
             </div>
           )}
+          {(() => {
+            const display = computeSeasonToneDisplay(rooms)
+            if (!display) return null
+            return (
+              <div style={{ padding: '10px 16px', borderBottom: '0.5px solid var(--color-border-tertiary)' }}>
+                <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 7 }}>Tone</div>
+                {display.type === 'varied'
+                  ? <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>So Many Tones</span>
+                  : <>
+                      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: display.premise ? 6 : 0 }}>
+                        {display.tags.map(t => (
+                          <span key={t} style={{ fontSize: 12, padding: '2px 8px', borderRadius: 99, background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-secondary)' }}>{t}</span>
+                        ))}
+                      </div>
+                      {display.premise && (
+                        <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>{display.premise}</p>
+                      )}
+                    </>
+                }
+              </div>
+            )
+          })()}
           <div style={{ padding: '0 12px 4px' }}>
             {rooms.map(r => <RoomRow key={r.id} room={r} onSelect={onSelect} playerId={playerId} />)}
           </div>

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -3,7 +3,7 @@ import Screen from '../components/Screen.jsx'
 import TagInput from '../components/TagInput.jsx'
 import { btn, inp, lbl } from '../styles.js'
 import { createSeason, getSeasons, updateSeason, getSeasonRooms, createPendingAward, getAwardsForScope, createAutoAwards } from '../supabase.js'
-import { uid, computeSeriesStandings, groupRoomsForHistory, getSeasonCombatantNominees, getSeasonEvolutionNominees, computeSeasonAutoAwards, AWARD_TYPE_LABELS } from '../gameLogic.js'
+import { uid, computeSeriesStandings, groupRoomsForHistory, getSeasonCombatantNominees, getSeasonEvolutionNominees, computeSeasonAutoAwards, computeSeasonToneDisplay, AWARD_TYPE_LABELS } from '../gameLogic.js'
 import VotingPanel from '../components/VotingPanel.jsx'
 
 function ToggleRow({ label, description, value, onToggle }) {
@@ -225,6 +225,30 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
       {seasonRooms !== null && seasonRooms.length > 0 && (
         <StandingsTable rooms={seasonRooms} />
       )}
+
+      {/* Derived tone display */}
+      {seasonRooms !== null && (() => {
+        const display = computeSeasonToneDisplay(seasonRooms)
+        if (!display) return null
+        return (
+          <div style={{ marginBottom: '1rem', padding: '10px 14px', background: 'var(--color-background-secondary)', border: '0.5px solid var(--color-border-tertiary)', borderRadius: 'var(--border-radius-md)' }}>
+            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 7 }}>Tone</div>
+            {display.type === 'varied'
+              ? <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>So Many Tones</span>
+              : <>
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: display.premise ? 6 : 0 }}>
+                    {display.tags.map(t => (
+                      <span key={t} style={{ fontSize: 12, padding: '2px 8px', borderRadius: 99, background: 'var(--color-background-tertiary)', border: '0.5px solid var(--color-border-secondary)', color: 'var(--color-text-secondary)' }}>{t}</span>
+                    ))}
+                  </div>
+                  {display.premise && (
+                    <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>{display.premise}</p>
+                  )}
+                </>
+            }
+          </div>
+        )
+      })()}
 
       {/* Series history */}
       {[...seriesItems, ...standaloneItems].length > 0 && (


### PR DESCRIPTION
Closes #112

## What changed

- **`computeSeasonToneDisplay(rooms)`** added to `gameLogic.js` — pure function that derives a display tone for a container of rooms by comparing snapshotted `room.tone` values:
  - All games share identical tags → `{ type: 'consistent', tags, premise }` (premise from most recently created room that has one)
  - Tags differ across any games → `{ type: 'varied' }`
  - No games had tone → `null`
- **SeasonDetail** (SeasonScreen): derived tone block rendered after standings, before series history. Hidden when no games had tone.
- **SeriesRow expanded** (ChroniclesScreen): derived tone block rendered after series awards, before the game list. Hidden when no games had tone.
- **ChroniclesRoomDetail** (ChroniclesScreen): individual room's snapshotted `room.tone` shown after the "continue series" banner and before results. Hidden when the room has no tone.
- 12 new unit tests for `computeSeasonToneDisplay` covering: empty/null inputs, single room, consistent tags, tag-order insensitivity, varied tags, rooms without tone ignored, premise selection by recency.

## Test notes
- `npx vitest run` — 781 tests, all passing.
- To verify: play a few games with different tones set in the lobby, then check the expanded series view in Chronicles and the season detail page.
- "So Many Tones" renders when games in a container had different tone tags.
- Tone section absent (no empty block) when no games in the container had tone.