### PR TITLE
ESLint: full lint cleanup — zero errors, zero warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,7 +58,7 @@ export default [
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
 
-      "no-console": "warn",
+      "no-console": ["warn", { allow: ["error"] }],
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default [
     rules: {
       // React
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
+      "react-hooks/exhaustive-deps": "off",
       "react/jsx-key": "error",
       "react/no-unknown-property": "error",
       "react/react-in-jsx-scope": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default [
     rules: {
       // React
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "off",
+      "react-hooks/exhaustive-deps": "warn",
       "react/jsx-key": "error",
       "react/no-unknown-property": "error",
       "react/react-in-jsx-scope": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,16 +6,17 @@ import tsPlugin from "@typescript-eslint/eslint-plugin";
 
 export default [
   {
-    files: ["**/*.{js,jsx,ts,tsx}"],
-
     ignores: [
       "dist/**",
       "build/**",
       "node_modules/**",
       "coverage/**",
       ".claude/**",
-      "supabase/functions/**" // 👈 optional if you want to skip edge funcs for now
+      "supabase/functions/**",
     ],
+  },
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
 
     languageOptions: {
       parser: tsParser, // 🔥 THIS IS THE BIG FIX
@@ -55,7 +56,7 @@ export default [
 
       // TS-aware unused vars (turn OFF base rule)
       "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
 
       "no-console": "warn",
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,7 +147,7 @@ export default function App() {
     }
   }
 
-  useEffect(() => { refreshLobbies() }, [currentUser?.id])
+  useEffect(() => { refreshLobbies() }, [currentUser?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [afterAuth, setAfterAuth] = useState(null)
   const [room, setRoom] = useState(null)
@@ -202,7 +202,7 @@ export default function App() {
       await sset('room:' + r.id, updated)
       setRoom(updated)
     })()
-  }, [currentUser?.id])
+  }, [currentUser?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const nav = s => setScreen(s)
 

--- a/src/components/CombatantSheet.jsx
+++ b/src/components/CombatantSheet.jsx
@@ -36,7 +36,7 @@ export default function CombatantSheet({ combatantId, combatant: inRoom, playerI
       }
       setLoading(false)
     })
-  }, [combatantId])
+  }, [combatantId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function pushCombatant(record) {
     setStack(s => [...s, { type: 'global', data: record }])
@@ -210,7 +210,7 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
     setC(init); setEditMode(false); setEditName(init.name); setEditBio(init.bio || '')
     setLineageStory([]); setLineageTree([]); setOwnChainStory([]); setOwnChainTree([])
     setH2hOpen(false); setH2hRows(null); setGroups([])
-  }, [init.id])
+  }, [init.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     getGroupsForCombatants([init.id]).then(map => setGroups(map[init.id] || []))
@@ -235,7 +235,7 @@ function GlobalView({ combatant: init, playerId, playerName, onViewCombatant }) 
         if (story.length > 1) setOwnChainStory(story)
       })
     }
-  }, [rootId, c.id])
+  }, [rootId, c.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function toggleH2h() {
     if (!h2hOpen && h2hRows === null) getCombatantRoundHistory(c.id).then(setH2hRows)

--- a/src/components/VotingPanel.jsx
+++ b/src/components/VotingPanel.jsx
@@ -268,7 +268,7 @@ export default function VotingPanel({ awardId, label, nominees, voters, playerId
 }
 
 // Read-only result display shown after the award is resolved.
-function VotingResult({ award, label, nominees }) {
+function VotingResult({ award, label, _nominees }) {
   const recipientName = award.recipient_name || '?'
   const isCoAward = award.co_award
 

--- a/src/components/VotingPanel.jsx
+++ b/src/components/VotingPanel.jsx
@@ -89,7 +89,7 @@ export default function VotingPanel({ awardId, label, nominees, voters, playerId
     }
 
     handleResolution(resolution)
-  }, [votes, award, phase, lockedVoterIds, resolved, isHost])
+  }, [votes, award, phase, lockedVoterIds, resolved, isHost]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Actions ──────────────────────────────────────────────────────────────
 

--- a/src/screens/ArenaDetailScreen.jsx
+++ b/src/screens/ArenaDetailScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import Screen from '../components/Screen.jsx'
 import TagChips from '../components/TagChips.jsx'
 import TagInput from '../components/TagInput.jsx'
-import { btn, inp } from '../styles.js'
+import { btn } from '../styles.js'
 import { getArena, getArenaLineageTree, getArenaReaction, upsertArenaReaction, deleteArenaReaction, getArenaAppearances, hasPlayerEncounteredArena, ARENA_DISLIKE_RATIO, superHostSetEntityTags, superHostSetArenaPools } from '../supabase.js'
 import GameSummaryScreen from './GameSummaryScreen.jsx'
 

--- a/src/screens/AuthScreen.jsx
+++ b/src/screens/AuthScreen.jsx
@@ -43,7 +43,7 @@ export default function AuthScreen({ onLogin, onBack }) {
         setLoading(false); onLogin({ id: userRecord.id, username: userRecord.username })
       }
     })()
-  }, [pin])
+  }, [pin]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (mode === 'lookup') {
     return (

--- a/src/screens/BattleScreen.jsx
+++ b/src/screens/BattleScreen.jsx
@@ -116,14 +116,14 @@ export default function BattleScreen({ room: init, playerId, setRoom, onVote, on
       setLocal(r); setRoom(r)
       if (r.phase === 'voting') onVote()
     })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return trackRoomPresence(room.id, playerId, isHost ? 'host' : 'player', {
       onHostStatusChange: setHostOnline,
       onPresenceChange:   setPresentIds,
     })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const isHost = room.host === playerId
   const round = room.rounds[room.currentRound - 1]

--- a/src/screens/ChroniclesScreen.jsx
+++ b/src/screens/ChroniclesScreen.jsx
@@ -420,7 +420,7 @@ function SeriesRow({ item, onSelect, playerId }) {
         }
       }
     })
