### PR TITLE
Create narrative.test.js and fill coverage gaps in awards and lineage tests

### DIFF
--- a/src/awards.test.js
+++ b/src/awards.test.js
@@ -479,3 +479,264 @@ describe('computeSeasonAutoAwards', () => {
     expect(computeSeasonAutoAwards([room], 'season1')).toEqual([])
   })
 })
+
+// ─── computeSuperlatives – edge branches ─────────────────────────────────────
+
+describe('computeSuperlatives – edge branches', () => {
+  it('handles null mvp_record (|| [] fallback)', () => {
+    const c = { wins: 1, losses: 0, draws: 0, mvp_record: null }
+    expect(() => computeSuperlatives(c, null)).not.toThrow()
+    expect(computeSuperlatives(c, null).find(s => s.label.startsWith('MVP'))).toBeUndefined()
+  })
+})
+
+// ─── getSeriesCombatantNominees – edge branches ───────────────────────────────
+
+describe('getSeriesCombatantNominees – edge branches', () => {
+  it('handles room with no combatants property', () => {
+    expect(() => getSeriesCombatantNominees([{ }])).not.toThrow()
+    expect(getSeriesCombatantNominees([{ }])).toEqual([])
+  })
+})
+
+// ─── getSeriesEvolutionNominees – edge branches ───────────────────────────────
+
+describe('getSeriesEvolutionNominees – edge branches', () => {
+  it('handles room with no rounds property', () => {
+    expect(() => getSeriesEvolutionNominees([{ }])).not.toThrow()
+    expect(getSeriesEvolutionNominees([{ }])).toEqual([])
+  })
+
+  it('handles evolution round with no combatants property', () => {
+    const round = {
+      evolution: { fromId: 'c1', fromName: 'Fighter', toId: 'v1', toName: 'SuperFighter' },
+    }
+    const nominees = getSeriesEvolutionNominees([{ rounds: [round] }])
+    expect(nominees).toHaveLength(1)
+    expect(nominees[0].name).toContain('?')
+  })
+})
+
+// ─── computeGameAutoAwards – edge branches ────────────────────────────────────
+
+describe('computeGameAutoAwards – edge branches', () => {
+  it('handles room with no rounds property', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const room = { id: 'room1', devMode: false, players: [p1], combatants: { p1: [] } }
+    expect(computeGameAutoAwards(room)).toEqual([])
+  })
+
+  it('handles room with no players property', () => {
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const room = {
+      id: 'room1', devMode: false,
+      combatants: { p1: [c1] },
+      rounds: [{ winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1] }],
+    }
+    expect(computeGameAutoAwards(room)).toEqual([])
+  })
+
+  it('handles winner round with no combatants property in the round', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const room = {
+      id: 'room1', devMode: false,
+      players: [p1, p2],
+      combatants: {},
+      rounds: [{ winner: { id: 'c1', ownerId: 'p1' } }],
+    }
+    expect(() => computeGameAutoAwards(room)).not.toThrow()
+  })
+
+  it('draw round in tally loop does not add wins or losses to any player', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', ownerId: 'p1' }
+    const c2 = { id: 'c2', ownerId: 'p2' }
+    const room = {
+      id: 'room1', devMode: false,
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds: [{ draw: true, combatants: [c1, c2] }],
+    }
+    const awards = computeGameAutoAwards(room)
+    expect(awards.find(a => a.type === 'most_wins')).toBeUndefined()
+    expect(awards.find(a => a.type === 'shutout')).toBeUndefined()
+    expect(awards.find(a => a.type === 'undefeated')).toBeUndefined()
+  })
+
+  it('returns empty when all players are bots', () => {
+    const bot = { id: 'bot1', name: 'Bot', isBot: true }
+    const c1  = { id: 'c1', name: 'Fighter', ownerId: 'bot1' }
+    const room = {
+      id: 'room1', phase: 'ended', devMode: false,
+      players: [bot],
+      combatants: { bot1: [c1] },
+      rounds: [{ winner: { id: 'c1', ownerId: 'bot1' }, combatants: [c1] }],
+    }
+    expect(computeGameAutoAwards(room)).toEqual([])
+  })
+
+  it('skips wins increment when winner ownerId is not in the player list', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Rival',   ownerId: 'unknown' }
+    const room = {
+      id: 'room1', phase: 'ended', devMode: false,
+      players: [p1],
+      combatants: { p1: [c1] },
+      rounds: [{ winner: { id: 'c2', ownerId: 'unknown' }, combatants: [c1, c2] }],
+    }
+    const awards = computeGameAutoAwards(room)
+    expect(awards.find(a => a.type === 'most_wins')).toBeUndefined()
+  })
+
+  it('skips losses increment for losing combatant whose owner is not in the player list', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Ghost',   ownerId: 'unknown' }
+    const room = {
+      id: 'room1', phase: 'ended', devMode: false,
+      players: [p1],
+      combatants: { p1: [c1] },
+      rounds: [{ winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1, c2] }],
+    }
+    expect(() => computeGameAutoAwards(room)).not.toThrow()
+  })
+
+  it('skips bot combatants in the most_reactions tally', () => {
+    const p1  = { id: 'p1', name: 'Alice', isBot: false }
+    const c1  = { id: 'c1', name: 'Fighter', ownerId: 'p1', isBot: false }
+    const bot = { id: 'b1', name: 'BotCombatant', ownerId: 'p1', isBot: true }
+    const room = {
+      id: 'room1', phase: 'ended', devMode: false,
+      players: [p1],
+      combatants: { p1: [c1, bot] },
+      rounds: [{
+        winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1],
+        playerReactions: { p1: { b1: 'heart' } },
+      }],
+    }
+    const awards = computeGameAutoAwards(room)
+    const mr = awards.find(a => a.type === 'most_reactions')
+    expect(mr).toBeUndefined()
+  })
+
+  it('handles room with no combatants property for reactions', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const room = {
+      id: 'room1', phase: 'ended', devMode: false,
+      players: [p1],
+      rounds: [{ winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1] }],
+    }
+    expect(() => computeGameAutoAwards(room)).not.toThrow()
+  })
+})
+
+// ─── computeSeriesAutoAwards – edge branches ──────────────────────────────────
+
+describe('computeSeriesAutoAwards – edge branches', () => {
+  it('handles null rooms argument', () => {
+    expect(computeSeriesAutoAwards(null, 'series1')).toEqual([])
+  })
+
+  it('handles room with no rounds property in scope calculation', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1],
+      combatants: { p1: [] },
+    }
+    expect(() => computeSeriesAutoAwards([room], 'series1')).not.toThrow()
+  })
+
+  it('handles room with no players property in scope calculation', () => {
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      combatants: { p1: [c1] },
+      rounds: [{ winner: { id: 'c1', ownerId: 'p1' }, combatants: [c1] }],
+    }
+    expect(() => computeSeriesAutoAwards([room], 'series1')).not.toThrow()
+  })
+
+  it('returns no most_wins when all rounds were draws (maxWins === 0)', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const p2 = { id: 'p2', name: 'Bob',   isBot: false }
+    const c1 = { id: 'c1', name: 'F1', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'F2', ownerId: 'p2' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1, p2],
+      combatants: { p1: [c1], p2: [c2] },
+      rounds: [{ draw: true, combatants: [c1, c2] }],
+    }
+    const awards = computeSeriesAutoAwards([room], 'series1')
+    expect(awards.find(a => a.type === 'most_wins')).toBeUndefined()
+  })
+
+  it('uses winner.ownerName fallback when owner is not in playerMap', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Rival',   ownerId: 'unknown' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1],
+      combatants: { p1: [c1], unknown: [c2] },
+      rounds: [{
+        winner: { id: 'c2', ownerId: 'unknown', ownerName: 'Ghost' },
+        combatants: [c1, c2],
+        evolution: { fromId: 'c2', fromName: 'Rival', toId: 'v1', toName: 'GhostPlus' },
+      }],
+    }
+    expect(() => computeSeriesAutoAwards([room], 'series1')).not.toThrow()
+    const awards = computeSeriesAutoAwards([room], 'series1')
+    const me = awards.find(a => a.type === 'most_evolutions')
+    expect(me).toBeDefined()
+    expect(me.recipient_name).toBe('Ghost')
+  })
+
+  it('skips evolution when ownerId is missing entirely', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter', ownerId: 'p1' }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1],
+      combatants: { p1: [c1] },
+      rounds: [{
+        winner: { id: 'c1' },
+        combatants: [c1],
+        evolution: { fromId: 'c1', fromName: 'Fighter', toId: 'v1', toName: 'Fighter+' },
+      }],
+    }
+    const awards = computeSeriesAutoAwards([room], 'series1')
+    expect(awards.find(a => a.type === 'most_evolutions')).toBeUndefined()
+  })
+
+  it('counts multiple evolutions by the same player correctly', () => {
+    const p1 = { id: 'p1', name: 'Alice', isBot: false }
+    const c1 = { id: 'c1', name: 'Fighter',  ownerId: 'p1' }
+    const c2 = { id: 'c2', name: 'Sidekick', ownerId: 'p1' }
+    const round1 = {
+      winner: { id: 'c1', ownerId: 'p1', name: 'Fighter' },
+      combatants: [c1],
+      evolution: { fromId: 'c1', fromName: 'Fighter', toId: 'v1', toName: 'Fighter+' },
+    }
+    const round2 = {
+      winner: { id: 'c2', ownerId: 'p1', name: 'Sidekick' },
+      combatants: [c2],
+      evolution: { fromId: 'c2', fromName: 'Sidekick', toId: 'v2', toName: 'Sidekick+' },
+    }
+    const room = {
+      id: 'room1', phase: 'ended',
+      players: [p1],
+      combatants: { p1: [c1, c2] },
+      rounds: [round1, round2],
+    }
+    const awards = computeSeriesAutoAwards([room], 'series1')
+    const me = awards.find(a => a.type === 'most_evolutions')
+    expect(me).toBeDefined()
+    expect(me.value).toBe(2)
+  })
+})

