### PR TITLE
Bug: login from top-right pill leaves user on blank screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -240,7 +240,7 @@ export default function App() {
     isGuest={isGuest}
     effectiveName={effectiveName}
     onLogout={logout}
-    onLogin={goAuth}
+    onLogin={() => goAuth('home')}
   />
 
   async function handleHostNextGame(completedRoom) {


### PR DESCRIPTION
Closes #113

## What changed
`UserPill` rendered its "Log in / Register" button as `<button onClick={onLogin}>`, which passes the `MouseEvent` as the first argument. The `onLogin` prop was bound directly to `goAuth`, so `goAuth(mouseEvent)` was called. Inside `goAuth`, `target ?? screen` resolved to the `MouseEvent` (truthy, so nullish coalescing didn't fall through), setting `afterAuth` to the event object. After auth completed, `nav(afterAuth || 'home')` tried to navigate to the event object — producing a blank screen.

Fix: wrap the prop in an arrow function so the event is discarded and `goAuth('home')` is called explicitly, consistent with all other in-flow `onLogin` call sites.

## Test notes
- Log in as a guest, open the top-right pill, tap "Log in / Register", complete auth → should land on home screen
- Verify existing in-flow login paths (draft, vote, lobby) still return to their respective screens after auth