-  }, [expanded, seriesId])
+  }, [expanded, seriesId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function exportSeries() {
     const sorted = [...rooms].sort((a, b) => (a.seriesIndex || 0) - (b.seriesIndex || 0))

--- a/src/screens/CreateRoom.jsx
+++ b/src/screens/CreateRoom.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import Screen from '../components/Screen.jsx'
 import { btn, inp, lbl, tab } from '../styles.js'
 import { sset, getArenaPickerOptions, getPlaylistPickerOptions } from '../supabase.js'

--- a/src/screens/DraftScreen.jsx
+++ b/src/screens/DraftScreen.jsx
@@ -80,7 +80,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
       setSaveStatus('saved')
     }, 2000)
     return () => clearTimeout(saveTimer.current)
-  }, [names, bios, globalIds, traps, stashSourceIds, submitted])
+  }, [names, bios, globalIds, traps, stashSourceIds, submitted]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return subscribeToRoom(room.id, r => {
@@ -91,7 +91,7 @@ export default function DraftScreen({ room: init, playerId, setRoom, onDone, isG
       setLocal(r); setRoom(r)
       if (r.phase === 'battle') onDone()
     })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Heritage game: load the ancestry chain and build active-form substitutions
   // so the autocomplete shows evolved forms instead of their superseded originals.

--- a/src/screens/GlobalCombatantDetail.jsx
+++ b/src/screens/GlobalCombatantDetail.jsx
@@ -279,7 +279,7 @@ export default function GlobalCombatantDetail({ combatant: init, playerId, playe
     getAwardsForCombatant(c.id).then(awards => {
       setCombatantAwards(awards.filter(a => a.type !== 'mvp'))
     })
-  }, [rootId, c.id])
+  }, [rootId, c.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function nameSlug() {
     return c.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '').slice(0, 30)

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -196,7 +196,7 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
   useEffect(() => {
     if (!isHost) return
     getRoomInvitations(room.id).then(setPendingInvitees)
-  }, [room.players?.length, isHost])
+  }, [room.id, room.players?.length, isHost])
 
   // Debounced user search for the invite panel
   useEffect(() => {
@@ -213,7 +213,7 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
       setInviteSearching(false)
     }, 300)
     return () => clearTimeout(t)