--- a/src/gameLogic.test.js
+++ b/src/gameLogic.test.js
@@ -1,5 +1,4 @@
 ﻿import { describe, it, expect, beforeEach } from 'vitest'
-import { buildTickerMessages } from './narrative.js'
 import {
   initials, playerColor, COLORS,
   BOT_COMBATANTS, BOT_BIOS, makeBotCombatants, makeBots,
@@ -451,107 +450,6 @@ describe('ownerLabel', () => {
 
   it('returns bare name for logged-in players', () => {
     expect(ownerLabel('Alice', false)).toBe('Alice')
-  })
-})
-
-// --- buildTickerMessages -----------------------------------------------------
-
-describe('buildTickerMessages', () => {
-  it('always returns at least the 15 static filler messages', () => {
-    const msgs = buildTickerMessages([])
-    expect(msgs.length).toBeGreaterThanOrEqual(15)
-  })
-
-  it('returns an array of strings', () => {
-    const msgs = buildTickerMessages([])
-    msgs.forEach(m => expect(typeof m).toBe('string'))
-  })
-
-  it('generates round-based messages when completed rounds exist', () => {
-    const c1 = makeCombatant({ id: 'c1', name: 'Blaster' })
-    const c2 = makeCombatant({ id: 'c2', name: 'Crusher' })
-    const round = { id: 'rd1', number: 1, combatants: [c1, c2], winner: c1, picks: {}, createdAt: Date.now() }
-    const room = {
-      id: 'R1', devMode: false, players: [{ id: 'p1', name: 'Alice', isBot: false }],
-      combatants: { p1: [c1] }, rounds: [round], currentRound: 1, createdAt: Date.now(),
-    }
-    const msgs = buildTickerMessages([room])
-    // At least one message should reference the winner or loser
-    const mentions = msgs.filter(m => m.includes('Blaster') || m.includes('Crusher'))
-    expect(mentions.length).toBeGreaterThan(0)
-  })
-
-  it('skips devMode rooms entirely', () => {
-    const c1 = makeCombatant({ id: 'c1', name: 'DevFighter' })
-    const c2 = makeCombatant({ id: 'c2', name: 'OtherFighter' })
-    const round = { id: 'rd1', number: 1, combatants: [c1, c2], winner: c1, picks: {}, createdAt: Date.now() }
-    const room = {
-      id: 'DEV1', devMode: true, players: [], combatants: { p1: [c1] },
-      rounds: [round], currentRound: 1, createdAt: Date.now(),
-    }
-    const msgs = buildTickerMessages([room])
-    const mentions = msgs.filter(m => m.includes('DevFighter'))
-    expect(mentions).toHaveLength(0)
-  })
-
-  it('generates a loss-shame message for combatants with 4+ losses', () => {
-    const c1 = makeCombatant({ id: 'c1', name: 'PunchingBag', wins: 0, losses: 5 })
-    const room = {
-      id: 'R1', devMode: false, players: [{ id: 'p1', name: 'Alice', isBot: false }],
-      combatants: { p1: [c1] }, rounds: [], currentRound: 0, createdAt: Date.now(),
-    }
-    const msgs = buildTickerMessages([room])
-    const shameMsg = msgs.find(m => m.includes('PunchingBag'))
-    expect(shameMsg).toBeDefined()
-  })
-
-  it('generates an undefeated message for 4+ wins with 0 losses', () => {
-    const c1 = makeCombatant({ id: 'c1', name: 'Invincible', wins: 4, losses: 0 })
-    const room = {
-      id: 'R1', devMode: false, players: [{ id: 'p1', name: 'Alice', isBot: false }],
-      combatants: { p1: [c1] }, rounds: [], currentRound: 0, createdAt: Date.now(),
-    }
-    const msgs = buildTickerMessages([room])
-    const heroMsg = msgs.find(m => m.includes('Invincible'))
-    expect(heroMsg).toBeDefined()
-  })
-
-  it('handles null/undefined gracefully', () => {
-    expect(() => buildTickerMessages(null)).not.toThrow()
-    expect(() => buildTickerMessages(undefined)).not.toThrow()
-    expect(() => buildTickerMessages([null, undefined])).not.toThrow()
-  })
-
-  it('generates a draw message when a draw round has 2+ combatants', () => {
-    const c1 = makeCombatant({ id: 'c1', name: 'LeftFighter' })
-    const c2 = makeCombatant({ id: 'c2', name: 'RightFighter' })
-    const room = {
-      id: 'R1', devMode: false, players: [{ id: 'p1', name: 'Alice', isBot: false }],
-      combatants: { p1: [c1, c2] },
-      rounds: [
-        { id: 'rd1', number: 1, combatants: [c1, c2], draw: true, winner: null, picks: {}, createdAt: Date.now() },
-      ],
-      currentRound: 1, createdAt: Date.now(),
-    }
-    const msgs = buildTickerMessages([room])
-    const drawMsgs = msgs.filter(m => m.includes('LeftFighter') || m.includes('RightFighter'))
-    expect(drawMsgs.length).toBeGreaterThan(0)
-  })
-
-  it('skips draw rounds with fewer than 2 combatants', () => {
-    const room = {
-      id: 'R1', devMode: false, players: [{ id: 'p1', name: 'Alice', isBot: false }],
-      combatants: {},
-      rounds: [
-        { id: 'rd1', number: 1, combatants: [], draw: true, winner: null, picks: {}, createdAt: Date.now() },
-        { id: 'rd2', number: 2, combatants: [makeCombatant({ id: 'c1', name: 'Solo' })], draw: true, winner: null, picks: {}, createdAt: Date.now() },
-      ],
-      currentRound: 2, createdAt: Date.now(),
-    }
-    // Should not throw and should return strings (draw messages not added for <2 combatants)
-    const msgs = buildTickerMessages([room])
-    expect(Array.isArray(msgs)).toBe(true)
-    msgs.forEach(m => expect(typeof m).toBe('string'))
   })
 })
 

--- a/src/lineage.test.js
+++ b/src/lineage.test.js
@@ -467,3 +467,82 @@ describe('buildChainEvolutionStory and buildStoryFromLineageTree output shape pa
     expect(chainNode.bornFrom.parentName).toBe(treeNode.bornFrom.parentName)
   })
 })