-  }, [inviteQuery, inviteOpen, room.players, pendingInvitees])
+  }, [inviteQuery, inviteOpen, room.players, pendingInvitees, playerId])
 
   // Focus the search input when the panel opens
   useEffect(() => {

--- a/src/screens/LobbyScreen.jsx
+++ b/src/screens/LobbyScreen.jsx
@@ -178,13 +178,13 @@ export default function LobbyScreen({ room: init, playerId, setRoom, isGuest, on
       if (r.phase === 'draft') onStart()
       if (r.phase === 'ended') onBack()
     })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return trackRoomPresence(room.id, playerId, isHost ? 'host' : 'player', {
       onPresenceChange: setPresentIds,
     })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load season for tone inheritance (if this game belongs to a season)
   useEffect(() => {

--- a/src/screens/PlayerProfile.jsx
+++ b/src/screens/PlayerProfile.jsx
@@ -42,7 +42,7 @@ export default function PlayerProfile({ profileId, playerId, onBack, onViewComba
       .then(({ items, total }) => { setCombatants(items); setCombTotal(total); setCombLoading(false); setLoading(false) })
   }
 
-  useEffect(() => { loadCombatants(query, sort, page) }, [profileId, sort, page])
+  useEffect(() => { loadCombatants(query, sort, page) }, [profileId, sort, page]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleQuery(v) {
     setQuery(v); setPage(0)

--- a/src/screens/PlayersScreen.jsx
+++ b/src/screens/PlayersScreen.jsx
@@ -25,7 +25,7 @@ export default function PlayersScreen({ playerId, onBack, onViewPlayer }) {
       .then(({ items, total }) => { setItems(items); setTotal(total); setLoading(false) })
   }
 
-  useEffect(() => { load(query, sort, page) }, [sort, page])
+  useEffect(() => { load(query, sort, page) }, [sort, page]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleQuery(v) {
     setQuery(v); setPage(0)

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -119,7 +119,7 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
       .then(() => updateSeason(season.id, { votes: { favoriteCombatantAwardId: favId, mostCreativeAwardId: mccId, bestEvolutionAwardId: bestId } }))
       .then(updated => setSeason(updated))
       .catch(e => console.error('createSeasonAwards', e))
-  }, [season.status, season.votes, seasonRooms])
+  }, [season.status, season.id, season.votes, seasonRooms])
 
   // Compute and store automatic season awards once (idempotent guard via autoAwardRef).
   useEffect(() => {

--- a/src/screens/SeasonScreen.jsx
+++ b/src/screens/SeasonScreen.jsx
@@ -257,7 +257,6 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             {seriesItems.map((item, idx) => {
               const firstGame = item.rooms[0]
-              const lastGame  = item.rooms[item.rooms.length - 1]
               const allDone   = item.rooms.every(r => r.phase === 'ended')
               const dateStr   = new Date(firstGame.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
               const totalRounds = item.rooms.reduce((n, r) => n + (r.rounds || []).filter(rd => rd.winner || rd.draw).length, 0)
@@ -276,7 +275,7 @@ function SeasonDetail({ season: initialSeason, playerId, onBack, onStartSeries }
                 </div>
               )
             })}
-            {standaloneItems.map((item, idx) => {
+            {standaloneItems.map((item, _idx) => {
               const r = item.room
               const dateStr = new Date(r.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
               const rounds = (r.rounds || []).filter(rd => rd.winner || rd.draw).length

--- a/src/screens/SpectateScreen.jsx
+++ b/src/screens/SpectateScreen.jsx
@@ -10,7 +10,7 @@ export default function SpectateScreen({ room: init, playerId, setRoom, onHome }
 
   useEffect(() => {
     return subscribeToRoom(room.id, r => { setLocal(r); setRoom(r) })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const spectators   = room.spectators || []
   const round        = room.currentRound > 0 ? room.rounds[room.currentRound - 1] : null

--- a/src/screens/VoteScreen.jsx
+++ b/src/screens/VoteScreen.jsx
@@ -159,14 +159,14 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
       }
       setLocal(r); setRoom(r)
     })
-  }, [room.id, room.currentRound])
+  }, [room.id, room.currentRound]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return trackRoomPresence(room.id, playerId, isHost ? 'host' : 'player', {
       onHostStatusChange: setHostOnline,
       onPresenceChange:   setPresentIds,
     })
-  }, [room.id])
+  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const arenaId = round?.arena?.id
 
@@ -179,7 +179,7 @@ export default function VoteScreen({ room: init, playerId, setRoom, onResult, on
     if (!round?.combatants?.length) return
     const ids = round.combatants.map(c => c.id)
     getGroupsForCombatants(ids).then(setCombatantGroupsState)
-  }, [round?.id])
+  }, [round?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleArenaReaction(value) {
     if (!arenaId || !playerId || arenaReacting) return

--- a/src/screens/WorkshopScreen.jsx
+++ b/src/screens/WorkshopScreen.jsx
@@ -1260,7 +1260,7 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
     getWorkshopCombatants(currentUser.id).then(data => {
       setItems(data); setLoading(false)
     })
-  }, [currentUser?.id])
+  }, [currentUser?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Lazy-load arenas on first visit to that section
   useEffect(() => {
@@ -1270,7 +1270,7 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
     getWorkshopArenas(currentUser.id).then(data => {
       setArenaItems(data); setArenaLoading(false); setArenaLoaded(true)
     })
-  }, [section, arenaLoaded, currentUser?.id])
+  }, [section, arenaLoaded, currentUser?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Lazy-load playlists on first visit to that section
   useEffect(() => {
@@ -1280,7 +1280,7 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
     getWorkshopPlaylists(currentUser.id).then(data => {
       setPlaylistItems(data); setPlaylistLoading(false); setPlaylistLoaded(true)
     })
-  }, [section, playlistLoaded, currentUser?.id])
+  }, [section, playlistLoaded, currentUser?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Lazy-load groups on first visit to that section
   useEffect(() => {
@@ -1290,7 +1290,7 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
     getWorkshopGroups(currentUser.id).then(data => {
       setGroupItems(data); setGroupLoading(false); setGroupLoaded(true)
     })
-  }, [section, groupLoaded, currentUser?.id])
+  }, [section, groupLoaded, currentUser?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!currentUser) return <GuestGate onLogin={onLogin} />
 

--- a/src/screens/WorkshopScreen.jsx
+++ b/src/screens/WorkshopScreen.jsx
@@ -1224,8 +1224,6 @@ function GroupCard({ group, onEdit, onPublish, onUnpublish, onDelete }) {
 // ─── Main screen ──────────────────────────────────────────────────────────────
 
 export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
-  if (!currentUser) return <GuestGate onLogin={onLogin} />
-
   const [section,    setSection]    = useState('combatants')  // 'combatants' | 'arenas' | 'playlists' | 'groups'
   const [view,       setView]       = useState('library')     // 'library' | 'create' | 'edit'
   const [editTarget, setEditTarget] = useState(null)
@@ -1257,38 +1255,44 @@ export default function WorkshopScreen({ currentUser, onBack, onLogin }) {
   const [groupEditTarget, setGroupEditTarget] = useState(null)
 
   useEffect(() => {
+    if (!currentUser) return
     setLoading(true)
     getWorkshopCombatants(currentUser.id).then(data => {
       setItems(data); setLoading(false)
     })
-  }, [currentUser.id])
+  }, [currentUser?.id])
 
   // Lazy-load arenas on first visit to that section
   useEffect(() => {
+    if (!currentUser) return
     if (section !== 'arenas' || arenaLoaded) return
     setArenaLoading(true)
     getWorkshopArenas(currentUser.id).then(data => {
       setArenaItems(data); setArenaLoading(false); setArenaLoaded(true)
     })
-  }, [section, arenaLoaded, currentUser.id])
+  }, [section, arenaLoaded, currentUser?.id])
 
   // Lazy-load playlists on first visit to that section
   useEffect(() => {
+    if (!currentUser) return
     if (section !== 'playlists' || playlistLoaded) return
     setPlaylistLoading(true)
     getWorkshopPlaylists(currentUser.id).then(data => {
       setPlaylistItems(data); setPlaylistLoading(false); setPlaylistLoaded(true)
     })
-  }, [section, playlistLoaded, currentUser.id])
+  }, [section, playlistLoaded, currentUser?.id])
 
   // Lazy-load groups on first visit to that section
   useEffect(() => {
+    if (!currentUser) return
     if (section !== 'groups' || groupLoaded) return
     setGroupLoading(true)
     getWorkshopGroups(currentUser.id).then(data => {
       setGroupItems(data); setGroupLoading(false); setGroupLoaded(true)
     })
-  }, [section, groupLoaded, currentUser.id])
+  }, [section, groupLoaded, currentUser?.id])
+
+  if (!currentUser) return <GuestGate onLogin={onLogin} />
 
   // ── Combatant handlers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #N/A — no tracker issue; lint cleanup initiated from session.

## What changed

**`eslint.config.js`**
- Moved `ignores` to a standalone config object (nested ignores were local-only; standalone ignores are global)
- Added `varsIgnorePattern: "^_"` so intentional discard bindings like `_removed` and `_c` are exempt
- Scoped `no-console` to `allow: ["error"]` — the codebase uses `console.error` exclusively and intentionally throughout the data layer; `console.log` is still flagged
- `exhaustive-deps` kept at `warn` with per-instance suppressions (see below)

**Genuine bug fixes**
- `WorkshopScreen.jsx` — 22 `rules-of-hooks` errors: all `useState`/`useEffect` calls were after an early `if (!currentUser) return`, violating Rules of Hooks. Moved guard below hooks; added `if (!currentUser) return` inside each effect body.
- `LobbyScreen.jsx` — `room.id` missing from invitations query dep array; `playerId` missing from invite search filter dep array
- `SeasonScreen.jsx` — `season.id` missing from award creation dep array

**Dead code removal**
- Removed unused `useEffect` import in `CreateRoom.jsx`
- Removed unused `inp` import in `ArenaDetailScreen.jsx`
- Removed unused `lastGame` variable in `SeasonScreen.jsx`
- Renamed unused callback params to `_`-prefix: `idx` → `_idx` (SeasonScreen), `nominees` → `_nominees` (VotingPanel)

**`exhaustive-deps` suppressions (25 instances)**
Each was individually reviewed before suppressing. Two patterns account for nearly all of them:
1. Supabase realtime subscription effects (`subscribeToRoom`, `trackRoomPresence`) — intentionally mount-once on `room.id`; adding callback props as deps would re-register the subscription on every render
2. Init/reset effects keyed on a stable `.id` scalar rather than the full object — correct behavior, object reference equality would cause spurious re-runs

## Test notes
- `npm run lint` exits clean (0 errors, 0 warnings)
- No logic was changed outside the three genuine dep fixes and the WorkshopScreen hooks reorder; all behaviour is identical