+
+// ─── getLineageStats – edge branches ─────────────────────────────────────────
+
+describe('getLineageStats – edge branches', () => {
+  it('skips a co-parent id that is already in the primary family (no double-count)', () => {
+    // Breakfast (bk) lists Egg (c1) as a co-parent, but Egg is already in the
+    // primary family (rootId === 'c1'). seen.has(cpId) should fire and skip it.
+    const egg      = { id: 'c1', wins: 3, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0 }
+    const breakfast = {
+      id: 'bk', wins: 1, losses: 0, reactions_heart: 0, reactions_angry: 0, reactions_cry: 0,
+      lineage: { rootId: 'c1', parentId: 'c1', coParentIds: ['c1'], generation: 1 },
+    }
+    const result = getLineageStats('c1', [egg, breakfast])
+    expect(result.wins).toBe(4)   // egg(3) + breakfast(1) — c1 not added twice
+    expect(result.forms).toBe(2)
+  })
+})
+
+// ─── buildActiveFormMap – edge branches ──────────────────────────────────────
+
+describe('buildActiveFormMap – edge branches', () => {
+  it('handles a room with no rounds property', () => {
+    const room = { code: 'A' }
+    expect(() => buildActiveFormMap([room])).not.toThrow()
+    expect(buildActiveFormMap([room])).toEqual({})
+  })
+})
+
+// ─── buildChainEvolutionStory – edge branches ─────────────────────────────────
+
+describe('buildChainEvolutionStory – edge branches', () => {
+  it('handles a room with no rounds property', () => {
+    expect(buildChainEvolutionStory([{ code: 'A' }], 'c1')).toEqual([])
+  })
+
+  it('handles an evolution round with no combatants property (opponentName becomes null)', () => {
+    const room = {
+      code: 'XKQT',
+      rounds: [{
+        number: 1,
+        evolution: { fromId: 'c1', fromName: 'MJ', toId: 'c2', toName: 'MJ scuffed', authorId: 'p1' },
+      }],
+    }
+    const story = buildChainEvolutionStory([room], 'c1')
+    expect(story).toHaveLength(2)
+    expect(story[1].bornFrom.opponentName).toBeNull()
+  })
+
+  it('merge round with no fromIds property does not throw', () => {
+    const room = {
+      code: 'XKQT',
+      rounds: [{
+        number: 1,
+        combatants: [{ id: 'c1', name: 'Egg' }, { id: 'b1', name: 'Bacon' }],
+        draw: { combatantIds: ['c1', 'b1'] },
+        merge: { fromIds: undefined, fromNames: undefined, toId: 'bk', toName: 'Breakfast',
+          primaryOwnerId: 'p1', primaryOwnerName: 'Alice', coOwnerIds: [], coOwnerNames: [], mergeNote: null },
+      }],
+    }
+    expect(() => buildChainEvolutionStory([room], 'c1')).not.toThrow()
+  })
+
+  it('merge round with null fromNames falls back to empty array and empty string for root name', () => {
+    const room = {
+      code: 'XKQT',
+      rounds: [{
+        number: 1,
+        combatants: [{ id: 'c1', name: 'Egg' }, { id: 'b1', name: 'Bacon' }],
+        draw: { combatantIds: ['c1', 'b1'] },
+        merge: { fromIds: ['c1', 'b1'], fromNames: null, toId: 'bk', toName: 'Breakfast',
+          primaryOwnerId: 'p1', primaryOwnerName: 'Alice', coOwnerIds: [], coOwnerNames: [], mergeNote: null },
+      }],
+    }
+    const story = buildChainEvolutionStory([room], 'c1')
+    expect(story).toHaveLength(2)
+    expect(story[0].name).toBe('')
+    expect(story[1].bornFrom.parentNames).toEqual([])
+  })
+})

--- a/src/narrative.test.js
+++ b/src/narrative.test.js
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import { buildTickerMessages } from './narrative.js'
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeCombatant(overrides = {}) {
+  return { id: 'c1', name: 'Fighter', wins: 0, losses: 0, draws: 0, isBot: false, ...overrides }
+}
+
+function makeWinRoom(winner, loser) {
+  const round = { combatants: [winner, loser], winner, draw: false }
+  return {
+    devMode: false,
+    players: [{ id: 'p1', name: 'Alice', isBot: false }],
+    combatants: { p1: [winner, loser] },
+    rounds: [round],
+  }
+}
+
+// ─── buildTickerMessages ──────────────────────────────────────────────────────
+
+describe('buildTickerMessages', () => {
+  it('always returns at least the 15 static filler messages', () => {
+    expect(buildTickerMessages([]).length).toBeGreaterThanOrEqual(15)
+  })
+
+  it('returns an array of strings', () => {
+    buildTickerMessages([]).forEach(m => expect(typeof m).toBe('string'))
+  })
+
+  it('always includes a known static message', () => {
+    const msgs = buildTickerMessages([])
+    expect(msgs).toContain("Submit your 8. Destiny will handle the rest.")
+  })
+
+  it('handles empty array input', () => {
+    expect(() => buildTickerMessages([])).not.toThrow()
+  })
+
+  it('handles null and undefined input', () => {
+    expect(() => buildTickerMessages(null)).not.toThrow()
+    expect(() => buildTickerMessages(undefined)).not.toThrow()
+    expect(buildTickerMessages(null).length).toBeGreaterThanOrEqual(15)
+  })
+
+  it('handles array containing null and undefined entries', () => {
+    expect(() => buildTickerMessages([null, undefined])).not.toThrow()
+  })
+
+  it('skips devMode rooms entirely', () => {
+    const c1 = makeCombatant({ id: 'c1', name: 'DevFighter', wins: 10, losses: 0 })
+    const room = {
+      devMode: true,
+      players: [{ id: 'p1', name: 'Alice', isBot: false }],
+      combatants: { p1: [c1] },
+      rounds: [{ combatants: [c1, makeCombatant({ id: 'c2', name: 'Rival' })], winner: c1 }],
+    }
+    const msgs = buildTickerMessages([room])
+    expect(msgs.filter(m => m.includes('DevFighter'))).toHaveLength(0)
+  })
+
+  it('generates messages referencing winner/loser when win rounds exist', () => {
+    const winner = makeCombatant({ id: 'c1', name: 'Blaster' })
+    const loser  = makeCombatant({ id: 'c2', name: 'Crusher' })
+    const msgs = buildTickerMessages([makeWinRoom(winner, loser)])
+    const mentions = msgs.filter(m => m.includes('Blaster') || m.includes('Crusher'))
+    expect(mentions.length).toBeGreaterThan(0)
+  })
+
+  it('generates draw messages when draw rounds have 2+ combatants', () => {
+    const c1 = makeCombatant({ id: 'c1', name: 'LeftFighter' })
+    const c2 = makeCombatant({ id: 'c2', name: 'RightFighter' })
+    const room = {
+      devMode: false,
+      players: [{ id: 'p1', name: 'Alice', isBot: false }],
+      combatants: { p1: [c1, c2] },
+      rounds: [{ combatants: [c1, c2], draw: true, winner: null }],
+    }
+    const msgs = buildTickerMessages([room])
+    const drawMsgs = msgs.filter(m => m.includes('LeftFighter') || m.includes('RightFighter'))
+    expect(drawMsgs.length).toBeGreaterThan(0)
+  })
+
+  it('skips draw rounds with fewer than 2 combatants', () => {
+    const room = {
+      devMode: false,
+      players: [],
+      combatants: {},
+      rounds: [
+        { combatants: [],                                            draw: true, winner: null },
+        { combatants: [makeCombatant({ id: 'c1', name: 'Solo' })],  draw: true, winner: null },
+      ],
+    }
+    const msgs = buildTickerMessages([room])
+    expect(Array.isArray(msgs)).toBe(true)
+    msgs.forEach(m => expect(typeof m).toBe('string'))
+  })
+
+  it('handles draw round with no combatants property', () => {
+    const room = {
+      devMode: false, players: [], combatants: {},
+      rounds: [{ draw: true, winner: null }],
+    }
+    expect(() => buildTickerMessages([room])).not.toThrow()
+  })
+
+  it('generates a loss-shame message for combatants with 4+ losses', () => {
+    const loser = makeCombatant({ id: 'c1', name: 'PunchingBag', wins: 0, losses: 5 })
+    const room = { devMode: false, players: [], combatants: { p1: [loser] }, rounds: [] }
+    const msgs = buildTickerMessages([room])
+    expect(msgs.find(m => m.includes('PunchingBag'))).toBeDefined()
+  })
+
+  it('generates an undefeated message for combatants with 4+ wins and 0 losses', () => {
+    const hero = makeCombatant({ id: 'c1', name: 'Invincible', wins: 4, losses: 0 })
+    const room = { devMode: false, players: [], combatants: { p1: [hero] }, rounds: [] }
+    const msgs = buildTickerMessages([room])
+    expect(msgs.find(m => m.includes('Invincible'))).toBeDefined()
+  })
+
+  it('generates a complicated-legacy message for combatants with 3+ wins and 3+ losses', () => {
+    const messy = makeCombatant({ id: 'c1', name: 'LegendMaybe', wins: 3, losses: 3 })
+    const room = { devMode: false, players: [], combatants: { p1: [messy] }, rounds: [] }
+    const msgs = buildTickerMessages([room])
+    const legacyMsg = msgs.find(m => m.includes('LegendMaybe') && m.includes('legacy'))
+    expect(legacyMsg).toBeDefined()
+  })
+
+  it('generates player greeting messages for non-bot players', () => {
+    const room = {
+      devMode: false,
+      players: [{ id: 'p1', name: 'DistinctPlayerName', isBot: false }],
+      combatants: {},
+      rounds: [],
+    }
+    const msgs = buildTickerMessages([room])
+    expect(msgs.find(m => m.includes('DistinctPlayerName'))).toBeDefined()
+  })
+
+  it('does not generate player greetings for bot players', () => {
+    const room = {
+      devMode: false,
+      players: [{ id: 'bot1', name: 'BotPlayer', isBot: true }],
+      combatants: {},
+      rounds: [],
+    }
+    const msgs = buildTickerMessages([room])
+    expect(msgs.filter(m => m.includes('BotPlayer'))).toHaveLength(0)
+  })
+
+  it('handles room with no rounds property', () => {
+    const room = { devMode: false, players: [], combatants: {} }
+    expect(() => buildTickerMessages([room])).not.toThrow()
+  })
+
+  it('handles room with no players property', () => {
+    const room = { devMode: false, combatants: {}, rounds: [] }
+    expect(() => buildTickerMessages([room])).not.toThrow()
+  })
+
+  it('handles room with no combatants property', () => {
+    const room = { devMode: false, players: [], rounds: [] }
+    expect(() => buildTickerMessages([room])).not.toThrow()
+  })
+
+  it('does not generate stat messages for bot combatants', () => {
+    const bot = makeCombatant({ id: 'c1', name: 'BotFighter', wins: 10, losses: 0, isBot: true })
+    const room = { devMode: false, players: [], combatants: { p1: [bot] }, rounds: [] }
+    const msgs = buildTickerMessages([room])
+    expect(msgs.filter(m => m.includes('BotFighter'))).toHaveLength(0)
+  })
+
+  it('accumulates stats for the same combatant appearing in multiple rooms', () => {
+    // Combatant name repeated across two rooms — stat messages should use the merged totals,
+    // not count the first room twice. We can verify no error is thrown and the message appears.
+    const c = makeCombatant({ id: 'c1', name: 'MultiRoom', wins: 2, losses: 2 })
+    const room1 = { devMode: false, players: [], combatants: { p1: [c] }, rounds: [] }
+    const room2 = { devMode: false, players: [], combatants: { p1: [c] }, rounds: [] }
+    expect(() => buildTickerMessages([room1, room2])).not.toThrow()
+  })
+
+  it('generates a message referencing both losers when win round has 3 combatants', () => {
+    const winner = makeCombatant({ id: 'c1', name: 'TriWinner' })
+    const loser1 = makeCombatant({ id: 'c2', name: 'TriLoserA' })
+    const loser2 = makeCombatant({ id: 'c3', name: 'TriLoserB' })
+    // Repeat the round 15 times so at least one gets sampled past the random slice.
+    const round = { combatants: [winner, loser1, loser2], winner, draw: false }
+    const bigRoom = { devMode: false, players: [], combatants: {},
+      rounds: Array(15).fill(round) }
+    const msgs = buildTickerMessages([bigRoom])
+    // At least one message should mention the winner
+    expect(msgs.filter(m => m.includes('TriWinner')).length).toBeGreaterThan(0)
+  })
+
+  it('skips a win round where combatants list is missing', () => {
+    const winner = makeCombatant({ id: 'c1', name: 'GhostWin' })
+    const room = {
+      devMode: false, players: [], combatants: {},
+      rounds: [{ winner, draw: false }],
+    }
+    expect(() => buildTickerMessages([room])).not.toThrow()
+  })
+
+  it('skips a win round where winner has no other combatants (no losers)', () => {
+    const winner = makeCombatant({ id: 'c1', name: 'LoneWinner' })
+    const room = {
+      devMode: false, players: [], combatants: {},
+      rounds: [{ combatants: [winner], winner, draw: false }],
+    }
+    const msgs = buildTickerMessages([room])
+    expect(Array.isArray(msgs)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What changed

- **`src/narrative.test.js` (new):** Moves the `buildTickerMessages` describe block out of `gameLogic.test.js`, where it imported directly from `narrative.js` but had no dedicated home. Adds new tests covering every remaining uncovered branch: the complicated-legacy stat message (`wins >= 3 && losses >= 3`), three-combatant win rounds (`l2` branch), bot player/combatant filtering, null-safety fallbacks on `rounds`/`players`/`combatants`, and draw rounds with missing `combatants` property.
- **`src/gameLogic.test.js`:** Removes the `buildTickerMessages` import and describe block (now in `narrative.test.js`). No other changes.
- **`src/awards.test.js`:** Adds tests for `mvp_record: null` fallback in `computeSuperlatives`, missing `combatants` property in `getSeriesCombatantNominees`, missing `rounds`/`players` properties and bot-combatant skip in `computeGameAutoAwards`, draw-round tally path, null rooms arg, `winner.ownerName` fallback, multi-evolution counting, and `standings.length > 0` false branch.
- **`src/lineage.test.js`:** Adds tests for co-parent already in the primary family (seen-set skip), room with no `rounds` property in `buildActiveFormMap` and `buildChainEvolutionStory`, evolution round with no `combatants` property, and merge with `fromNames: null` to exercise the `|| []` and `|| ''` fallbacks on lines 204-206.

## Coverage results

| File | Branch before | Branch after |
|---|---|---|
| `narrative.js` | 76% | 100% |
| `awards.js` | 82% | 99% |
| `lineage.js` | 89% | 99% |

The two remaining uncovered branches (`awards:171`, `lineage:205`) are unreachable defensive guards — the `else if (round.draw)` false-arm inside a loop already filtered for `winner || draw`, and `fromIds || []` behind an `ancestorIdx === -1` guard above it.

## Test notes
- `npx vitest run`: 470 tests, 0 failures (was 429)
- `npm run lint`: 0 errors, 1 pre-existing warning in `scripts/coverage/block-navigation.js`